### PR TITLE
chore: Update default KASPAD_BRANCH to 'atan'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ IGRA_RPC_PROVIDER_BRANCH=main
 VIADUCT_BRANCH=main
 
 # The following branches are only used if you run ./setup-repos.sh --dev
-KASPAD_BRANCH=re-org_merged_kaspad_v1.0.0
+KASPAD_BRANCH=atan
 KASPA_MINER_BRANCH=main
 
 # HTTPS domain settings


### PR DESCRIPTION
The default branch for the `kaspad` repository in the example environment file is changed from `re-org_merged_kaspad_v1.0.0` to `atan`.