### PR TITLE
feat: Add performance diagnostics toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ IGRA_ORCHESTRA_DOMAIN_EMAIL=igor@igralabs.com
 # Defaults to 'syslog' which works well on Linux.
 # On macOS, 'json-file' is recommended as 'syslog' might not be available or work correctly.
 LOGGING_DRIVER=json-file
+ENABLE_PERF_DIAGNOSTICS=false
 
 # General and share configuration
 RUST_LOG=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,7 @@ services:
       L1_REFERENCE_DAA_SCORE: ${L1_REFERENCE_DAA_SCORE}
       GENESIS_BLOCK_HASH: ${GENESIS_BLOCK_HASH}
       MIN_PROTOCOL_FEE_PER_GAS_GWEI: ${MIN_PROTOCOL_FEE_PER_GAS_GWEI}
+      ENABLE_PERF_DIAGNOSTICS: ${ENABLE_PERF_DIAGNOSTICS}
     volumes:
       - ./keys/jwt.hex:/app/jwt.hex:ro
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Introduces a new environment variable `ENABLE_PERF_DIAGNOSTICS` to selectively enable performance data collection. This allows for in-depth performance analysis and debugging when required, without incurring the overhead of continuous monitoring during normal operation.

The flag is set to `false` by default to ensure no performance impact on standard deployments.