### PR TITLE
build: Switch kaspad to build from public rusty-kaspa repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ IGRA_RPC_PROVIDER_BRANCH=main
 VIADUCT_BRANCH=main
 
 # The following branches are only used if you run ./setup-repos.sh --dev
-KASPAD_BRANCH=main
+KASPAD_BRANCH=master
 KASPA_MINER_BRANCH=main
 
 # HTTPS domain settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -473,7 +473,7 @@ services:
   kaspad:
     <<: *default-service
     build:
-      context: build/repos/rusty-kaspa-private
+      context: build/repos/rusty-kaspa
       dockerfile: ../../Dockerfile.kaspad
     image: kaspad-testnet
     profiles: ["kaspad"]


### PR DESCRIPTION
This change updates the kaspad service configuration to use the public `rusty-kaspa` repository as its build source, replacing the previous private fork (`rusty-kaspa-private`).

The build context in `docker-compose.yml` is modified to point to the new repository location. The default branch for kaspad in `.env.example` is also updated from `main` to `master` to align with the public repository's default branch. This standardizes the build process.