### PR TITLE
[ENG-575] fix: add libclang-dev to kaswallet Dockerfile

### DIFF
--- a/build/Dockerfile.kaswallet
+++ b/build/Dockerfile.kaswallet
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install OpenSSL and Protocol Buffers compiler
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev protobuf-compiler && \
+    apt-get install -y pkg-config libssl-dev protobuf-compiler libclang-dev build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . .


### PR DESCRIPTION
## Summary
- Added `libclang-dev` and `build-essential` packages to `Dockerfile.kaswallet` builder stage
- Fixes build failure caused by missing libclang for bindgen (used by librocksdb-sys)
- Aligns kaswallet Dockerfile with kaspad and reth Dockerfiles which already have these dependencies

## Root Cause
The `librocksdb-sys` crate uses `bindgen` to generate Rust bindings from C/C++ headers. Bindgen requires `libclang` to be installed, which was missing from the kaswallet Dockerfile.

## Test plan
- [x] Verified Docker build succeeds locally
- [ ] CI/CD pipeline passes

## ClickUp
https://app.clickup.com/t/86ae36wvr