### PR TITLE
[ENG-422] feat: add kaspad event logging toggle

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -35,9 +35,11 @@ IGRA_ENTRY_MIN_AMOUNT=100000000
 REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 
-# --- Performance ---
+# --- Kaspad Diagnostics ---
 # Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
+# Enable event logging in kaspad (passes --igra-enable-event-logging flag)
+ENABLE_EVENT_LOGGING=false
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -35,9 +35,11 @@ IGRA_ENTRY_MIN_AMOUNT=100000000
 REPLAY_ON_ERROR=-1
 SYNC_THREADS=64
 
-# --- Performance ---
+# --- Kaspad Diagnostics ---
 # Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
+# Enable event logging in kaspad (passes --igra-enable-event-logging flag)
+ENABLE_EVENT_LOGGING=false
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,11 @@ USE_PREBUILT_IMAGES=false
 # On macOS, 'json-file' is recommended as 'syslog' might not be available or work correctly.
 LOGGING_DRIVER=json-file
 
-# --- Kaspad Performance ---
+# --- Kaspad Diagnostics ---
 # Enable performance diagnostics in kaspad (passes --igra-enable-perf-diagnostics flag)
 ENABLE_PERF_DIAGNOSTICS=false
+# Enable event logging in kaspad (passes --igra-enable-event-logging flag)
+ENABLE_EVENT_LOGGING=false
 
 # --- General and Shared Configuration ---
 RUST_LOG=debug

--- a/README.md
+++ b/README.md
@@ -261,6 +261,34 @@ If you've configured the `json-file` driver (e.g., on macOS), use standard `dock
 
 The syslog tagging format allows for easy filtering by service name, making it possible to debug specific components of the stack. If using the `json-file` driver, standard `docker logs` filtering applies.
 
+### Kaspad Diagnostics
+
+Enable diagnostic features by setting environment variables in your `.env` file:
+
+```bash
+# Enable performance diagnostics (passes --igra-enable-perf-diagnostics flag)
+ENABLE_PERF_DIAGNOSTICS=true
+
+# Enable event logging (passes --igra-enable-event-logging flag)
+ENABLE_EVENT_LOGGING=true
+```
+
+#### Adapter Stats
+
+Analyze kaspad adapter performance by piping logs to the adapter-stats tool:
+
+```bash
+docker logs -f -n 1000 kaspad 2>&1 | docker run --rm -i --entrypoint /app/adapter-stats kaspad
+```
+
+#### Transaction Parser
+
+When event logging is enabled, transaction logs are written to `./logs/`. Use the igra-tx-parser to watch and analyze them:
+
+```bash
+docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser kaspad watch --logs-dir /app/logs
+```
+
 ## Documentation
 
 - [Quick Setup with Pre-built Images](docs/quick-setup-prebuilt.md) - Simplified deployment guide

--- a/build/Dockerfile.kaspad
+++ b/build/Dockerfile.kaspad
@@ -13,6 +13,7 @@ RUN rustup component add rustfmt
 COPY . .
 
 RUN cargo build --bin kaspad --bin kaspa-cli --release
+RUN cargo build -p igra-tx-parser -p adapter-stats --release
 
 FROM rust:slim
 
@@ -24,5 +25,7 @@ RUN apt-get update && \
 
 COPY --from=builder /app/target/release/kaspad /app/
 COPY --from=builder /app/target/release/kaspa-cli /app/
+COPY --from=builder /app/target/release/igra-tx-parser /app/
+COPY --from=builder /app/target/release/adapter-stats /app/
 
 ENTRYPOINT ["/app/kaspad"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
     environment:
       - KASPAD_ADD_PEER
       - ENABLE_PERF_DIAGNOSTICS
+      - ENABLE_EVENT_LOGGING
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint: |
       sh -c '
@@ -132,10 +133,14 @@ services:
       if [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ]; then
         ARGS="$$ARGS --igra-enable-perf-diagnostics"
       fi
+      if [ "$$ENABLE_EVENT_LOGGING" = "true" ]; then
+        ARGS="$$ARGS --igra-enable-event-logging"
+      fi
       exec /app/kaspad $$ARGS
       '
     volumes:
       - kaspad_data:/app/data/
+      - ./logs/:/app/logs/  # Event logs when ENABLE_EVENT_LOGGING=true
       - ./keys/jwt.hex:/app/jwt.hex:ro
     networks:
       - igra-network


### PR DESCRIPTION
## Summary
- Add `ENABLE_EVENT_LOGGING` environment variable to optionally pass `--igra-enable-event-logging` flag to kaspad
- Add `igra_event_logs` Docker volume mounted at `/app/logs/` for log persistence
- Rename section header from "Kaspad Performance" to "Kaspad Diagnostics"

## Changes
- `.env.example` - Added `ENABLE_EVENT_LOGGING=false` with documentation
- `.env.backend.example` - Added `ENABLE_EVENT_LOGGING=false` with documentation
- `.env.backend-with-rpc.example` - Added `ENABLE_EVENT_LOGGING=false` with documentation
- `docker-compose.yml` - Added volume, env var, conditional logic, and volume mount

## Test plan
- [ ] Verify kaspad starts without `--igra-enable-event-logging` when `ENABLE_EVENT_LOGGING=false` (default)
- [ ] Verify kaspad starts with `--igra-enable-event-logging` when `ENABLE_EVENT_LOGGING=true`
- [ ] Verify logs are written to `/app/logs/` when feature is enabled
- [ ] Verify logs persist across container restarts
