### PR TITLE
fix: mitigate L2 reorgs by delaying blocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ KASPAD_ADD_PEER=<ip-address> # optional argument
 REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 MAGIC_SPK=20587b999b5b38f5c87ce04e4a2100998a05d303cc54c30ec77fa2c51dc5aa0a53ac
-DELAY_BLOCKS=0
+DELAY_WINDOWS=3
 
 # Mining configuration
 MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,7 @@ services:
       - SYNC_THREADS
       - IGRA_LAUNCH_DAA_SCORE
       - MAGIC_SPK
-      - DELAY_BLOCKS
+      - DELAY_WINDOWS
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: ["--ip-port=${KASPAD_HOST}:${KASPAD_BORSH_PORT}", "--bb-ip-port=block-builder:8561"]


### PR DESCRIPTION
L2 reorgs can leave the system in an inconsistent state. To reduce this risk, temporarily delay blocks until the reorg is resolved.