### PR TITLE
chore: Update Reth image to official v1.5+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
   execution-layer:
     <<: *default-service
     container_name: execution-layer
-    image: igralabscom/reth:v1.4.8
+    image: ghcr.io/paradigmxyz/reth:latest
     entrypoint: /root/reth/run-igra-dev-el.sh
     profiles: ["igra-w1", "igra-w2", "igra-w3", "igra-w4", "igra-w5", "igra-backend"]
     expose:


### PR DESCRIPTION
This commit updates the `execution-layer` service to use the official Reth Docker image from `ghcr.io/paradigmxyz/reth:latest`.

We previously used a custom image to incorporate a specific fix that has since been merged into the upstream Reth repository in version 1.5.0.

By switching to the official image, we can now remove our dependency on the custom build, simplifying maintenance and ensuring we benefit from the latest official releases and security patches.

Related-PR: https://github.com/paradigmxyz/reth/pull/16676