### PR TITLE
[ENG-446] feat: add persistent volume for reth chain data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ name: igra-orchestra-${NETWORK}
 volumes:
   kaspad_data:
   traefik_certs:
+  reth_data:
   reth_ipc:
     driver: local
     driver_opts:
@@ -185,6 +186,7 @@ services:
       - ./build/repos/execution-layer/genesis.template.json:/root/reth/genesis.template.json
       - ./build/repos/execution-layer/run-igra-dev-el.sh:/root/reth/run-igra-dev-el.sh
       - reth_ipc:/root/reth/socket
+      - reth_data:/root/reth/data/
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.el_stats.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"


### PR DESCRIPTION
## Summary
- Add `reth_data` named volume following the existing `kaspad_data` pattern
- Mount volume at `/root/reth/data/` in the execution-layer service
- Prevents blockchain re-sync on container restarts

## Changes
1. Added `reth_data:` named volume in the volumes section
2. Added mount `- reth_data:/root/reth/data/` to execution-layer service

## Test Plan
- [x] Verify execution-layer container starts correctly
- [x] Verify reth can write to `/root/reth/data/`
- [x] Verify data persists across container restarts