### PR TITLE
feat: Expand RPC access token capacity in Traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,17 @@ x-rpc-provider-base: &rpc-provider-base
       PathPrefix(`/${RPC_ACCESS_TOKEN_33}`) ||
       PathPrefix(`/${RPC_ACCESS_TOKEN_34}`) ||
       PathPrefix(`/${RPC_ACCESS_TOKEN_35}`) ||
-      PathPrefix(`/${RPC_ACCESS_TOKEN_36}`)))
+      PathPrefix(`/${RPC_ACCESS_TOKEN_36}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_37}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_38}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_39}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_40}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_41}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_42}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_43}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_44}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_45}`) ||
+      PathPrefix(`/${RPC_ACCESS_TOKEN_46}`)))
     - "traefik.http.routers.rpc0.entrypoints=rpc"
     - "traefik.http.routers.rpc0.tls=true"
     - "traefik.http.routers.rpc0.tls.certresolver=myresolver"


### PR DESCRIPTION
This commit updates the Traefik router configuration within `docker-compose.yml` to support additional RPC access tokens. Specifically, path prefixes for `RPC_ACCESS_TOKEN_37` through `RPC_ACCESS_TOKEN_46` have been added.