### PR TITLE
chore: Mount Docker socket into block-builder container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - igra-network
     volumes:
       - ${PWD}/jwt.hex:/app/jwt.hex
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - execution-layer
 


### PR DESCRIPTION
Mount the host's Docker socket (`/var/run/docker.sock`) into the block-builder service container defined in `docker-compose.yml`.

This allows the `DockerService` within the block-builder application to connect to the Docker daemon on the host machine. Access to the Docker daemon is required for the feature implemented in parallel, which involves resetting the `execution-layer` container (executing commands inside it and restarting it) via the Docker API when the `igra_startL2V0` RPC method is called.

This configuration change is a prerequisite for enabling the block-builder service to manage other Docker containers.