### PR TITLE
fix: restore permissions and restart rsyslog after cleanup

### DIFF
--- a/scripts/log-management/cleanup-logs.sh
+++ b/scripts/log-management/cleanup-logs.sh
@@ -317,6 +317,15 @@ main() {
     # Generate summary report
     generate_summary
     
+    # Fix ownership and permissions for system logs after cleanup
+    log_message "INFO" "Fixing log file permissions and ownership"
+    chown syslog:adm /var/log/syslog /var/log/auth.log /var/log/kern.log /var/log/daemon.log /var/log/user.log 2>/dev/null || true
+    chmod 640 /var/log/syslog /var/log/auth.log /var/log/kern.log /var/log/daemon.log /var/log/user.log 2>/dev/null || true
+    
+    # Restart rsyslog to ensure it can write to the logs
+    log_message "INFO" "Restarting rsyslog service"
+    systemctl restart rsyslog 2>/dev/null || service rsyslog restart 2>/dev/null || true
+    
     log_message "INFO" "Log cleanup completed successfully"
     
     # Exit with appropriate code


### PR DESCRIPTION
Ensure system log files have correct ownership and permissions after cleanup. Set chown to syslog:adm and chmod 640 for core logs (syslog, auth, kern, daemon, user). Restart rsyslog so it can reopen and write to rotated or cleaned files.

Motivation: post-cleanup, mismatched perms or ownership can block rsyslog, causing missed entries and noisy failures. This change hardens the script to recover a working logging state.

Implementation: tolerate missing files and init systems by redirecting errors and falling back from systemctl to service. Keep the script idempotent and resilient with "|| true".

Impact: reduce logging disruptions after maintenance with minimal risk (a brief rsyslog restart).