### PR TITLE
build: Use official kaspad repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ IGRA_RPC_PROVIDER_BRANCH=main
 VIADUCT_BRANCH=main
 
 # The following branches are only used if you run ./setup-repos.sh --dev
-KASPAD_BRANCH=atan
+KASPAD_BRANCH=main
 KASPA_MINER_BRANCH=main
 
 # HTTPS domain settings

--- a/setup-repos.sh
+++ b/setup-repos.sh
@@ -154,7 +154,7 @@ URLS=(
     "git@github.com:IgraLabs/kaswallet.git"
     "git@github.com:IgraLabs/igra-rpc-provider.git"
     "git@github.com:IgraLabs/viaduct.git"
-    "git@github.com:IgraLabs/rusty-kaspa-private.git"
+    "git@github.com:kaspanet/rusty-kaspa.git"
     "git@github.com:elichai/kaspa-miner.git"
 )
 BRANCHES=(


### PR DESCRIPTION
This change updates the `setup-repos.sh` script to use the public, official `kaspanet/rusty-kaspa` repository instead of the private IgraLabs fork.

Using the official repository ensures that the project relies on the standard, upstream version of `kaspad`. The `KASPAD_BRANCH` in `.env.example` has been updated to `main` accordingly.