### PR TITLE
fix: decouple health-check from execution-layer in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,8 +179,6 @@ services:
       - NODE_ID=igra-orchestra-${NODE_ID}
       - API_KEY=${HEALTH_CHECK_API_KEY}
       - POLL_INTERVAL=5
-    depends_on:
-      - execution-layer
     restart: unless-stopped
 
   block-builder:


### PR DESCRIPTION
Remove depends_on constraint between health-check and execution-layer to allow health-check to start independently. This prevents blocked startups when execution-layer is down or slow and lets the service report system status early. The health-check already handles transient failures and retries via POLL_INTERVAL, so a hard startup dependency is unnecessary. This change improves resilience and reduces coupling across environments.