### PR TITLE
[ENG-568] fix: disable reth warm start by removing data volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ name: igra-orchestra-${NETWORK}
 volumes:
   kaspad_data:
   traefik_certs:
-  reth_data:
   reth_ipc:
     driver: local
     driver_opts:
@@ -193,7 +192,6 @@ services:
       - reth_ipc:/root/reth/socket
       - ./build/repos/reth-private/igra/genesis.template.json:/root/reth/genesis.template.json
       - ./build/repos/reth-private/igra/run-igra-el.sh:/root/reth/run-igra-el.sh
-      - reth_data:/root/reth/data/
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.el_stats.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"


### PR DESCRIPTION
## Summary
- Remove `reth_data` volume mount from execution-layer service to disable warm start
- Warm start is currently broken, so chain data needs to reset on each container restart

## Changes
- Removed `reth_data:` volume definition from volumes section
- Removed `reth_data:/root/reth/data/` mount from execution-layer service

## Test Plan
- [x] Deploy and verify execution-layer starts fresh without persisted data
- [x] Verify execution-layer syncs correctly from genesis