### PR TITLE
feat: Enable discarding of reorged transactions in reth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     <<: *default-service
     restart: "no"
     container_name: execution-layer
-    image: ghcr.io/paradigmxyz/reth:latest
+    image: igralabscom/reth:v1.6.0
     entrypoint: /root/reth/run-igra-dev-el.sh
     profiles: ["backend"]
     ports:


### PR DESCRIPTION
This commit updates the `docker-compose.yml` to use a custom `igralabscom/reth` image. This custom image enables the `--txpool.discard-reorged-transactions` flag for the local development node.

By enabling this flag, transactions from reorged blocks are discarded instead of being re-injected into the pool. This helps maintain a cleaner and more predictable transaction pool state during development, especially when dealing with frequent chain reorganizations.