### PR TITLE
build: Use rust:slim as base image in all Dockerfiles

### DIFF
--- a/build/Dockerfile.block-builder
+++ b/build/Dockerfile.block-builder
@@ -9,7 +9,7 @@ COPY . .
 RUN cargo build --release
 
 # Runtime stage
-FROM debian:bookworm-slim
+FROM rust:slim
 
 # Install dependencies
 RUN apt-get update -y && \

--- a/build/Dockerfile.kaspa-miner
+++ b/build/Dockerfile.kaspa-miner
@@ -14,7 +14,7 @@ COPY . .
 
 RUN cargo build --bin kaspa-miner --release
 
-FROM debian:bookworm-slim
+FROM rust:slim
 
 WORKDIR /app
 

--- a/build/Dockerfile.kaspad
+++ b/build/Dockerfile.kaspad
@@ -14,7 +14,7 @@ COPY . .
 
 RUN cargo build --bin kaspad --release
 
-FROM debian:bookworm-slim
+FROM rust:slim
 
 WORKDIR /app
 

--- a/build/Dockerfile.kaswallet
+++ b/build/Dockerfile.kaswallet
@@ -11,7 +11,7 @@ COPY . .
 
 RUN cargo build --bin kaswallet-daemon --release
 
-FROM debian:bookworm-slim
+FROM rust:slim
 
 WORKDIR /app
 

--- a/build/Dockerfile.rpc-provider
+++ b/build/Dockerfile.rpc-provider
@@ -11,7 +11,7 @@ COPY . .
 
 RUN cargo build --bin igra-rpc-provider --release
 
-FROM debian:bookworm-slim
+FROM rust:slim
 
 WORKDIR /app
 

--- a/build/Dockerfile.viaduct
+++ b/build/Dockerfile.viaduct
@@ -20,7 +20,7 @@ COPY . .
 # Use BuildKit SSH mount for cargo build
 RUN --mount=type=ssh cargo build --release
 
-FROM debian:bookworm-slim
+FROM rust:slim
 
 WORKDIR /app
 


### PR DESCRIPTION
The Docker image builds started failing suddenly, likely due to a recent upstream change in the `debian:bookworm-slim` base image which appears to have removed a required shared library.

Previously, this base image contained the necessary runtime dependencies for our compiled Rust applications. To fix the builds and make them more robust against future upstream changes, this commit replaces the debian base image with `rust:slim`.

The `rust:slim` image is specifically designed for running Rust binaries, ensuring that all necessary runtime dependencies are included by default. This resolves the immediate issue and stabilizes the build process.