### PR TITLE
[ENG-572] refactor: update atan-importer environment variables

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -61,6 +61,24 @@ IGRA_ORCHESTRA_DOMAIN_EMAIL=you@example.com
 # --- RPC Configuration ---
 RPC_READ_ONLY=false
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files to S3 and maintains an index.pb
+# Uses NETWORK variable (defined above) to determine correct data paths
+# Uses TX_ID_PREFIX variable (defined above) for transaction filtering
+#
+# Required:
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# DATADIR path must match the network (NETWORK variable above):
+#   testnet: /app/data/kaspa-testnet-10/datadir
+#   mainnet: /app/data/kaspa-mainnet/datadir
+DATADIR=/app/data/kaspa-testnet-10/datadir
+#
+# Optional (defaults shown below are from docker-compose.yml):
+# AWS_REGION=us-east-1
+# S3_BUCKET=atan-import
+# CDN_BASE_URL=https://cdn.example.com
+
 # --- Worker Configuration ---
 # Worker 0
 W0_WALLET_TO_ADDRESS=kaspatest:qqfrt9vlrpl98m8gwsrw45ynvpgxcrl87x3h2337k8ft4eyhacyqumc0t9vng

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -54,3 +54,21 @@ ENABLE_EVENT_LOGGING=false
 NODE_ID=<your-node-name> # for example PublicTestNode-1
 HEALTH_CHECK_API_KEY=<your-api-key>
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files to S3 and maintains an index.pb
+# Uses NETWORK variable (defined above) to determine correct data paths
+# Uses TX_ID_PREFIX variable (defined above) for transaction filtering
+#
+# Required:
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# DATADIR path must match the network (NETWORK variable above):
+#   testnet: /app/data/kaspa-testnet-10/datadir
+#   mainnet: /app/data/kaspa-mainnet/datadir
+DATADIR=/app/data/kaspa-testnet-10/datadir
+#
+# Optional (defaults shown below are from docker-compose.yml):
+# AWS_REGION=us-east-1
+# S3_BUCKET=atan-import
+# CDN_BASE_URL=https://cdn.example.com
+

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,24 @@ EL_ONE_TIME_ADDRESS=0x2B7dABDF193677725C6Ecd25dc7CfAf6054193d8
 # --- RPC Configuration ---
 RPC_READ_ONLY=false
 
+# --- ATAN Importer (S3 uploader + indexer) ---
+# Uploads new ATAN chain block list files to S3 and maintains an index.pb
+# Uses NETWORK variable (defined above) to determine correct data paths
+# Uses TX_ID_PREFIX variable (defined above) for transaction filtering
+#
+# Required:
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+# DATADIR path must match the network (NETWORK variable above):
+#   testnet: /app/data/kaspa-testnet-10/datadir
+#   mainnet: /app/data/kaspa-mainnet/datadir
+DATADIR=/app/data/kaspa-testnet-10/datadir
+#
+# Optional (defaults shown below are from docker-compose.yml):
+# AWS_REGION=us-east-1
+# S3_BUCKET=atan-import
+# CDN_BASE_URL=https://cdn.example.com
+
 # --- Worker Configuration ---
 # Worker 0
 W0_WALLET_TO_ADDRESS=kaspadev:qpm06zv507sh59hjevsmkkgj9kv0q7a02wtnxt6l9qcvjk7dqtysy9kg4u3um

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -514,3 +514,28 @@ services:
       '
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  atan-importer:
+    <<: *default-service
+    image: igranetwork/atan-importer:latest
+    profiles: ["atan-importer"]
+    container_name: atan-importer
+    restart: unless-stopped
+    environment:
+      # AWS credentials (required)
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # AWS S3 configuration (with defaults)
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      S3_BUCKET: ${S3_BUCKET:-atan-import}
+      CDN_BASE_URL: ${CDN_BASE_URL:-https://cdn.example.com}
+      # Network and transaction configuration (required)
+      NETWORK: ${NETWORK}
+      TX_ID_PREFIX: ${TX_ID_PREFIX}
+      # Data directory path (required, must match NETWORK)
+      DATADIR: ${DATADIR}
+    volumes:
+      - kaspad_data:/app/data/
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD-SHELL", "pgrep -f atan-importer > /dev/null || exit 1"]


### PR DESCRIPTION
## Summary
- Update atan-importer service configuration to align with application requirements
- Replace legacy environment variables with new ones matching the importer's config.py
- Add sensible defaults for optional configuration
- Improve healthcheck and documentation

## Changes
- **Removed:** `S3_PREFIX`, `WATCH_FOLDER` (no longer used by importer)
- **Added:** `NETWORK`, `TX_ID_PREFIX`, `DATADIR` (required by importer)
- **Defaults:** `AWS_REGION=us-east-1`, `S3_BUCKET=atan-import`, `CDN_BASE_URL=https://cdn.example.com`
- **Healthcheck:** Changed to verify process is running (`pgrep -f atan-importer`)

## DATADIR Configuration
Must be set based on network:
- testnet: `/app/data/kaspa-testnet-10/datadir`
- mainnet: `/data/kaspa-mainnet/datadir`

## Test plan
- [x] Verify docker-compose config is valid (`docker compose config --quiet`)
- [x] Test atan-importer service starts with new env vars
- [x] Confirm healthcheck works correctly