### PR TITLE
chore: pin image tags to v0.2.2 and rename health-check client service

### DIFF
--- a/doc/quick-setup-prebuilt.md
+++ b/doc/quick-setup-prebuilt.md
@@ -65,7 +65,7 @@ docker compose logs -f
 # Track block-builder progress
 docker logs -f block-builder
 # Optional analyzer
-docker logs -f block-builder | docker run -i --rm --entrypoint /app/reorg_analyzer igranetwork/block-builder:latest
+docker logs -f block-builder | docker run -i --rm --entrypoint /app/reorg_analyzer igranetwork/block-builder:v0.2.2
 ```
 
 #### Common issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,8 +169,8 @@ services:
       test: ["CMD", "bash", "-c", "test -S /root/reth/socket/auth.ipc"]
 
   health-check-client:
-    image: igranetwork/node-push-client:latest
-    container_name: node-push-client
+    image: igranetwork/node-health-check-client:v0.2.2
+    container_name: node-health-check-client
     networks:
       - igra-network
     environment:


### PR DESCRIPTION
Pin the block-builder analyzer in docs to v0.2.2 instead of latest to ensure reproducible setups and avoid unexpected changes from upstream. Update docker-compose to use the new node-health-check-client:v0.2.2 image and rename the container from node-push-client to node-health-check-client for clarity and consistency, and to prevent breakage from floating tags. Align configurations with the v0.2.2 release for traceability.

BREAKING CHANGE: container_name changes from node-push-client to node-health-check-client.