### PR TITLE
[ENG-452] feat: add optional --igra-warm-start-block CLI arg for kaspad

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -40,6 +40,9 @@ SYNC_THREADS=64
 ENABLE_PERF_DIAGNOSTICS=false
 # Enable event logging in kaspad (passes --igra-enable-event-logging flag)
 ENABLE_EVENT_LOGGING=false
+# Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
+# When set, kaspad will start processing from this block number
+# WARM_START_BLOCK=
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -40,6 +40,9 @@ SYNC_THREADS=64
 ENABLE_PERF_DIAGNOSTICS=false
 # Enable event logging in kaspad (passes --igra-enable-event-logging flag)
 ENABLE_EVENT_LOGGING=false
+# Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
+# When set, kaspad will start processing from this block number
+# WARM_START_BLOCK=
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ LOGGING_DRIVER=json-file
 ENABLE_PERF_DIAGNOSTICS=false
 # Enable event logging in kaspad (passes --igra-enable-event-logging flag)
 ENABLE_EVENT_LOGGING=false
+# Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
+# When set, kaspad will start processing from this block number
+# WARM_START_BLOCK=
 
 # --- General and Shared Configuration ---
 RUST_LOG=debug

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ ENABLE_PERF_DIAGNOSTICS=true
 
 # Enable event logging (passes --igra-enable-event-logging flag)
 ENABLE_EVENT_LOGGING=true
+
+# Warm start from a specific block number (passes --igra-warm-start-block flag)
+WARM_START_BLOCK=200184247
 ```
 
 #### Adapter Stats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - KASPAD_ADD_PEER
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
+      - WARM_START_BLOCK
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint: |
       sh -c '
@@ -136,6 +137,9 @@ services:
       fi
       if [ "$$ENABLE_EVENT_LOGGING" = "true" ]; then
         ARGS="$$ARGS --igra-enable-event-logging"
+      fi
+      if [ -n "$$WARM_START_BLOCK" ]; then
+        ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
       fi
       exec /app/kaspad $$ARGS
       '


### PR DESCRIPTION
## Summary
- Add `WARM_START_BLOCK` environment variable to kaspad service
- Conditionally pass `--igra-warm-start-block=<value>` CLI argument when env var is set
- Document the new variable in `.env.example`

## Usage
Set `WARM_START_BLOCK` in your `.env` file:
```bash
WARM_START_BLOCK=12345
```

When set, kaspad will receive `--igra-warm-start-block=12345`. When empty/unset, the argument is omitted.

## Test plan
- [x] Verify kaspad starts without WARM_START_BLOCK set (default behavior)
- [x] Verify kaspad starts with WARM_START_BLOCK set and receives the CLI argument
- [x] Verify docker-compose config is valid: `docker compose config`