### PR TITLE
[ENG-637] feat: add Traefik health check routing for load balancers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,16 @@ x-rpc-provider-base: &rpc-provider-base
     - "traefik.http.routers.rpc0.tls.certresolver=myresolver"
     - "traefik.http.routers.rpc0.middlewares=cors"
     - "traefik.http.services.rpc0.loadbalancer.server.port=8535"
+    # Health check router - HTTPS (port 443) for load balancer health checks
+    - "traefik.http.routers.health.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`) && PathPrefix(`/health`) && Method(`GET`)"
+    - "traefik.http.routers.health.entrypoints=websecure"
+    - "traefik.http.routers.health.tls=true"
+    - "traefik.http.routers.health.tls.certresolver=myresolver"
+    - "traefik.http.routers.health.service=rpc0"
+    # Health check router - HTTP (port 80) - bypasses HTTP-to-HTTPS redirect for load balancers
+    - "traefik.http.routers.health-http.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`) && PathPrefix(`/health`) && Method(`GET`)"
+    - "traefik.http.routers.health-http.entrypoints=web"
+    - "traefik.http.routers.health-http.service=rpc0"
 
 x-kaswallet-base: &kaswallet-base
   <<: *default-service


### PR DESCRIPTION
## Summary
- Add Traefik routing for GET /health requests to rpc-provider service
- Enable health checks on both HTTP (port 80) and HTTPS (port 443)
- HTTP route bypasses HTTP-to-HTTPS redirect for load balancer compatibility

## Changes
- Added health router labels to `x-rpc-provider-base` in docker-compose.yml
- HTTPS router: `traefik.http.routers.health` on websecure entrypoint (443)
- HTTP router: `traefik.http.routers.health-http` on web entrypoint (80)

## Test plan
- [x] Deploy and verify `curl -X GET https://<domain>/health` returns health status
- [x] Verify `curl -X GET http://<domain>/health` returns health status (not redirect)
- [x] Verify `curl -I http://<domain>/` still redirects to HTTPS
- [x] JSON-RPC traffic on port 8545 continues to work unchanged

## Dependencies
- Depends on: ENG-636 (RPC provider /health endpoint)
- Blocks: ENG-634 (Traefik health checks in load balancer)