### PR TITLE
[ENG-540] feat: build reth execution layer from source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Uncomment and set these variables in your .env file to override the default branches
 # used by the setup-repos.sh script. If left commented or unset, the script defaults will be used.
 
-EXECUTION_LAYER_BRANCH=main
+RETH_BRANCH=main
 KASWALLET_BRANCH=main
 IGRA_RPC_PROVIDER_BRANCH=main
 KASPAD_BRANCH=master

--- a/build/.dockerignore
+++ b/build/.dockerignore
@@ -1,0 +1,13 @@
+target/
+.git/
+.github/
+*.log
+*.tmp
+**/.DS_Store
+**/node_modules
+docs/
+tests/
+benches/
+examples/
+*.md
+!README.md

--- a/build/Dockerfile.reth
+++ b/build/Dockerfile.reth
@@ -1,0 +1,25 @@
+FROM rust:slim AS builder
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y pkg-config libssl-dev libclang-dev build-essential git && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN cargo build --bin reth --release
+
+FROM rust:slim
+
+WORKDIR /root/reth
+
+RUN apt-get update && \
+    apt-get install -y libssl-dev openssl bash && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/reth /usr/local/bin/reth
+
+RUN mkdir -p /root/reth/socket /root/reth/data
+
+ENTRYPOINT ["/root/reth/igra-run-el"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,11 +166,14 @@ services:
 
   execution-layer:
     <<: *default-service
+    build:
+      context: build/repos/reth-private
+      dockerfile: ../../Dockerfile.reth
+    image: reth
     restart: "no"
     container_name: execution-layer
-    image: igranetwork/reth:1.9.3
     profiles: ["execution-layer"]
-    entrypoint: /root/reth/run-igra-dev-el.sh
+    entrypoint: /root/reth/run-igra-el.sh
     ports:
       - "127.0.0.1:9545:8545"  # open 8545 on localhost for blockscout
       - "127.0.0.1:9546:8546"  # open 8546 on localhost for blockscout
@@ -187,9 +190,9 @@ services:
       IGRA_LAUNCH_DAA_SCORE: ${IGRA_LAUNCH_DAA_SCORE}
     volumes:
       - ./keys/jwt.hex:/root/reth/jwt.hex
-      - ./build/repos/execution-layer/genesis.template.json:/root/reth/genesis.template.json
-      - ./build/repos/execution-layer/run-igra-dev-el.sh:/root/reth/run-igra-dev-el.sh
       - reth_ipc:/root/reth/socket
+      - ./build/repos/reth-private/igra/genesis.template.json:/root/reth/genesis.template.json
+      - ./build/repos/reth-private/igra/run-igra-el.sh:/root/reth/run-igra-el.sh
       - reth_data:/root/reth/data/
     labels:
       - "traefik.enable=true"
@@ -422,7 +425,7 @@ services:
   # TRAEFIK SERVICE
   traefik:
     <<: *default-service
-    image: traefik:v3.0
+    image: traefik:v3
     profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
     container_name: traefik
     command:

--- a/setup-repos.sh
+++ b/setup-repos.sh
@@ -11,7 +11,7 @@ function print_help() {
     echo ""
     echo "Environment Variables:"
     echo "  You can override the default branches for each repository by setting the following environment variables:"
-    echo "    EXECUTION_LAYER_BRANCH"
+    echo "    RETH_BRANCH"
     echo "    KASWALLET_BRANCH"
     echo "    IGRA_RPC_PROVIDER_BRANCH"
     echo "    KASPAD_BRANCH"
@@ -114,7 +114,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 # Default branches
-EXECUTION_LAYER_BRANCH=${EXECUTION_LAYER_BRANCH:-main}
+RETH_BRANCH=${RETH_BRANCH:-main}
 KASWALLET_BRANCH=${KASWALLET_BRANCH:-main}
 IGRA_RPC_PROVIDER_BRANCH=${IGRA_RPC_PROVIDER_BRANCH:-main}
 KASPAD_BRANCH=${KASPAD_BRANCH:-master}
@@ -143,7 +143,7 @@ else
 
     # Repository information - all repositories
     REPOS=(
-        "execution-layer  "
+        "reth             "
         "kaswallet        "
         "igra-rpc-provider"
         "kaspad           "
@@ -151,14 +151,14 @@ else
     )
 
     URLS=(
-        "git@github.com:IgraLabs/execution-layer.git"
+        "git@github.com:IgraLabs/reth-private.git"
         "git@github.com:IgraLabs/kaswallet.git"
         "git@github.com:IgraLabs/igra-rpc-provider.git"
         "git@github.com:IgraLabs/rusty-kaspa-private.git"
         "git@github.com:elichai/kaspa-miner.git"
     )
     BRANCHES=(
-        "$EXECUTION_LAYER_BRANCH"
+        "$RETH_BRANCH"
         "$KASWALLET_BRANCH"
         "$IGRA_RPC_PROVIDER_BRANCH"
         "$KASPAD_BRANCH"


### PR DESCRIPTION
## Summary
- Replace pre-built Docker image (`igranetwork/reth:1.9.3`) with cargo build from `IgraLabs/reth` repository
- Enable local development and customization of the execution layer
- Follow the same build pattern as other services (kaspad, rpc-provider, kaswallet)

## Changes
- Add `build/Dockerfile.reth` for multi-stage Rust build
- Update `setup-repos.sh` to clone `IgraLabs/reth` instead of `execution-layer`
- Update `docker-compose.yml` with build context and volume paths to `./build/repos/reth/igra/`
- Replace `EXECUTION_LAYER_BRANCH` with `RETH_BRANCH` in `.env.example`

## Prerequisites
The `IgraLabs/reth` repository must have an `igra/` folder containing:
- `genesis.template.json`
- `run-igra-dev-el.sh`

## Test plan
- [x] Run `./setup-repos.sh` to clone repositories
- [x] Run `docker compose build execution-layer` to build reth from source
- [x] Run `docker compose --profile execution-layer up -d` to start the service
- [x] Verify execution-layer starts and responds on port 8545