### PR TITLE
fix: disable automatic restart for core services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ services:
   # CORE SERVICES
   execution-layer:
     <<: *default-service
+    restart: "no"
     container_name: execution-layer
     image: ghcr.io/paradigmxyz/reth:latest
     entrypoint: /root/reth/run-igra-dev-el.sh
@@ -172,6 +173,7 @@ services:
 
   block-builder:
     <<: *default-service
+    restart: "no"
     build:
       context: build/repos/block-builder
       dockerfile: ../../Dockerfile.block-builder
@@ -202,6 +204,7 @@ services:
 
   viaduct:
     <<: *default-service
+    restart: "no"
     build:
       context: build/repos/viaduct
       dockerfile: ../../Dockerfile.viaduct


### PR DESCRIPTION
Sets the restart policy to "no" for the `execution-layer`, `block-builder`, and `viaduct` services.

Automatic restarts can obscure the root cause of service failures, making debugging more difficult. When a service fails, it is preferable for it to remain in an exited state. This allows developers to inspect logs and the container's final state to diagnose the problem effectively. This change improves the stability and debuggability of the local environment.