### PR TITLE
[ENG-605] feat: add ATAN auto-import URL configuration for kaspad

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -49,6 +49,10 @@ ENABLE_EVENT_LOGGING=false
 # Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from NETWORK and TX_ID_PREFIX: https://igra.b-cdn.net/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -49,6 +49,10 @@ ENABLE_EVENT_LOGGING=false
 # Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from NETWORK and TX_ID_PREFIX: https://igra.b-cdn.net/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
 
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ ENABLE_EVENT_LOGGING=false
 # Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from NETWORK and TX_ID_PREFIX: https://igra.b-cdn.net/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
 
 # --- General and Shared Configuration ---
 RUST_LOG=debug

--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ ENABLE_EVENT_LOGGING=true
 
 # Warm start from a specific block number (passes --igra-warm-start-block flag)
 WARM_START_BLOCK=200184247
+
+# ATAN auto-import URL (passes --atan-import-url flag, remote URLs only)
+# Auto-constructed from NETWORK and TX_ID_PREFIX by default
+# Override only if you need a custom remote URL:
+# ATAN_IMPORT_URL=https://custom-cdn.example.com/index.pb
 ```
 
 #### Adapter Stats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,9 @@ services:
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
       - WARM_START_BLOCK
+      - ATAN_IMPORT_URL
+      - NETWORK
+      - TX_ID_PREFIX
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint: |
       sh -c '
@@ -142,6 +145,12 @@ services:
       fi
       if [ -n "$$WARM_START_BLOCK" ]; then
         ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
+      fi
+      # Auto-construct ATAN import URL from NETWORK and TX_ID_PREFIX, allow override via env
+      if [ -n "$$ATAN_IMPORT_URL" ]; then
+        ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"
+      else
+        ARGS="$$ARGS --atan-import-url=https://igra.b-cdn.net/$$NETWORK/$$TX_ID_PREFIX/index.pb"
       fi
       exec /app/kaspad $$ARGS
       '


### PR DESCRIPTION
## Summary

Enable automatic ATAN data import on kaspad startup by auto-constructing the import URL from existing `NETWORK` and `TX_ID_PREFIX` environment variables.

**Default behavior:**
- URL is auto-constructed: `https://igra.b-cdn.net/{NETWORK}/{TX_ID_PREFIX}/index.pb`
- Example for testnet with prefix 97b1: `https://igra.b-cdn.net/testnet/97b1/index.pb`

**Optional override:**
- Set `ATAN_IMPORT_URL` in `.env` to use a custom remote CDN source
- Note: Only remote URLs are supported (no local paths)

This allows new nodes to quickly bootstrap ATAN data from a CDN source instead of syncing from the network, significantly reducing initial sync time.

## Changes

- Add `ATAN_IMPORT_URL` env var to kaspad service (optional override)
- Auto-construct `--atan-import-url` CLI arg from `NETWORK`/`TX_ID_PREFIX`
- Document the feature in all `.env.example` files and `README.md`

## Test plan

- [ ] Verify kaspad starts with auto-constructed ATAN import URL
- [ ] Verify `ATAN_IMPORT_URL` env var overrides the default URL when set
- [ ] Verify existing behavior unchanged when kaspad runs without this feature
