### PR TITLE
Igor/feat/open stats port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,14 @@ services:
       - ./keys/jwt.hex:/root/reth/jwt.hex
       - ./build/repos/execution-layer/genesis.template.json:/root/reth/genesis.template.json
       - ./build/repos/execution-layer/run-igra-dev-el.sh:/root/reth/run-igra-dev-el.sh
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.el_stats.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
+      - "traefik.http.routers.el_stats.entrypoints=el_stats"
+      - "traefik.http.routers.el_stats.service=el_stats_svc"
+      - "traefik.http.routers.el_stats.tls=true"
+      - "traefik.http.routers.el_stats.tls.certresolver=myresolver"
+      - "traefik.http.services.el_stats_svc.loadbalancer.server.port=9001"
     healthcheck:
       <<: *default-healthcheck
       test: ["CMD", "bash", "-c", "echo hello > /dev/tcp/$$HOSTNAME/8545"]
@@ -171,7 +179,6 @@ services:
       L1_REFERENCE_TIMESTAMP: ${L1_REFERENCE_TIMESTAMP}
       L1_REFERENCE_DAA_SCORE: ${L1_REFERENCE_DAA_SCORE}
       GENESIS_BLOCK_HASH: ${GENESIS_BLOCK_HASH}
-      MIN_PROTOCOL_FEE_PER_GAS_GWEI: ${MIN_PROTOCOL_FEE_PER_GAS_GWEI}
     volumes:
       - ./keys/jwt.hex:/app/jwt.hex:ro
       - /var/run/docker.sock:/var/run/docker.sock
@@ -231,6 +238,7 @@ services:
       - "--entrypoints.kaspad_grpc.address=:16210"
       - "--entrypoints.kaspad_borsh.address=:17210"
       - "--entrypoints.kaspad_json.address=:18210"
+      - "--entrypoints.el_stats.address=:9001"
       - "--log.level=DEBUG"
       - "--certificatesresolvers.myresolver.acme.email=${IGRA_ORCHESTRA_DOMAIN_EMAIL}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
@@ -242,6 +250,7 @@ services:
       - "8001:8001"
       - "8010:8010"
       - "8545:8545"
+      - "9001:9001"
       - "17611:17210"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
This commit opens the metrics port for the execution layer, making it
accessible for monitoring purposes.

Exposing this endpoint allows external tools, such as Prometheus, to
scrape and collect vital statistics and performance data. This change
significantly improves the observability of the execution layer,
enabling better health checks, performance tracking, and easier
debugging.