### PR TITLE
feat: configurable local retention via env

### DIFF
--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -29,7 +29,8 @@ BACKUP_DIR="$HOME/.backups/${CONTAINER_NAME}-backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="$BACKUP_DIR/${VOLUME_NAME}_$TIMESTAMP.tar.gz"
 LOG_FILE="$BACKUP_DIR/backup_logs.log"
-KEEP_BACKUPS=7 # Number of recent backups to keep
+# Allow overriding local retention with environment variable
+KEEP_BACKUPS=${LOCAL_BACKUP_RETENTION_COUNT:-3} # Number of recent backups to keep
 GZIP_LEVEL=1   # Compression level (1=fastest, 9=best, 6=default). Set to "" to use default.
 
 # Function for logging
@@ -183,11 +184,11 @@ fi
 # Set S3_BACKUP_AUTO_UPLOAD=true in .env to enable automatic S3 upload after successful backup
 if [ "$VERIFICATION_SUCCESSFUL" = true ] && [ "${S3_BACKUP_AUTO_UPLOAD,,}" = "true" ]; then
   log_message "S3 auto-upload is enabled, starting upload process..."
-  
+
   # Get the directory where this script is located
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   S3_UPLOAD_SCRIPT="$SCRIPT_DIR/upload-to-s3.sh"
-  
+
   if [ -x "$S3_UPLOAD_SCRIPT" ]; then
     log_message "Calling S3 upload script for container: $CONTAINER_NAME"
     if "$S3_UPLOAD_SCRIPT" "$CONTAINER_NAME" "$BACKUP_FILE"; then

--- a/scripts/backup/upload-to-s3.sh
+++ b/scripts/backup/upload-to-s3.sh
@@ -83,10 +83,10 @@ log_message() {
     local message="$*"
     local timestamp
     timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    
+
     local formatted_message
     formatted_message=$(format_log_message "$level" "$timestamp" "$message")
-    
+
     output_log_message "$formatted_message"
 }
 
@@ -95,7 +95,7 @@ format_log_message() {
     local level="$1"
     local timestamp="$2"
     local message="$3"
-    
+
     case "$level" in
         "ERROR")   echo -e "\033[31m[$timestamp] ERROR: $message\033[0m" ;;
         "WARNING") echo -e "\033[33m[$timestamp] WARNING: $message\033[0m" ;;
