### PR TITLE
[ENG-421] feat: add env toggle for kaspad perf diagnostics

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -36,6 +36,7 @@ REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 
 # --- Performance ---
+# Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
 
 # --- Your Node Settings ---

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -36,6 +36,7 @@ REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 
 # --- Performance ---
+# Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
 
 # --- Your Node Settings ---

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ USE_PREBUILT_IMAGES=false
 # Defaults to 'syslog' which works well on Linux.
 # On macOS, 'json-file' is recommended as 'syslog' might not be available or work correctly.
 LOGGING_DRIVER=json-file
+
+# --- Kaspad Performance ---
+# Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
 
 # --- General and Shared Configuration ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       - "16211:16211"
     environment:
       - KASPAD_ADD_PEER
+      - ENABLE_PERF_DIAGNOSTICS
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint: |
       sh -c '
@@ -127,6 +128,9 @@ services:
         ARGS="$$ARGS --addpeer=$$KASPAD_ADD_PEER"
       else
         ARGS="$$ARGS --enable-unsynced-mining"
+      fi
+      if [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ]; then
+        ARGS="$$ARGS --igra-enable-perf-diagnostics"
       fi
       exec /app/kaspad $$ARGS
       '


### PR DESCRIPTION
Add a configurable environment variable to enable kaspad performance diagnostics and pass the corresponding flag to the kaspad process when running via docker-compose. This allows operators to turn on detailed performance diagnostics without modifying container arguments manually.

Document the new `ENABLE_PERF_DIAGNOSTICS` option in all relevant `.env` example files, clarifying that it controls the `--igra-enable-perf-diagnostics` flag. Wire this variable into the `kaspad` service in `docker-compose.yml` so that the flag is added only when explicitly enabled, keeping default behavior unchanged while simplifying performance troubleshooting when needed.