### PR TITLE
[ENG-693] Move setup-repos.sh to scripts/dev/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # --- Repository Branch Configuration ---
 # Uncomment and set these variables in your .env file to override the default branches
-# used by the setup-repos.sh script. If left commented or unset, the script defaults will be used.
+# used by the ./scripts/dev/setup-repos.sh script. If left commented or unset, the script defaults will be used.
 
 RETH_BRANCH=production
 KASWALLET_BRANCH=main
@@ -25,7 +25,7 @@ IGRA_ORCHESTRA_DOMAIN_EMAIL=igor@igralabs.com
 # Docker Image Source Configuration
 # Set to true to use pre-built Docker Hub images for proprietary services
 # Set to false to build from source code (requires access to private repositories)
-# When true, setup-repos.sh will automatically pull and tag the images
+# When true, ./scripts/dev/setup-repos.sh will automatically pull and tag the images
 USE_PREBUILT_IMAGES=false
 
 # Logging driver for Docker containers.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Docker Compose-based development environment for IGRA Orchestra components.
 
 ## Repository Structure
 
-The `setup-repos.sh` script clones the necessary repositories into the `build/repos/` directory.
+The `./scripts/dev/setup-repos.sh` script clones the necessary repositories into the `build/repos/` directory.
 
 **Repositories:**
 
@@ -21,9 +21,9 @@ The `setup-repos.sh` script clones the necessary repositories into the `build/re
 *   `build/repos/kaswallet` - Wallet service for relaying transactions (repo: `IgraLabs/kaswallet`)
 *   `build/repos/rusty-kaspa-private` - Contains the Kaspad node (repo: `IgraLabs/rusty-kaspa-private`)
 
-The `setup-repos.sh` script also clones the `kaspa-miner` repository (repo: `elichai/kaspa-miner`) when building from source.
+The `./scripts/dev/setup-repos.sh` script also clones the `kaspa-miner` repository (repo: `elichai/kaspa-miner`) when building from source.
 
-Ensure these repositories are present before running the Docker Compose environment. The `setup-repos.sh` script handles cloning and configuring the correct branches.
+Ensure these repositories are present before running the Docker Compose environment. The `./scripts/dev/setup-repos.sh` script handles cloning and configuring the correct branches.
 
 ## Deployment Modes
 
@@ -56,7 +56,7 @@ cp .env.example .env
 
 # 2. Setup repositories and pull images
 # This will clone Kaspad and kaspa-miner and automatically pull/tag pre-built images
-./setup-repos.sh
+./scripts/dev/setup-repos.sh
 
 # 3. Create JWT secret
 openssl rand -hex 32 > ./keys/jwt.hex
@@ -75,7 +75,7 @@ cp .env.example .env
 # Keep USE_PREBUILT_IMAGES=false (default)
 
 # 2. Setup all repositories (including proprietary)
-./setup-repos.sh
+./scripts/dev/setup-repos.sh
 
 # 3. Create JWT secret
 openssl rand -hex 32 > ./keys/jwt.hex
@@ -121,11 +121,11 @@ Follow these steps before the first run:
 
 2.  **Clone and setup the repositories:**
     Run the setup script. It prioritizes branch names in the following order:
-    1.  Environment variables passed directly to the script (e.g., `KASWALLET_BRANCH=my-branch ./setup-repos.sh`).
+    1.  Environment variables passed directly to the script (e.g., `KASWALLET_BRANCH=my-branch ./scripts/dev/setup-repos.sh`).
     2.  Variables defined in the `.env` file (if it exists).
-    3.  Default values hardcoded in the `setup-repos.sh` script.
+    3.  Default values hardcoded in the `./scripts/dev/setup-repos.sh` script.
     ```bash
