### PR TITLE
[ENG-447] feat: upgrade reth execution layer from 1.7.0 to 1.9.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
     <<: *default-service
     restart: "no"
     container_name: execution-layer
-    image: igranetwork/reth:1.7.0
+    image: igranetwork/reth:1.9.3
     profiles: ["execution-layer"]
     entrypoint: /root/reth/run-igra-dev-el.sh
     ports:


### PR DESCRIPTION
## Summary
- Upgrade reth Docker image from 1.7.0 to 1.9.3 in docker-compose.yml
- No configuration changes required

## Test plan
- [ ] Verify docker image exists and is pullable
- [ ] Test execution-layer service starts successfully
- [ ] Verify kaspad integration works with new reth version
- [ ] Check IPC socket communication is functional