### PR TITLE
[ENG-578] fix: remove kaspad dependency from kaspa-miner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -513,6 +513,3 @@ services:
       '
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    depends_on:
-      kaspad:
-        condition: service_healthy


### PR DESCRIPTION
## Summary
- Remove `depends_on` block from kaspa-miner service in docker-compose.yml
- Fixes validation error when running `--profile kaspa-miner` without kaspad profile
- Allows miner to start independently and fail gracefully if kaspad is unavailable

## Test plan
- [x] Run `docker compose --profile kaspa-miner config` to verify compose file is valid
- [x] Run `docker compose --profile kaspa-miner up -d` to verify miner starts