### PR TITLE
fix: Restrict reth_ipc volume to socket directory and reduce size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
     driver_opts:
       type: tmpfs
       device: tmpfs
-      o: size=30g
+      o: size=1m
 networks:
   igra-network:
   kaspa-explorer-network:
@@ -158,7 +158,7 @@ services:
       - ./keys/jwt.hex:/root/reth/jwt.hex
       - ./build/repos/execution-layer/genesis.template.json:/root/reth/genesis.template.json
       - ./build/repos/execution-layer/run-igra-dev-el.sh:/root/reth/run-igra-dev-el.sh
-      - reth_ipc:/root/reth
+      - reth_ipc:/root/reth/socket
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.el_stats.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
@@ -169,7 +169,7 @@ services:
       - "traefik.http.services.el_stats_svc.loadbalancer.server.port=9001"
     healthcheck:
       <<: *default-healthcheck
-      test: ["CMD", "bash", "-c", "test -S /root/reth/auth.ipc"]
+      test: ["CMD", "bash", "-c", "test -S /root/reth/socket/auth.ipc"]
 
   block-builder:
     <<: *default-service


### PR DESCRIPTION
Previously, the `reth_ipc` volume mounted the entire `/root/reth` directory and allocated a 30g tmpfs for it. This was inefficient as it shared the entire Reth data directory when only the IPC socket was needed, and reserved an excessive amount of memory.

This commit refines the configuration by mounting the volume specifically to the `/root/reth/socket` directory. The tmpfs size has also been reduced to 1m, which is more than enough for a socket file.

These changes enhance security by limiting data exposure and improve resource management by allocating a more appropriate volume size.