### PR TITLE
[ENG-577] fix: enable SSH forwarding for rpc-provider Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ cp .env.example .env
 # 3. Create JWT secret
 openssl rand -hex 32 > ./keys/jwt.hex
 
-# 4. Build and start services
+# 4. Setup SSH agent (required for private dependencies)
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519  # or your GitHub SSH key
+ssh -T git@github.com      # verify access
+
+# 5. Build and start services
 docker compose build
 docker compose --profile kaspad up -d
 docker compose --profile backend up -d
@@ -309,4 +314,5 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser kaspad watc
 5. **Profile dependencies**: Make sure to start profiles in the correct order (kaspad → explorer → workers)
 6. **Missing JWT file**: Ensure you've created the JWT file before starting services
 7. **Service connectivity**: Ensure all services can properly connect by starting profiles in the correct order and allowing time for services to initialize
+8. **SSH authentication during build**: If `docker compose build` fails with "failed to authenticate when downloading repository", ensure your SSH agent is running with your GitHub key loaded: `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519`
 ```

--- a/build/Dockerfile.rpc-provider
+++ b/build/Dockerfile.rpc-provider
@@ -1,15 +1,23 @@
+# syntax=docker/dockerfile:1
 FROM rust:slim AS builder
 
 WORKDIR /app
 
-# Install dependencies including OpenSSL, pkg-config, and protobuf compiler
+# Install build dependencies and git with SSH support
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev protobuf-compiler && \
+    apt-get install -y pkg-config libssl-dev protobuf-compiler libclang-dev build-essential git openssh-client && \
     rm -rf /var/lib/apt/lists/*
+
+# Configure SSH with pinned GitHub host keys (prevents MITM attacks)
+RUN mkdir -p /root/.ssh && \
+    echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" >> /root/.ssh/known_hosts && \
+    echo "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=" >> /root/.ssh/known_hosts && \
+    echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> /root/.ssh/known_hosts
 
 COPY . .
 
-RUN cargo build --release
+# Build with SSH mount for private repository access
+RUN --mount=type=ssh cargo build --release
 
 FROM rust:slim
 
@@ -23,4 +31,4 @@ COPY --from=builder /app/target/release/igra-rpc-provider /app/
 COPY --from=builder /app/target/release/entry_transaction_sender /app/
 COPY --from=builder /app/config.toml /app/
 
-ENTRYPOINT [/app/igra-rpc-provider]
+ENTRYPOINT ["/app/igra-rpc-provider"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ x-rpc-provider-base: &rpc-provider-base
   build:
     context: build/repos/igra-rpc-provider
     dockerfile: ../../Dockerfile.rpc-provider
+    ssh:
+      - default
   image: igranetwork/rpc-provider:v0.2.1
   environment: *rpc-provider-environment
   expose:


### PR DESCRIPTION
## Summary
- Enable Docker BuildKit SSH agent forwarding for rpc-provider build
- Fix SSH authentication failure when Cargo fetches private kaswallet-proto dependency
- Pin GitHub SSH host keys to prevent MITM attacks during build
- Add SSH agent setup documentation to README

## Changes
- `build/Dockerfile.rpc-provider`: BuildKit syntax, SSH packages, pinned host keys, SSH mount
- `docker-compose.yml`: Added `ssh: [default]` to rpc-provider build config  
- `README.md`: Added SSH agent setup instructions and troubleshooting entry

## Test plan
- [x] Verify SSH agent is running with GitHub key loaded
- [x] Run `docker compose build rpc-provider-0` 
- [x] Confirm build completes without SSH authentication errors
- [x] Verify final image runs correctly

## Ticket
[ENG-577](https://app.clickup.com/t/86ae3av4y)