### PR TITLE
[ENG-521] feat(reth): re-introduce discard reorged transactions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,8 @@ services:
     <<: *default-service
     restart: "no"
     container_name: execution-layer
-    image: igranetwork/reth:1.9.3-discard-reorg-txs-and-fifo-order
+    image: igranetwork/reth:1.9.3-discard-reorg-txs-and-fifo-order-and-fcu-clear-and-fix
+
     profiles: ["execution-layer"]
     entrypoint: /root/reth/run-igra-el.sh
     ports:


### PR DESCRIPTION
Introduces --txpool.discard-reorged-transactions flag to control whether transactions from reorged blocks should be re-injected into the mempool or permanently discarded.