### PR TITLE
build: pin Docker image tags; bump reth to 1.7.0; update docs

### DIFF
--- a/doc/multi-platform-quick.md
+++ b/doc/multi-platform-quick.md
@@ -30,29 +30,25 @@ docker login
 # Build and push each service with SSH forwarding
 docker buildx build --platform linux/amd64,linux/arm64 \
   --ssh default \
-  --tag igranetwork/block-builder:v0.2.1 \
-  --tag igranetwork/block-builder:latest \
+  --tag igranetwork/block-builder:v0.2.2 \
   --file build/Dockerfile.block-builder \
   --push build/repos/block-builder
 
 docker buildx build --platform linux/amd64,linux/arm64 \
   --ssh default \
-  --tag igranetwork/viaduct:v0.2.1 \
-  --tag igranetwork/viaduct:latest \
+  --tag igranetwork/viaduct:v0.2.2 \
   --file build/Dockerfile.viaduct \
   --push build/repos/viaduct
 
 docker buildx build --platform linux/amd64,linux/arm64 \
   --ssh default \
   --tag igranetwork/rpc-provider:v0.2.1 \
-  --tag igranetwork/rpc-provider:latest \
   --file build/Dockerfile.rpc-provider \
   --push build/repos/igra-rpc-provider
 
 docker buildx build --platform linux/amd64,linux/arm64 \
   --ssh default \
   --tag igranetwork/kaswallet:v0.2.1 \
-  --tag igranetwork/kaswallet:latest \
   --file build/Dockerfile.kaswallet \
   --push build/repos/kaswallet
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ x-rpc-provider-base: &rpc-provider-base
   build:
     context: build/repos/igra-rpc-provider
     dockerfile: ../../Dockerfile.rpc-provider
-  image: igranetwork/rpc-provider:latest
+  image: igranetwork/rpc-provider:v0.2.1
   environment: *rpc-provider-environment
   expose:
     - "8535"
@@ -114,7 +114,7 @@ x-kaswallet-base: &kaswallet-base
   build:
     context: build/repos/kaswallet
     dockerfile: ../../Dockerfile.kaswallet
-  image: igranetwork/kaswallet:latest
+  image: igranetwork/kaswallet:v0.2.1
   expose:
     - "8082"
   environment:
@@ -134,7 +134,7 @@ services:
     <<: *default-service
     restart: "no"
     container_name: execution-layer
-    image: igranetwork/reth:v1.6.0
+    image: igranetwork/reth:1.7.0
     entrypoint: /root/reth/run-igra-dev-el.sh
     profiles: ["backend"]
     ports:
@@ -187,7 +187,7 @@ services:
     build:
       context: build/repos/block-builder
       dockerfile: ../../Dockerfile.block-builder
-    image: igranetwork/block-builder:latest
+    image: igranetwork/block-builder:v0.2.2
     command: /app/jwt.hex http://execution-layer
     profiles: ["backend"]
     container_name: block-builder
@@ -220,7 +220,7 @@ services:
       dockerfile: ../../Dockerfile.viaduct
       ssh:
         - default
-    image: igranetwork/viaduct:latest
+    image: igranetwork/viaduct:v0.2.2
     profiles: ["backend"]
     container_name: viaduct
     environment:


### PR DESCRIPTION
Pin images in docker-compose to explicit versions for reproducible builds and to avoid accidental upgrades from latest. Align quickstart docs with pinned tags and recent releases.

-  docker-compose.yml:
    - rpc-provider, kaswallet: latest -> v0.2.1
    - block-builder, viaduct: latest -> v0.2.2
    - execution-layer (reth): v1.6.0 -> 1.7.0
-  doc/multi-platform-quick.md:
    - remove :latest tags from buildx commands
    - set block-builder and viaduct to v0.2.2
    - keep rpc-provider and kaswallet at v0.2.1