### PR TITLE
fix: clean up incomplete temp archives and document storage usage

### DIFF
--- a/doc/backups/local-backup-restore.md
+++ b/doc/backups/local-backup-restore.md
@@ -18,6 +18,17 @@ This script performs the following actions:
 6.  Optionally uploads the archive to S3 if `S3_BACKUP_AUTO_UPLOAD=true`.
 7.  Logs all operations and timings; the "Container Frozen Time" reflects only pause/copy/unpause.
 
+#### Storage usage and cleanup
+
+- Staging directory: created under `~/.backups/<container>-backups/staging/...`. It is removed automatically:
+  - after successful verification when auto-upload is disabled;
+  - after successful S3 upload when `S3_BACKUP_AUTO_UPLOAD=true`;
+  - on failure or script exit to prevent disk exhaustion.
+
+- Temp archive: a `.tar.gz.tmp` is created during compression and renamed to the final `.tar.gz` after verification. It is removed automatically on failure or script exit.
+
+- Temporary disk usage: during a run you may briefly have both the staging copy and the temporary archive; ensure sufficient free space or reduce `LOCAL_BACKUP_RETENTION_COUNT` to limit concurrent local archives.
+
 **Usage:**
 
 ```bash

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -79,6 +79,11 @@ cleanup() {
     rm -rf "$STAGING_DIR"
     log_message "Removed staging directory during cleanup: $STAGING_DIR"
   fi
+  # Remove any leftover temporary archive on exit (e.g., when compression fails)
+  if [ -n "$TEMP_BACKUP_FILE" ] && [ -f "$TEMP_BACKUP_FILE" ]; then
+    rm -f "$TEMP_BACKUP_FILE"
+    log_message "Removed temporary backup file during cleanup: $TEMP_BACKUP_FILE"
+  fi
   cleanup_lock
   log_message "Cleanup finished."
 }
@@ -167,6 +172,9 @@ if [ -n "$GZIP_LEVEL" ]; then
     -v "$BACKUP_DIR":/backup:rw \
     alpine sh -c 'tar -c -C /data . | gzip -"$1" > "/backup/$2"' sh "$GZIP_LEVEL" "$OUT_BASE_NAME"; then
       log_message "ERROR: Failed to create backup archive from staging."
+      # Clean up potentially large, incomplete temporary archive file
+      rm -f "$TEMP_BACKUP_FILE" 2>/dev/null || true
+      log_message "Removed incomplete temporary archive: $TEMP_BACKUP_FILE"
       exit 1
   fi
 else
@@ -177,6 +185,9 @@ else
     -v "$BACKUP_DIR":/backup:rw \
     alpine sh -c 'tar -czf "/backup/$1" -C /data .' sh "$OUT_BASE_NAME"; then
       log_message "ERROR: Failed to create backup archive from staging."
+      # Clean up potentially large, incomplete temporary archive file
+      rm -f "$TEMP_BACKUP_FILE" 2>/dev/null || true
+      log_message "Removed incomplete temporary archive: $TEMP_BACKUP_FILE"
       exit 1
   fi
 fi


### PR DESCRIPTION
Prevent disk exhaustion and orphaned files by removing temporary archives on failure or script exit. In backup.sh, extend cleanup() to delete any TEMP_BACKUP_FILE if present, and explicitly remove the incomplete archive on tar/gzip errors in both compressed and gzip-level paths, with clear logging.

Update documentation with a "Storage usage and cleanup" section describing the staging directory lifecycle, the temporary .tar.gz.tmp file behavior and renaming, automatic cleanup conditions, and guidance on temporary disk usage and tuning via LOCAL_BACKUP_RETENTION_COUNT.

This makes failure handling safer and disk usage more predictable without changing successful backup behavior.