@@ -108,7 +108,7 @@ format_log_message() {
 # Function to output log messages to console and file
 output_log_message() {
     local formatted_message="$1"
-    
+
     if [ -n "$LOG_FILE" ]; then
         echo "$formatted_message" | tee -a "$LOG_FILE"
     else
@@ -119,12 +119,12 @@ output_log_message() {
 # Function to validate AWS CLI availability
 check_aws_cli() {
     log_message "INFO" "Checking AWS CLI availability..."
-    
+
     if ! command -v aws &> /dev/null; then
         log_aws_cli_missing_error
         exit $EXIT_AWS_CLI_MISSING
     fi
-    
+
     log_aws_cli_version
 }
 
@@ -144,12 +144,12 @@ log_aws_cli_version() {
 # Function to validate AWS credentials
 check_aws_credentials() {
     log_message "INFO" "Validating AWS credentials..."
-    
+
     if ! aws_identity_exists; then
         log_aws_credentials_error
         exit $EXIT_AWS_CREDENTIALS_ERROR
     fi
-    
+
     log_aws_identity_info
 }
 
@@ -177,7 +177,7 @@ log_aws_identity_info() {
 # Function to source .env file (similar to backup.sh)
 source_env_file() {
     local env_file=".env"
-    
+
     if [ -f "$env_file" ]; then
         log_message "INFO" "Loading configuration from $env_file"
         while IFS= read -r line; do
@@ -195,7 +195,7 @@ source_env_file() {
 # Function to validate required environment variables
 validate_environment() {
     log_message "INFO" "Validating environment configuration..."
-    
+
     check_required_environment_variables
     set_default_environment_values
     configure_dry_run_mode
@@ -207,13 +207,13 @@ validate_environment() {
 check_required_environment_variables() {
     local required_vars=("NETWORK" "S3_BACKUP_BUCKET" "S3_BACKUP_REGION")
     local missing_vars=()
-    
+
     for var in "${required_vars[@]}"; do
         if [ -z "${!var}" ]; then
             missing_vars+=("$var")
         fi
     done
-    
+
     if [ ${#missing_vars[@]} -gt 0 ]; then
         log_missing_environment_variables "${missing_vars[@]}"
         exit $EXIT_CONFIG_ERROR
@@ -223,7 +223,7 @@ check_required_environment_variables() {
 # Function to log missing environment variables
 log_missing_environment_variables() {
     local missing_vars=("$@")
-    
+
     log_message "ERROR" "Missing required environment variables:"
     for var in "${missing_vars[@]}"; do
         log_message "ERROR" "  - $var"
@@ -268,12 +268,12 @@ log_environment_configuration() {
 # Function to test S3 bucket access and permissions
 test_s3_access() {
     log_message "INFO" "Testing S3 bucket access and permissions..."
-    
+
     if ! test_s3_bucket_access; then
         log_s3_bucket_access_error
         exit $EXIT_CONFIG_ERROR
     fi
-    
+
     log_message "SUCCESS" "S3 bucket access confirmed"
     test_s3_permissions
 }
@@ -297,21 +297,21 @@ test_s3_permissions() {
         log_message "INFO" "[DRY-RUN] Skipping S3 permission test"
         return 0
     fi
-    
+
     log_message "INFO" "Testing S3 write permissions..."
-    
+
     local test_context
     test_context=$(create_s3_permission_test_context)
-    
+
     local test_key test_content temp_test_file
     test_key=$(echo "$test_context" | cut -d'|' -f1)
     test_content=$(echo "$test_context" | cut -d'|' -f2)
     temp_test_file=$(echo "$test_context" | cut -d'|' -f3)
-    
+
     test_s3_upload_permission "$temp_test_file" "$test_key"
     test_s3_download_permission "$test_key" "$test_content"
     test_s3_delete_permission "$test_key"
-    
+
     cleanup_s3_permission_test "$temp_test_file"
     log_message "SUCCESS" "S3 permission testing completed"
 }
@@ -323,7 +323,7 @@ create_s3_permission_test_context() {
     local test_content="IGRA Orchestra S3 permission test"
     local temp_test_file
     temp_test_file=$(mktemp)
-    
+
     echo "$test_content" > "$temp_test_file"
     echo "$test_key|$test_content|$temp_test_file"
 }
@@ -332,7 +332,7 @@ create_s3_permission_test_context() {
 test_s3_upload_permission() {
     local temp_test_file="$1"
     local test_key="$2"
-    
+
     if ! aws s3 cp "$temp_test_file" "s3://$S3_BACKUP_BUCKET/$test_key" \
         --region "$S3_BACKUP_REGION" \
         --storage-class "$S3_BACKUP_STORAGE_CLASS" \
@@ -342,7 +342,7 @@ test_s3_upload_permission() {
         log_message "ERROR" "AWS credentials need s3:PutObject permission"
         exit $EXIT_CONFIG_ERROR
     fi
-    
+
     log_message "SUCCESS" "S3 upload permission confirmed"
 }
 
@@ -350,7 +350,7 @@ test_s3_upload_permission() {
 test_s3_download_permission() {
     local test_key="$1"
     local expected_content="$2"
-    
+
     local downloaded_content
     if downloaded_content=$(aws s3 cp "s3://$S3_BACKUP_BUCKET/$test_key" - \
         --region "$S3_BACKUP_REGION" 2>/dev/null); then
@@ -365,7 +365,7 @@ test_s3_download_permission() {
 verify_s3_content_integrity() {
     local downloaded_content="$1"
     local expected_content="$2"
-    
+
     if [ "$downloaded_content" = "$expected_content" ]; then
         log_message "SUCCESS" "S3 upload/download integrity verified"
     else
@@ -376,7 +376,7 @@ verify_s3_content_integrity() {
 # Function to test S3 delete permission
 test_s3_delete_permission() {
     local test_key="$1"
-    
+
     if aws s3 rm "s3://$S3_BACKUP_BUCKET/$test_key" \
         --region "$S3_BACKUP_REGION" \
         --only-show-errors 2>/dev/null; then
@@ -397,15 +397,15 @@ cleanup_s3_permission_test() {
 find_latest_backup() {
     local container="$1"
     local backup_dir="$HOME/.backups/${container}-backups"
-    
+
     log_message "INFO" "Looking for latest backup in: $backup_dir"
-    
+
     if [ ! -d "$backup_dir" ]; then
         log_message "ERROR" "Backup directory not found: $backup_dir"
         log_message "ERROR" "Run backup.sh first to create backups"
         exit $EXIT_FILE_NOT_FOUND
     fi
-    
+
     # Find the most recent backup file (portable for macOS and Linux)
     local latest_backup
     if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -415,13 +415,13 @@ find_latest_backup() {
         # Linux version using find -printf
         latest_backup=$(find "$backup_dir" -name "*.tar.gz" -type f -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
     fi
-    
+
     if [ -z "$latest_backup" ]; then
         log_message "ERROR" "No backup files found in: $backup_dir"
         log_message "ERROR" "Run backup.sh first to create backups"
         exit $EXIT_FILE_NOT_FOUND
     fi
-    
+
     log_message "SUCCESS" "Found latest backup: $latest_backup"
     # Return only the file path, not log messages
     echo "$latest_backup"
@@ -430,20 +430,20 @@ find_latest_backup() {
 # Function to validate backup file
 validate_backup_file() {
     local file="$1"
-    
+
     log_message "INFO" "Validating backup file: $file"
-    
+
     check_backup_file_exists "$file"
     check_backup_file_size "$file"
     check_backup_file_readable "$file"
-    
+
     log_backup_file_validation_success "$file"
 }
 
 # Function to check if backup file exists
 check_backup_file_exists() {
     local file="$1"
-    
+
     if [ ! -f "$file" ]; then
         log_message "ERROR" "Backup file not found: $file"
         exit $EXIT_FILE_NOT_FOUND
@@ -453,10 +453,10 @@ check_backup_file_exists() {
 # Function to check backup file size
 check_backup_file_size() {
     local file="$1"
-    
+
     local file_size
     file_size=$(get_file_size "$file")
-    
+
     if [ "$file_size" -eq 0 ]; then
         log_message "ERROR" "Backup file is empty: $file"
         exit $EXIT_FILE_NOT_FOUND
@@ -472,7 +472,7 @@ get_file_size() {
 # Function to check if backup file is readable
 check_backup_file_readable() {
     local file="$1"
-    
+
     if [ ! -r "$file" ]; then
         log_message "ERROR" "Backup file is not readable: $file"
         exit $EXIT_FILE_NOT_FOUND
@@ -483,9 +483,9 @@ check_backup_file_readable() {
 log_backup_file_validation_success() {
     local file="$1"
     local file_size
-    
+
     file_size=$(get_file_size "$file")
-    
+
     log_message "SUCCESS" "Backup file validation passed"
     log_message "INFO" "File size: $(numfmt --to=iec --suffix=B "$file_size")"
 }
@@ -495,15 +495,15 @@ calculate_md5() {
     local file="$1"
     local start_time
     start_time=$(date +%s)
-    
+
     log_message "INFO" "Calculating MD5 checksum for $(basename "$file")..."
-    
+
     local md5sum_result
     md5sum_result=$(get_md5_checksum "$file")
-    
+
     local duration
     duration=$(calculate_duration "$start_time")
-    
+
     log_message "SUCCESS" "MD5 checksum calculated in ${duration}s: $md5sum_result"
     echo "$md5sum_result"
 }
@@ -511,7 +511,7 @@ calculate_md5() {
 # Function to get MD5 checksum (cross-platform)
 get_md5_checksum() {
     local file="$1"
-    
+
     if command -v md5sum &> /dev/null; then
         md5sum "$file" | cut -d' ' -f1
     elif command -v md5 &> /dev/null; then
@@ -533,10 +533,10 @@ calculate_duration() {
 # Function to list current S3 backups
 list_s3_backups() {
     log_message "INFO" "Listing S3 backups for $CONTAINER_NAME in $S3_BASE_PATH"
-    
+
     # Note: Match the backup naming pattern from backup.sh
     local prefix_filter="igra-orchestra-${NETWORK}_${CONTAINER_NAME}_"
-    
+
     # List objects with detailed information
     if ! aws s3api list-objects-v2 \
         --bucket "$S3_BACKUP_BUCKET" \
@@ -547,14 +547,14 @@ list_s3_backups() {
         log_message "WARNING" "No backups found or failed to list S3 objects"
         return 1
     fi
-    
+
     return 0
 }
 
 # Function to get existing S3 backups sorted by date
 get_s3_backups_sorted() {
     local prefix_filter="${S3_BASE_PATH}igra-orchestra-${NETWORK}_${CONTAINER_NAME}_"
-    
+
     # Get list of matching objects sorted by LastModified (oldest first)
     aws s3api list-objects-v2 \
         --bucket "$S3_BACKUP_BUCKET" \
@@ -567,24 +567,24 @@ get_s3_backups_sorted() {
 # Function to manage S3 backup retention
 manage_s3_retention() {
     log_message "INFO" "Managing S3 backup retention (keeping latest $S3_BACKUP_RETENTION_COUNT backups)"
-    
+
     local backups_json
     backups_json=$(get_s3_backups_sorted)
-    
+
     if ! has_existing_backups "$backups_json"; then
         log_message "INFO" "No existing backups found for retention management"
         return 0
     fi
-    
+
     local backup_count delete_count
     backup_count=$(count_existing_backups "$backups_json")
     delete_count=$(calculate_backups_to_delete "$backup_count")
-    
+
     if [ "$delete_count" -le 0 ]; then
         log_message "INFO" "No backups need to be deleted (within retention limit)"
         return 0
     fi
-    
+
     delete_old_backups "$backups_json" "$delete_count"
 }
 
@@ -611,17 +611,17 @@ calculate_backups_to_delete() {
 delete_old_backups() {
     local backups_json="$1"
     local delete_count="$2"
-    
+
     log_message "INFO" "Will delete $delete_count old backup(s) to maintain retention policy"
-    
+
     local keys_to_delete
     keys_to_delete=$(get_keys_to_delete "$backups_json" "$delete_count")
-    
+
     if [ -z "$keys_to_delete" ]; then
         log_message "WARNING" "No keys found for deletion"
         return 0
     fi
-    
+
     process_backup_deletions "$keys_to_delete"
 }
 
@@ -636,19 +636,19 @@ get_keys_to_delete() {
 process_backup_deletions() {
     local keys_to_delete="$1"
     local deleted_count=0
-    
+
     while IFS= read -r key; do
         [ -z "$key" ] && continue
-        
+
         local filename
         filename=$(basename "$key")
         if delete_single_backup "$key" "$filename"; then
-            ((deleted_count++))
+            ((++deleted_count))
         else
             return 1
         fi
     done <<< "$keys_to_delete"
-    
+
     log_deletion_summary "$deleted_count"
 }
 
@@ -656,12 +656,12 @@ process_backup_deletions() {
 delete_single_backup() {
     local key="$1"
     local filename="$2"
-    
+
     if [ "$DRY_RUN" = true ]; then
         log_message "INFO" "[DRY-RUN] Would delete: $filename"
         return 0
     fi
-    
+
     log_message "INFO" "Deleting old backup: $filename"
     if aws s3 rm "s3://$S3_BACKUP_BUCKET/$key" --region "$S3_BACKUP_REGION" &> /dev/null; then
         log_message "SUCCESS" "Deleted: $filename"
@@ -675,7 +675,7 @@ delete_single_backup() {
 # Function to log deletion summary
 log_deletion_summary() {
     local deleted_count="$1"
-    
+
     if [ "$DRY_RUN" != true ]; then
         log_message "SUCCESS" "Retention management completed: deleted $deleted_count backup(s)"
     fi
@@ -686,24 +686,24 @@ upload_to_s3() {
     local local_file="$1"
     local upload_context
     upload_context=$(create_upload_context "$local_file")
-    
+
     local s3_key s3_uri
     s3_key=$(echo "$upload_context" | cut -d'|' -f1)
     s3_uri=$(echo "$upload_context" | cut -d'|' -f2)
-    
+
     # Store S3 key for potential rollback
     UPLOADED_S3_KEY="$s3_key"
-    
+
     log_upload_start_info "$local_file" "$s3_uri"
-    
+
     if [ "$DRY_RUN" = true ]; then
         log_message "INFO" "[DRY-RUN] Would upload to: $s3_uri"
         return 0
     fi
-    
+
     local local_md5
     local_md5=$(calculate_md5 "$local_file" | tail -1)
-    
+
     execute_upload_with_retry "$local_file" "$s3_uri" "$s3_key" "$local_md5"
 }
 
@@ -714,7 +714,7 @@ create_upload_context() {
     filename=$(basename "$local_file")
     local s3_key="${S3_BASE_PATH}${filename}"
     local s3_uri="s3://$S3_BACKUP_BUCKET/$s3_key"
-    
+
     echo "$s3_key|$s3_uri"
 }
 
@@ -722,7 +722,7 @@ create_upload_context() {
 log_upload_start_info() {
     local local_file="$1"
     local s3_uri="$2"
-    
+
     log_message "INFO" "Starting S3 upload..."
     log_message "INFO" "  Local: $local_file"
     log_message "INFO" "  S3 URI: $s3_uri"
@@ -735,11 +735,11 @@ execute_upload_with_retry() {
     local s3_uri="$2"
     local s3_key="$3"
     local local_md5="$4"
-    
+
     # Check if file already exists in S3 with same MD5
     check_s3_file_exists_with_md5 "$s3_key" "$local_md5"
     local check_result=$?
-    
+
     if [ $check_result -eq 0 ]; then
         # File exists with same MD5, skip upload
         log_message "SUCCESS" "Skipping upload - identical file already exists in S3"
@@ -751,21 +751,21 @@ execute_upload_with_retry() {
         log_message "WARNING" "File exists in S3 with different content - will overwrite"
     fi
     # If check_result is 2, file doesn't exist, proceed with normal upload
-    
+
     local max_attempts=3
     local attempt=1
-    
+
     while [ $attempt -le $max_attempts ]; do
         log_message "INFO" "Upload attempt $attempt of $max_attempts..."
-        
+
         if attempt_single_upload "$local_file" "$s3_uri" "$s3_key" "$local_md5"; then
             return 0
         fi
-        
+
         handle_upload_attempt_failure "$attempt" "$max_attempts"
         ((attempt++))
     done
-    
+
     log_upload_final_failure "$max_attempts"
     return 1
 }
@@ -776,18 +776,18 @@ attempt_single_upload() {
     local s3_uri="$2"
     local s3_key="$3"
     local local_md5="$4"
-    
+
     local upload_start
     upload_start=$(date +%s)
-    
+
     if perform_s3_upload "$local_file" "$s3_uri"; then
         local upload_duration
         upload_duration=$(calculate_duration "$upload_start")
         log_message "SUCCESS" "Upload completed in ${upload_duration}s"
-        
+
         # Mark that rollback might be needed (file exists in S3 but not verified)
         ROLLBACK_NEEDED=true
-        
+
         if verify_s3_upload "$local_file" "$s3_key" "$local_md5"; then
             UPLOAD_SUCCESS=true
             ROLLBACK_NEEDED=false  # Upload successful, no rollback needed
@@ -807,13 +807,13 @@ attempt_single_upload() {
 check_s3_file_exists_with_md5() {
     local s3_key="$1"
     local local_md5="$2"
-    
+
     # Check if file exists in S3
     if aws s3api head-object \
         --bucket "$S3_BACKUP_BUCKET" \
         --key "$s3_key" \
         --region "$S3_BACKUP_REGION" &>/dev/null; then
-        
+
         # Get S3 file's ETag (MD5 for single-part uploads)
         local s3_etag
         s3_etag=$(aws s3api head-object \
@@ -822,7 +822,7 @@ check_s3_file_exists_with_md5() {
             --region "$S3_BACKUP_REGION" \
             --query 'ETag' \
             --output text | tr -d '"')
-        
+
         # Compare MD5 checksums
         if [ "$s3_etag" = "$local_md5" ]; then
             log_message "INFO" "File already exists in S3 with matching MD5: $s3_etag"
@@ -832,7 +832,7 @@ check_s3_file_exists_with_md5() {
             return 1  # File exists but content differs
         fi
     fi
-    
+
     return 2  # File doesn't exist in S3
 }
 
@@ -842,7 +842,7 @@ perform_s3_upload() {
     local s3_uri="$2"
     local file_size
     file_size=$(get_file_size "$local_file")
-    
+
     # Show progress for files larger than 5MB
     if [ "$file_size" -gt 5242880 ]; then
         log_message "INFO" "Upload progress:"
@@ -863,7 +863,7 @@ perform_s3_upload() {
 handle_upload_attempt_failure() {
     local attempt="$1"
     local max_attempts="$2"
-    
+
     if [ $((attempt + 1)) -le "$max_attempts" ]; then
         log_message "INFO" "Retrying in 5 seconds..."
         sleep 5
@@ -873,7 +873,7 @@ handle_upload_attempt_failure() {
 # Function to log final upload failure
 log_upload_final_failure() {
     local max_attempts="$1"
-    
+
     log_message "ERROR" "Upload failed after $max_attempts attempts"
     log_message "INFO" "Rollback will be attempted to clean up any partial uploads"
 }
@@ -883,29 +883,29 @@ verify_s3_upload() {
     local local_file="$1"
     local s3_key="$2"
     local local_md5="$3"
-    
+
     log_message "INFO" "Verifying S3 upload..."
-    
+
     local s3_metadata
     s3_metadata=$(get_s3_object_metadata "$s3_key")
-    
+
     if [ -z "$s3_metadata" ]; then
         log_message "ERROR" "Failed to get S3 object metadata"
         return 1
     fi
-    
+
     local verification_context
     verification_context=$(create_verification_context "$s3_metadata" "$local_file")
-    
+
     local s3_etag s3_size local_size
     s3_etag=$(echo "$verification_context" | cut -d'|' -f1)
     s3_size=$(echo "$verification_context" | cut -d'|' -f2)
     local_size=$(echo "$verification_context" | cut -d'|' -f3)
-    
+
     if ! verify_file_size "$local_size" "$s3_size"; then
         return 1
     fi
-    
+
     verify_checksum "$local_md5" "$s3_etag"
     log_message "SUCCESS" "Upload verification completed successfully"
     return 0
@@ -914,7 +914,7 @@ verify_s3_upload() {
 # Function to get S3 object metadata
 get_s3_object_metadata() {
     local s3_key="$1"
-    
+
     aws s3api head-object \
         --bucket "$S3_BACKUP_BUCKET" \
         --key "$s3_key" \
@@ -925,12 +925,12 @@ get_s3_object_metadata() {
 create_verification_context() {
     local s3_metadata="$1"
     local local_file="$2"
-    
+
     local s3_etag s3_size local_size
     s3_etag=$(echo "$s3_metadata" | jq -r '.ETag // empty' | tr -d '"')
     s3_size=$(echo "$s3_metadata" | jq -r '.ContentLength // empty')
     local_size=$(get_file_size "$local_file")
-    
+
     echo "$s3_etag|$s3_size|$local_size"
 }
 
@@ -938,12 +938,12 @@ create_verification_context() {
 verify_file_size() {
     local local_size="$1"
     local s3_size="$2"
-    
+
     if [ "$local_size" != "$s3_size" ]; then
         log_message "ERROR" "File size mismatch: local=$local_size, S3=$s3_size"
         return 1
     fi
-    
+
     log_message "SUCCESS" "File size verification passed: $(numfmt --to=iec --suffix=B "$local_size")"
     return 0
 }
@@ -952,7 +952,7 @@ verify_file_size() {
 verify_checksum() {
     local local_md5="$1"
     local s3_etag="$2"
-    
+
     # For single-part uploads, ETag should match MD5
     # For multipart uploads, ETag has a different format (contains hyphen)
     if [[ "$s3_etag" != *"-"* ]]; then
@@ -966,12 +966,12 @@ verify_checksum() {
 verify_single_part_checksum() {
     local local_md5="$1"
     local s3_etag="$2"
-    
+
     if [ "$local_md5" != "$s3_etag" ]; then
         log_message "ERROR" "MD5 checksum mismatch: local=$local_md5, S3=$s3_etag"
         return 1
     fi
-    
+
     log_message "SUCCESS" "MD5 checksum verification passed: $local_md5"
     return 0
 }
@@ -979,11 +979,11 @@ verify_single_part_checksum() {
 # Function to create lock file
 create_lock() {
     LOCK_FILE="/tmp/${SCRIPT_NAME}_${CONTAINER_NAME}.lock"
-    
+
     if [ -f "$LOCK_FILE" ]; then
         local lock_pid
         lock_pid=$(cat "$LOCK_FILE" 2>/dev/null)
-        
+
         if kill -0 "$lock_pid" 2>/dev/null; then
             log_message "ERROR" "Another upload process is already running (PID: $lock_pid)"
             log_message "ERROR" "Lock file: $LOCK_FILE"
@@ -993,7 +993,7 @@ create_lock() {
             rm -f "$LOCK_FILE"
         fi
     fi
-    
+
     echo $$ > "$LOCK_FILE"
     log_message "INFO" "Lock file created: $LOCK_FILE"
 }
@@ -1004,12 +1004,12 @@ create_lock() {
 rollback_failed_upload() {
     if [ "$ROLLBACK_NEEDED" = true ] && [ -n "$UPLOADED_S3_KEY" ]; then
         log_message "WARNING" "Rolling back failed upload..."
-        
+
         if [ "$DRY_RUN" = true ]; then
             log_message "INFO" "[DRY-RUN] Would rollback S3 object: $UPLOADED_S3_KEY"
             return 0
         fi
-        
+
         # Attempt to delete the partially uploaded or failed file
         if aws s3 rm "s3://$S3_BACKUP_BUCKET/$UPLOADED_S3_KEY" \
             --region "$S3_BACKUP_REGION" \
@@ -1042,7 +1042,7 @@ show_summary() {
     local end_time
     end_time=$(date +%s)
     local total_duration=$((end_time - START_TIME))
-    
+
     log_message "INFO" ""
     log_message "INFO" "===== S3 Upload Summary ====="
     log_message "INFO" "Container: $CONTAINER_NAME"
@@ -1071,7 +1071,7 @@ cleanup() {
     if [ "$UPLOAD_SUCCESS" != true ]; then
         rollback_failed_upload
     fi
-    
+
     # Only show summary if we're not just displaying help
     if [ -n "$LOG_FILE" ] && [ "$LOG_FILE" != "" ]; then
         show_summary


### PR DESCRIPTION
Introduce LOCAL_BACKUP_RETENTION_COUNT in backup.sh to override the number of recent local backups to keep. Default is now 3 (was 7). This enables per-environment control without editing the script and helps reduce disk usage on hosts with limited space.

Update upload-to-s3.sh with whitespace cleanups and switch the deletion counter to pre-increment for clarity. No functional change is expected.