### PR TITLE
fix: prevent deleting fresh backup when retention=0; prune post-upload

### DIFF
--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -35,6 +35,13 @@ STAGING_DIR="$BACKUP_DIR/staging/${VOLUME_NAME}_$TIMESTAMP"
 KEEP_BACKUPS=${LOCAL_BACKUP_RETENTION_COUNT:-1} # Number of recent backups to keep
 GZIP_LEVEL=1   # Compression level (1=fastest, 9=best, 6=default). Set to "" to use default.
 
+# Ensure backup directory and log file exist before any logging
+mkdir -p "$BACKUP_DIR"
+touch "$LOG_FILE" 2>/dev/null || true
+
+# Normalize auto-upload flag for portability (avoid bash 4+ lowercase expansion)
+S3_UPLOAD_ENABLED=$(echo "${S3_BACKUP_AUTO_UPLOAD:-false}" | tr -d '"' | tr '[:upper:]' '[:lower:]')
+
 # Function for logging
 log_message() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOG_FILE"
@@ -70,6 +77,16 @@ cleanup_lock() {
   fi
 }
 
+# Prune local backups, keeping the most recent N files matching pattern
+prune_backups() {
+  local keep_count="$1"
+  log_message "Pruning old backups (keeping last $keep_count)..."
+  # Suppress ls errors if no files match; xargs -r avoids running rm with no args
+  ls -1t "$BACKUP_DIR"/"${VOLUME_NAME}"_*.tar.gz 2>/dev/null | \
+    tail -n +$((keep_count + 1)) | xargs -r rm -fv | tee -a "$LOG_FILE"
+  log_message "Pruning complete."
+}
+
 cleanup() {
   # Ensure container is unpaused and lock is removed on exit
   log_message "Attempting to unpause container $CONTAINER_NAME due to script exit..."
@@ -97,9 +114,6 @@ if ! docker volume inspect "$VOLUME_NAME" > /dev/null 2>&1; then
     exit 1
 fi
 log_message "Volume $VOLUME_NAME exists and will be backed up."
-
-# Create backup directory if it doesn't exist
-mkdir -p "$BACKUP_DIR"
 
 # Create staging directory
 mkdir -p "$STAGING_DIR"
@@ -217,11 +231,13 @@ log_message "Backup verified in $VERIFY_DURATION seconds."
 BACKUP_SIZE="N/A"
 if [ "$VERIFICATION_SUCCESSFUL" = true ]; then
     BACKUP_SIZE=$(du -sh "$BACKUP_FILE" | cut -f1)
-    # Prune old backups (Only if a new backup was successfully created)
-    log_message "Pruning old backups (keeping last $KEEP_BACKUPS)..."
-    # List files matching the pattern, sort by time, take all but the last N, delete them
-    ls -1t "$BACKUP_DIR"/"${VOLUME_NAME}"_*.tar.gz | tail -n +$((KEEP_BACKUPS + 1)) | xargs -r rm -fv | tee -a "$LOG_FILE"
-    log_message "Pruning complete."
+    # If auto-upload is enabled, defer pruning until after successful S3 upload
+    if [ "$S3_UPLOAD_ENABLED" = "true" ]; then
+      log_message "Deferring local pruning until after S3 upload (keeping last $KEEP_BACKUPS)"
+    else
+      # Prune old backups immediately (no auto-upload scenario)
+      prune_backups "$KEEP_BACKUPS"
+    fi
 fi
 
 # Check volume size (Moved AFTER unpause)
@@ -270,7 +286,7 @@ fi
 
 # Optional S3 upload integration
 # Set S3_BACKUP_AUTO_UPLOAD=true in .env to enable automatic S3 upload after successful backup
-if [ "$VERIFICATION_SUCCESSFUL" = true ] && [ "${S3_BACKUP_AUTO_UPLOAD,,}" = "true" ]; then
+if [ "$VERIFICATION_SUCCESSFUL" = true ] && [ "$S3_UPLOAD_ENABLED" = "true" ]; then
   log_message "S3 auto-upload is enabled, starting upload process..."
 
   # Get the directory where this script is located
@@ -281,6 +297,8 @@ if [ "$VERIFICATION_SUCCESSFUL" = true ] && [ "${S3_BACKUP_AUTO_UPLOAD,,}" = "tr
     log_message "Calling S3 upload script for container: $CONTAINER_NAME"
     if "$S3_UPLOAD_SCRIPT" "$CONTAINER_NAME" "$BACKUP_FILE"; then
       log_message "S3 upload completed successfully"
+      # Apply local retention pruning after successful upload (handles KEEP_BACKUPS=0)
+      prune_backups "$KEEP_BACKUPS"
       # Remove staging only after successful upload when auto-upload is enabled
       if [ -d "$STAGING_DIR" ]; then
         rm -rf "$STAGING_DIR"

--- a/scripts/backup/upload-to-s3.sh
+++ b/scripts/backup/upload-to-s3.sh
@@ -17,6 +17,12 @@ LOCK_FILE=""
 UPLOADED_S3_KEY=""
 ROLLBACK_NEEDED=false
 
+# Optional dependency checks
+HAS_JQ=true
+HAS_NUMFMT=true
+command -v jq >/dev/null 2>&1 || HAS_JQ=false
+command -v numfmt >/dev/null 2>&1 || HAS_NUMFMT=false
+
 # Exit codes
 EXIT_SUCCESS=0
 EXIT_INVALID_ARGS=1
@@ -263,6 +269,12 @@ log_environment_configuration() {
     log_message "INFO" "  - Retention Count: $S3_BACKUP_RETENTION_COUNT"
     log_message "INFO" "  - Storage Class: $S3_BACKUP_STORAGE_CLASS"
     log_message "INFO" "  - Dry Run Mode: $DRY_RUN"
+    if [ "$HAS_JQ" != true ]; then
+        log_message "WARNING" "jq not found; using basic parsing fallbacks"
+    fi
+    if [ "$HAS_NUMFMT" != true ]; then
+        log_message "WARNING" "numfmt not found; using built-in size formatter"
+    fi
 }
 
 # Function to test S3 bucket access and permissions
@@ -487,7 +499,7 @@ log_backup_file_validation_success() {
     file_size=$(get_file_size "$file")
 
     log_message "SUCCESS" "Backup file validation passed"
-    log_message "INFO" "File size: $(numfmt --to=iec --suffix=B "$file_size")"
+    log_message "INFO" "File size: $(format_bytes "$file_size")"
 }
 
 # Function to calculate MD5 checksum
@@ -597,7 +609,11 @@ has_existing_backups() {
 # Function to count existing backups
 count_existing_backups() {
     local backups_json="$1"
-    echo "$backups_json" | jq length 2>/dev/null || echo "0"
+    if [ "$HAS_JQ" = true ]; then
+        echo "$backups_json" | jq length 2>/dev/null || echo "0"
+    else
+        echo "$backups_json" | grep -o '"Key"' | wc -l | tr -d ' ' || echo "0"
+    fi
 }
 
 # Function to calculate how many backups to delete
@@ -629,7 +645,11 @@ delete_old_backups() {
 get_keys_to_delete() {
     local backups_json="$1"
     local delete_count="$2"
-    echo "$backups_json" | jq -r ".[0:$delete_count][].Key" 2>/dev/null
+    if [ "$HAS_JQ" = true ]; then
+        echo "$backups_json" | jq -r ".[0:$delete_count][].Key" 2>/dev/null
+    else
+        echo "$backups_json" | sed -n 's/.*"Key"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' | head -n "$delete_count"
+    fi
 }
 
 # Function to process backup deletions
@@ -927,8 +947,13 @@ create_verification_context() {
     local local_file="$2"
 
     local s3_etag s3_size local_size
-    s3_etag=$(echo "$s3_metadata" | jq -r '.ETag // empty' | tr -d '"')
-    s3_size=$(echo "$s3_metadata" | jq -r '.ContentLength // empty')
+    if [ "$HAS_JQ" = true ]; then
+        s3_etag=$(echo "$s3_metadata" | jq -r '.ETag // empty' | tr -d '"')
+        s3_size=$(echo "$s3_metadata" | jq -r '.ContentLength // empty')
+    else
+        s3_etag=$(echo "$s3_metadata" | sed -n 's/.*"ETag"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' | head -n1 | tr -d '"')
+        s3_size=$(echo "$s3_metadata" | sed -n 's/.*"ContentLength"[[:space:]]*:[[:space:]]*\([0-9]\+\).*/\1/p' | head -n1)
+    fi
     local_size=$(get_file_size "$local_file")
 
     echo "$s3_etag|$s3_size|$local_size"
@@ -944,8 +969,29 @@ verify_file_size() {
         return 1
     fi
 
-    log_message "SUCCESS" "File size verification passed: $(numfmt --to=iec --suffix=B "$local_size")"
+    log_message "SUCCESS" "File size verification passed: $(format_bytes "$local_size")"
     return 0
+}
+
+# Format bytes using built-in calculator if numfmt is unavailable
+format_bytes() {
+    local bytes="$1"
+    if [ "$HAS_NUMFMT" = true ]; then
+        numfmt --to=iec --suffix=B "$bytes" 2>/dev/null && return 0
+    fi
+    # Fallback implementation (integer-only)
+    local units=(B KiB MiB GiB TiB PiB)
+    local idx=0
+    local value="$bytes"
+    if ! echo "$value" | grep -Eq '^[0-9]+$'; then
+        echo "$value B"
+        return 0
+    fi
+    while [ "$value" -ge 1024 ] && [ $idx -lt 5 ]; do
+        value=$((value / 1024))
+        idx=$((idx + 1))
+    done
+    echo "$value ${units[$idx]}"
 }
 
 # Function to verify checksum


### PR DESCRIPTION
Fix accidental deletion when KEEP_BACKUPS=0 by deferring local pruning until after a successful S3 upload when auto-upload is enabled. In local-only runs, prune immediately as before. This preserves the newly created backup while still enforcing retention for older files.

Add prune_backups helper and call it post-upload; handle retention=0 correctly. Normalize S3_BACKUP_AUTO_UPLOAD to portable S3_UPLOAD_ENABLED (lowercased). Ensure BACKUP_DIR and LOG_FILE exist before first log write to avoid tee errors.

In upload-to-s3.sh, add fallbacks when jq/numfmt are absent (basic JSON parsing and format_bytes), use format_bytes for size logs, and warn if tools are missing.

Impact: prevents data loss with retention=0, improves portability and logging. No changes to cron-backup.sh. Backward compatible; no config changes required.