### PR TITLE
feat: add infrastructure for reorgs support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,15 @@ KASWALLET_BRANCH=main
 IGRA_RPC_PROVIDER_BRANCH=main
 VIADUCT_BRANCH=updated_storage_tests
 
+# The following branches are only used if you run ./setup-repos.sh --dev
+KASPAD_BRANCH=re-org_merged_kaspad_v1.0.0
+KASPA_MINER_BRANCH=main
+
 # HTTPS domain settings
 IGRA_ORCHESTRA_DOMAIN=stage.igralabs.com
 IGRA_ORCHESTRA_DOMAIN_EMAIL=igor@igralabs.com
 
-# The following branches are only used if you run ./setup-repos.sh --dev
-KASPAD_BRANCH=for-wallet
-KASPA_MINER_BRANCH=main
+
 
 # --- Docker Configuration ---
 
@@ -35,6 +37,7 @@ KASPAD_BORSH_PORT=17610
 REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 MAGIC_HASH=000000000000000000000000000000000000000000000000000000000000000b
+DELAY_BLOCKS=0
 
 # Mining configuration
 MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data/
 .DS_Store
 .env
 .cursor
+letsencrypt/

--- a/build/Dockerfile.viaduct
+++ b/build/Dockerfile.viaduct
@@ -1,18 +1,24 @@
+# syntax=docker/dockerfile:1
 FROM rust:slim AS builder
 
 WORKDIR /app
 
 # Install OpenSSL and Protocol Buffers compiler
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev protobuf-compiler libclang-dev build-essential && \
+    apt-get install -y pkg-config libssl-dev protobuf-compiler libclang-dev build-essential git openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Install rustfmt
 RUN rustup component add rustfmt
 
+# Configure git to use SSH
+RUN mkdir -p -m 0600 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 COPY . .
 
-RUN cargo build --bin viaduct --release
+# Use BuildKit SSH mount for cargo build
+RUN --mount=type=ssh cargo build --release
 
 FROM debian:bookworm-slim
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
   execution-layer:
     <<: *default-service
     container_name: execution-layer
-    image: ghcr.io/paradigmxyz/reth
+    image: igralabscom/reth:v1.4.8
     entrypoint: /root/reth/run-igra-dev-el.sh
     profiles: ["igra-w1", "igra-w2", "igra-w3", "igra-w4", "igra-w5"]
     expose:
@@ -180,8 +180,10 @@ services:
   viaduct:
     <<: *default-service
     build:
-      context: build/repos/rusty-kaspa-private
+      context: build/repos/viaduct
       dockerfile: ../../Dockerfile.viaduct
+      ssh:
+        - default
     image: viaduct
     profiles: ["igra-w1", "igra-w2", "igra-w3", "igra-w4", "igra-w5"]
     container_name: viaduct
@@ -190,6 +192,7 @@ services:
       - REPLAY_ON_ERROR
       - SYNC_THREADS
       - MAGIC_HASH
+      - DELAY_BLOCKS
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: ["--ip-port=${KASPAD_HOST}:${KASPAD_BORSH_PORT}", "--bb-ip-port=block-builder:8561"]
@@ -473,7 +476,7 @@ services:
   kaspad:
     <<: *default-service
     build:
-      context: build/repos/rusty-kaspa
+      context: build/repos/rusty-kaspa-private
       dockerfile: ../../Dockerfile.kaspad
     image: kaspad-devnet
     profiles: ["kaspad"]
@@ -485,20 +488,27 @@ services:
       - "18610" # WRPC (json) Server
     ports:
       - "17610:17610"
+      - "16611:16611"
+      # - "17611:17611"
+      # - "18611:18611"
     environment:
       - RUST_LOG
       - REPLAY_ON_ERROR
       - SYNC_THREADS
     command:
       [
-        "--loglevel=debug",
-        "--utxoindex",
-        "--rpclisten=0.0.0.0:16610",
-        "--rpclisten-borsh=0.0.0.0:17610",
-        "--rpclisten-json=0.0.0.0:18610",
         "--devnet",
-        "--enable-unsynced-mining",
         "--disable-upnp",
+        "--nodnsseed",
+        "--rpclisten-borsh=0.0.0.0",
+        "--rpclisten=0.0.0.0",
+        "--rpclisten-json=0.0.0.0",
+        "--listen=0.0.0.0",
+        "--loglevel=info",
+        "--utxoindex",
+        "--enable-unsynced-mining",
+        # "--rpclisten=0.0.0.0:16610",
+        # "--listen-borsh=0.0.0.0",
         "--appdir=/app/data",
       ]
     volumes:

--- a/setup-repos.sh
+++ b/setup-repos.sh
@@ -127,8 +127,8 @@ BLOCK_BUILDER_BRANCH=${BLOCK_BUILDER_BRANCH:-main}
 EXECUTION_LAYER_BRANCH=${EXECUTION_LAYER_BRANCH:-main}
 KASWALLET_BRANCH=${KASWALLET_BRANCH:-main}
 IGRA_RPC_PROVIDER_BRANCH=${IGRA_RPC_PROVIDER_BRANCH:-main}
-VIADUCT_BRANCH=${VIADUCT_BRANCH:-updated_storage_tests}
-KASPAD_BRANCH=${KASPAD_BRANCH:-for-wallet}
+VIADUCT_BRANCH=${VIADUCT_BRANCH:-main}
+KASPAD_BRANCH=${KASPAD_BRANCH:-main}
 KASPA_MINER_BRANCH=${KASPA_MINER_BRANCH:-main}
 
 log "Starting repository setup"
@@ -153,8 +153,8 @@ URLS=(
     "git@github.com:IgraLabs/execution-layer.git"
     "git@github.com:IgraLabs/kaswallet.git"
     "git@github.com:IgraLabs/igra-rpc-provider.git"
+    "git@github.com:IgraLabs/viaduct.git"
     "git@github.com:IgraLabs/rusty-kaspa-private.git"
-    "git@github.com:IgraLabs/rusty-kaspa.git"
     "git@github.com:elichai/kaspa-miner.git"
 )
 BRANCHES=(


### PR DESCRIPTION
Update Docker configurations to support reorganization testing scenarios.

Key changes:
- Switch viaduct build context from rusty-kaspa-private to dedicated viaduct repository with SSH mount support for private dependencies
- Update kaspad to use re-org_merged_kaspad_v1.0.0 branch with simplified network configuration and info-level logging
- Replace execution layer image with custom igralabscom/reth:v1.4.8
- Add DELAY_BLOCKS environment variable for controlling block timing
- Update repository setup script to use main branches and viaduct repo
- Add letsencrypt directory to gitignore for SSL certificate storage
- Expose additional kaspad port 16611 for reorganization testing

These changes enable blockchain reorganization.

Issue-URL: https://app.clickup.com/t/86a9753p5