### PR TITLE
[ENG-605] feat: add ATAN auto-import URL configuration for kaspad

### DIFF
--- a/.env.backend-with-rpc.example
+++ b/.env.backend-with-rpc.example
@@ -50,6 +50,14 @@ ENABLE_EVENT_LOGGING=false
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
 
+# --- ATAN Import Configuration ---
+# CDN base URL for ATAN data (required for kaspad and atan-uploader services)
+CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from CDN_BASE_URL, NETWORK and TX_ID_PREFIX: {CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
+
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1
 HEALTH_CHECK_API_KEY=<your-api-key>

--- a/.env.backend.example
+++ b/.env.backend.example
@@ -50,6 +50,14 @@ ENABLE_EVENT_LOGGING=false
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
 
+# --- ATAN Import Configuration ---
+# CDN base URL for ATAN data (required for kaspad and atan-uploader services)
+CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from CDN_BASE_URL, NETWORK and TX_ID_PREFIX: {CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
+
 # --- Your Node Settings ---
 NODE_ID=<your-node-name> # for example PublicTestNode-1
 HEALTH_CHECK_API_KEY=<your-api-key>

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ ENABLE_EVENT_LOGGING=false
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
 
+# --- ATAN Import Configuration ---
+# CDN base URL for ATAN data (required for kaspad and atan-uploader services)
+CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
+# ATAN auto-import URL for importing ATAN data on kaspad startup (remote URLs only)
+# Auto-constructed from CDN_BASE_URL, NETWORK and TX_ID_PREFIX: {CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb
+# Override only if you need a custom remote URL
+# ATAN_IMPORT_URL=
+
 # --- General and Shared Configuration ---
 RUST_LOG=debug
 IGRA_CHAIN_ID=19416

--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ ENABLE_EVENT_LOGGING=true
 
 # Warm start from a specific block number (passes --igra-warm-start-block flag)
 WARM_START_BLOCK=200184247
+
+# CDN base URL for ATAN data (required)
+CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
+
+# ATAN auto-import URL (passes --atan-import-url flag, remote URLs only)
+# Auto-constructed from CDN_BASE_URL, NETWORK and TX_ID_PREFIX by default
+# Override only if you need a custom remote URL:
+# ATAN_IMPORT_URL=https://custom-cdn.example.com/index.pb
 ```
 
 #### Adapter Stats

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,10 @@ services:
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
       - WARM_START_BLOCK
+      - ATAN_IMPORT_URL
+      - CDN_BASE_URL
+      - NETWORK
+      - TX_ID_PREFIX
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint: |
       sh -c '
@@ -142,6 +146,15 @@ services:
       fi
       if [ -n "$$WARM_START_BLOCK" ]; then
         ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
+      fi
+      # Auto-construct ATAN import URL from NETWORK and TX_ID_PREFIX, allow override via env
+      if [ -n "$$ATAN_IMPORT_URL" ]; then
+        ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"
+      elif [ -n "$$NETWORK" ] && [ -n "$$TX_ID_PREFIX" ]; then
+        ARGS="$$ARGS --atan-import-url=https://dyehoijgeqfp8.cloudfront.net/$$NETWORK/$$TX_ID_PREFIX/index.pb"
+      else
+        echo "Error: NETWORK and TX_ID_PREFIX must be set for ATAN import" >&2
+        exit 1
       fi
       exec /app/kaspad $$ARGS
       '
@@ -515,11 +528,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  atan-importer:
+  atan-uploader:
     <<: *default-service
-    image: igranetwork/atan-importer:latest
-    profiles: ["atan-importer"]
-    container_name: atan-importer
+    image: igranetwork/atan-uploader:latest
+    profiles: ["atan-uploader"]
+    container_name: atan-uploader
     restart: unless-stopped
     environment:
       # AWS credentials (required)
@@ -528,7 +541,7 @@ services:
       # AWS S3 configuration (with defaults)
       AWS_REGION: ${AWS_REGION:-us-east-1}
       S3_BUCKET: ${S3_BUCKET:-atan-import}
-      CDN_BASE_URL: ${CDN_BASE_URL:-https://igra.b-cdn.net}
+      CDN_BASE_URL: ${CDN_BASE_URL:-https://dyehoijgeqfp8.cloudfront.net}
       # Network and transaction configuration (required)
       NETWORK: ${NETWORK}
       TX_ID_PREFIX: ${TX_ID_PREFIX}
@@ -538,4 +551,4 @@ services:
       - kaspad_data:/app/data/
     healthcheck:
       <<: *default-healthcheck
-      test: ["CMD-SHELL", "pgrep -f atan-importer > /dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -f atan-uploader > /dev/null || exit 1"]


### PR DESCRIPTION
## Summary

Enable automatic ATAN data import on kaspad startup by auto-constructing the import URL from `CDN_BASE_URL`, `NETWORK`, and `TX_ID_PREFIX` environment variables.

**Required configuration:**
- `CDN_BASE_URL` - Base URL for ATAN CDN (default: `https://dyehoijgeqfp8.cloudfront.net`)
- `NETWORK` - Network identifier (e.g., `testnet`, `mainnet`)
- `TX_ID_PREFIX` - Transaction ID prefix (e.g., `97b1`)

**Default behavior:**
- URL is auto-constructed: `{CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb`
- Example for testnet with prefix 97b1: `https://dyehoijgeqfp8.cloudfront.net/testnet/97b1/index.pb`

**Optional override:**
- Set `ATAN_IMPORT_URL` in `.env` to use a custom remote CDN source
- Note: Only remote URLs are supported (no local paths)

This allows new nodes to quickly bootstrap ATAN data from a CDN source instead of syncing from the network, significantly reducing initial sync time.

## Changes

- Add `CDN_BASE_URL` env var as required for kaspad and atan-uploader services
- Add `ATAN_IMPORT_URL` env var to kaspad service (optional override)
- Auto-construct `--atan-import-url` CLI arg from `CDN_BASE_URL`/`NETWORK`/`TX_ID_PREFIX`
- Rename `atan-importer` service to `atan-uploader` (matches upstream rename)
- Document the feature in all `.env.example` files and `README.md`

## Test plan

- [ ] Verify kaspad starts with auto-constructed ATAN import URL when CDN_BASE_URL, NETWORK, and TX_ID_PREFIX are set
- [ ] Verify `ATAN_IMPORT_URL` env var overrides the default URL when set
- [ ] Verify kaspad fails with clear error if CDN_BASE_URL, NETWORK, or TX_ID_PREFIX is missing
- [ ] Verify atan-uploader service starts correctly with the new name