### PR TITLE
Atan importer service setup

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -61,6 +61,17 @@ IGRA_ORCHESTRA_DOMAIN_EMAIL=you@example.com
 # --- RPC Configuration ---
 RPC_READ_ONLY=false
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files (`[finality_score].pb`) to S3 and maintains an index.pb
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET=
+# e.g. testnet, mainnet, or any path prefix (no leading slash). Leave empty for bucket root.
+S3_PREFIX=testnet
+# Optional: if set, index download links will use this base URL instead of S3 URLs
+CDN_BASE_URL=
+
 # --- Worker Configuration ---
 # Worker 0
 W0_WALLET_TO_ADDRESS=kaspatest:qqfrt9vlrpl98m8gwsrw45ynvpgxcrl87x3h2337k8ft4eyhacyqumc0t9vng

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -54,3 +54,14 @@ ENABLE_EVENT_LOGGING=false
 NODE_ID=<your-node-name> # for example PublicTestNode-1
 HEALTH_CHECK_API_KEY=<your-api-key>
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files (`[finality_score].pb`) to S3 and maintains an index.pb
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET=
+# e.g. testnet, mainnet, or any path prefix (no leading slash). Leave empty for bucket root.
+S3_PREFIX=testnet
+# Optional: if set, index download links will use this base URL instead of S3 URLs
+CDN_BASE_URL=
+

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,17 @@ EL_ONE_TIME_ADDRESS=0x2B7dABDF193677725C6Ecd25dc7CfAf6054193d8
 # --- RPC Configuration ---
 RPC_READ_ONLY=false
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files (`[finality_score].pb`) to S3 and maintains an index.pb
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET=
+# e.g. testnet, mainnet, or any path prefix (no leading slash). Leave empty for bucket root.
+S3_PREFIX=testnet
+# Optional: if set, index download links will use this base URL instead of S3 URLs
+CDN_BASE_URL=
+
 # --- Worker Configuration ---
 # Worker 0
 W0_WALLET_TO_ADDRESS=kaspadev:qpm06zv507sh59hjevsmkkgj9kv0q7a02wtnxt6l9qcvjk7dqtysy9kg4u3um

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,33 @@ services:
       <<: *default-healthcheck
       test: ["CMD", "bash", "-c", "echo hello > /dev/tcp/kaspad/16210"]
 
+  atan-importer:
+    <<: *default-service
+    image: ghcr.io/igralabs/atan-importer:latest
+    profiles: ["kaspad"]
+    container_name: atan-importer
+    restart: unless-stopped
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REGION: ${AWS_REGION}
+      S3_BUCKET: ${S3_BUCKET}
+      S3_PREFIX: ${S3_PREFIX:-}
+      CDN_BASE_URL: ${CDN_BASE_URL:-}
+      WATCH_FOLDER: /app/data/kaspa-testnet-10/datadir/atan_datadir/chain_block_lists
+    volumes:
+      - kaspad_data:/app/data/
+    depends_on:
+      kaspad:
+        condition: service_healthy
+    healthcheck:
+      <<: *default-healthcheck
+      test:
+        [
+          "CMD-SHELL",
+          "test -n \"$$AWS_ACCESS_KEY_ID\" && test -n \"$$AWS_SECRET_ACCESS_KEY\" && test -n \"$$AWS_REGION\" && test -n \"$$S3_BUCKET\" && test -d \"$$WATCH_FOLDER\"",
+        ]
+
   execution-layer:
     <<: *default-service
     build:


### PR DESCRIPTION
Add `atan-importer` service to upload Kaspad's ATAN chain block list files to S3 and maintain a protobuf index.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3622716-e946-4c6f-89bf-8b33a3daae75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3622716-e946-4c6f-89bf-8b33a3daae75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

