### PR TITLE
chore: Configure syslog logging driver for persistent logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - execution-layer
+    logging:
+      driver: "syslog"
+      options:
+        tag: "block-builder/{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   execution-layer:
     container_name: execution-layer
@@ -32,6 +36,10 @@ services:
       - ./jwt.hex:/root/reth/jwt.hex
       - ./repos/execution-layer/genesis.json:/root/reth/genesis.json
       - ./repos/execution-layer/run-igra-dev-el.sh:/root/reth/run-igra-dev-el.sh
+    logging:
+      driver: "syslog"
+      options:
+        tag: "execution-layer/{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   rpc-provider:
     container_name: rpc-provider
@@ -48,6 +56,10 @@ services:
       - kaswallet
     ports:
       - "8545:8535"
+    logging:
+      driver: "syslog"
+      options:
+        tag: "rpc-provider/{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   kaswallet:
     container_name: kaswallet
@@ -66,6 +78,10 @@ services:
     command: ["--devnet", "--logs-level=debug", "--keys-file", "/app/keys.json", "--server", "ws://host.docker.internal:17610", "--listen", "0.0.0.0:8082"]
     ports:
       - "8082:8082"
+    logging:
+      driver: "syslog"
+      options:
+        tag: "kaswallet/{{.ImageName}}/{{.Name}}/{{.ID}}"
 
   viaduct:
     container_name: viaduct
@@ -86,6 +102,10 @@ services:
     command: ["--ip-port=host.docker.internal:17610", "--bb-ip-port=block-builder:8561"]
     depends_on:
       - block-builder
+    logging:
+      driver: "syslog"
+      options:
+        tag: "viaduct/{{.ImageName}}/{{.Name}}/{{.ID}}"
 
 networks:
   igra-network:


### PR DESCRIPTION
The default `json-file` logging driver in Docker Compose results in log loss when containers are removed (e.g., via `docker compose down`). This hinders debugging efforts, especially in development environments where containers are frequently cycled.

This commit configures the `syslog` logging driver for all services (`block-builder`, `execution-layer`, `rpc-provider`, `kaswallet`, `viaduct`). By forwarding container logs (stdout/stderr) to the host's syslog daemon, logs are preserved independently of the container lifecycle, ensuring they persist even after containers are stopped and removed.

Each log entry is tagged with service-specific metadata (`{{.ImageName}}/{{.Name}}/{{.ID}}`) to facilitate easier identification and filtering within the host's system logs.