-    ./setup-repos.sh
+    ./scripts/dev/setup-repos.sh
     ```
 
 3.  **Create the JWT secret:**
@@ -320,7 +320,7 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser kaspad watc
 
 1. **Container name conflicts**: Stop existing containers before starting new ones
 2. **Missing worker keys**: Ensure required key files exist in the correct format
-3. **Missing repositories**: Run `setup-repos.sh` to clone the required repositories
+3. **Missing repositories**: Run `./scripts/dev/setup-repos.sh` to clone the required repositories
 4. **Permission issues**: Check data directory permissions
 5. **Profile dependencies**: Make sure to start profiles in the correct order (kaspad → explorer → workers)
 6. **Missing JWT file**: Ensure you've created the JWT file before starting services

--- a/scripts/dev/setup-repos.sh
+++ b/scripts/dev/setup-repos.sh
@@ -3,7 +3,7 @@
 
 # Function to print help information
 function print_help() {
-    echo "Usage: ./setup-repos.sh"
+    echo "Usage: ./scripts/dev/setup-repos.sh"
     echo ""
     echo "Description:"
     echo "  This script clones and configures repositories for Igra Orchestra."
@@ -18,10 +18,10 @@ function print_help() {
     echo "    KASPA_MINER_BRANCH"
     echo ""
     echo "Examples:"
-    echo "  ./setup-repos.sh"
+    echo "  ./scripts/dev/setup-repos.sh"
     echo ""
     echo "  # Example with environment variables:"
-    echo "  KASWALLET_BRANCH=my-branch ./setup-repos.sh"
+    echo "  KASWALLET_BRANCH=my-branch ./scripts/dev/setup-repos.sh"
     echo ""
     echo "Notes:"
     echo "  - Ensure you have the required permissions and SSH key set up to clone from private repositories."
@@ -41,19 +41,21 @@ function log() {
 function panic() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
     echo >&2
-    echo "Try './setup-repos.sh --help'" >&2
+    echo "Try './scripts/dev/setup-repos.sh --help'" >&2
     exit 1
 }
 
-# Original working directory
-SCRIPT_DIR="$(pwd)"
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Project root is two levels up from scripts/dev/
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Load environment variables from .env file if it exists
-if [[ -f "$SCRIPT_DIR/.env" ]]; then
+if [[ -f "$PROJECT_DIR/.env" ]]; then
     log "Loading environment variables from .env file"
     set -a # Automatically export all variables
     # shellcheck source=/dev/null
-    source "$SCRIPT_DIR/.env"
+    source "$PROJECT_DIR/.env"
     set +a
 else
     log ".env file not found, using default branch settings or environment variables."
@@ -66,16 +68,19 @@ USE_PREBUILT_IMAGES=${USE_PREBUILT_IMAGES:-false}
 function clone_repo() {
     local repo_url=$1
     # Extract, e.g. kaspa-miner from git@github.com:elichai/kaspa-miner.git
-    local folder=$(basename -s .git "$repo_url")
+    local folder
+    folder=$(basename -s .git "$repo_url")
 
     log "Setting up $folder repository"
-    if [[ -d "$SCRIPT_DIR/build/repos/$folder" ]]; then
+    if [[ -d "$PROJECT_DIR/build/repos/$folder" ]]; then
         log "$folder repository already exists, skipping clone"
     else
         log "Cloning $folder repository..."
-        git clone $repo_url "$SCRIPT_DIR/build/repos/$folder" \
-            && log "Successfully cloned $folder repository" \
-            || panic "Failed to clone $folder repository"
+        if git clone "$repo_url" "$PROJECT_DIR/build/repos/$folder"; then
+            log "Successfully cloned $folder repository"
+        else
+            panic "Failed to clone $folder repository"
+        fi
     fi
 }
 
@@ -86,8 +91,9 @@ function configure_repo() {
     local branch=$3
 
     log "Configuring $repo_name repository"
-    local folder=$(basename -s .git "$repo_url")
-    cd "$SCRIPT_DIR/build/repos/$folder"
+    local folder
+    folder=$(basename -s .git "$repo_url")
+    cd "$PROJECT_DIR/build/repos/$folder" || panic "Failed to cd into $folder"
     log "Current directory: $(pwd)"
 
     log "Fetching latest changes..."
@@ -95,7 +101,7 @@ function configure_repo() {
         || panic "Failed to fetch changes for $repo_name"
 
     log "Checking out branch: $branch"
-    git checkout $branch \
+    git checkout "$branch" \
         || panic "Failed to checkout branch $branch for $repo_name"
 
     log "Pulling latest changes..."
@@ -105,8 +111,8 @@ function configure_repo() {
     log "Current branch info for $repo_name:"
     git --no-pager branch -v
 
-    # Return to the script directory
-    cd "$SCRIPT_DIR"
+    # Return to the project directory
+    cd "$PROJECT_DIR" || panic "Failed to cd back to project directory"
 }
 
 if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
## Summary
Relocate setup-repos.sh from project root to scripts/dev/ and fix path resolution to work correctly when invoked from any directory.

### Changes
- Move setup-repos.sh to scripts/dev/setup-repos.sh
- Replace `$(pwd)` with `BASH_SOURCE[0]` for reliable script location detection
- Add PROJECT_DIR variable for project-relative paths
- Update all references in README.md and .env.example
- Fix shellcheck warnings (SC2155, SC2015, SC2164)

### Usage
```bash
# From project root
./scripts/dev/setup-repos.sh

# From any directory
/path/to/project/scripts/dev/setup-repos.sh
```

## Test Plan
- [ ] Run `./scripts/dev/setup-repos.sh --help` from project root
- [ ] Run script from different directory (e.g., `/tmp`)
- [ ] Verify .env loading works correctly
- [ ] Verify repos clone to build/repos/ in project root