### PR TITLE
[ENG-691] feat: add IGRA_SKIP_LOCK_SCRIPT_CHECK param to orchestra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ ENABLE_EVENT_LOGGING=false
 # Warm start block number for kaspad (passes --igra-warm-start-block=<value> flag)
 # When set, kaspad will start processing from this block number
 # WARM_START_BLOCK=
+# Skip lock script public key verification for Entry transactions (TESTING ONLY)
+# When true, kaspad will not verify the lock script pubkey in Entry transactions
+IGRA_SKIP_LOCK_SCRIPT_CHECK=false
 
 # --- ATAN Import Configuration ---
 # CDN base URL for ATAN data (required for kaspad and atan-uploader services)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
       - WARM_START_BLOCK
+      - IGRA_SKIP_LOCK_SCRIPT_CHECK
       - ATAN_IMPORT_URL
       - CDN_BASE_URL
       - NETWORK
@@ -181,6 +182,7 @@ services:
         [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ] && ARGS="$$ARGS --igra-enable-perf-diagnostics"
         [ "$$ENABLE_EVENT_LOGGING" = "true" ] && ARGS="$$ARGS --igra-enable-event-logging"
         [ -n "$$WARM_START_BLOCK" ] && ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
+        [ "$$IGRA_SKIP_LOCK_SCRIPT_CHECK" = "true" ] && ARGS="$$ARGS --igra-skip-lock-script-check"
 
         # Auto-construct ATAN import URL from NETWORK and TX_ID_PREFIX, allow override via env
         if [ -n "$$ATAN_IMPORT_URL" ]; then


### PR DESCRIPTION
## Summary
- Add `IGRA_SKIP_LOCK_SCRIPT_CHECK` environment variable to `.env.example` (default: `false`)
- Pass `--igra-skip-lock-script-check` flag to kaspad when set to `true`
- This allows skipping lock script public key verification for Entry transactions (testing only)

## Test plan
- [ ] Set `IGRA_SKIP_LOCK_SCRIPT_CHECK=true` in `.env`
- [ ] Verify kaspad receives `--igra-skip-lock-script-check` flag
- [ ] Verify default behavior (false) does not pass the flag