### PR TITLE
[ENG-787] feat: add fail-fast dependency handling

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -32,6 +32,7 @@ USE_PREBUILT_IMAGES=false
 # Defaults to 'syslog' which works well on Linux.
 # On macOS, 'json-file' is recommended as 'syslog' might not be available or work correctly.
 LOGGING_DRIVER=json-file
+SERVICE_RESTART_POLICY=no
 
 # --- Kaspad Configuration ---
 # Enable/disable IGRA adapter (default: true)

--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -10,6 +10,7 @@ USE_PREBUILT_IMAGES=true
 # On Linux: 'syslog' works well
 # On macOS: 'json-file' is recommended
 LOGGING_DRIVER=json-file
+SERVICE_RESTART_POLICY=no
 
 # --- IGRA Network Configuration ---
 NETWORK=testnet

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -10,6 +10,7 @@ USE_PREBUILT_IMAGES=true
 # On Linux: 'syslog' works well
 # On macOS: 'json-file' is recommended
 LOGGING_DRIVER=json-file
+SERVICE_RESTART_POLICY=unless-stopped
 
 # --- IGRA Network Configuration ---
 NETWORK=mainnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ x-default-service: &default-service
     - igra-network
   logging: *default-logging
 
+x-service-restart-policy: &service-restart-policy "${SERVICE_RESTART_POLICY:-no}"
+x-dependency-watch-volume: &dependency-watch-volume ./scripts/lib/watch-dependencies.sh:/app/watch-dependencies.sh:ro
+
 x-rpc-provider-environment: &rpc-provider-environment
   RUST_LOG: ${RUST_LOG}
   SERVER_HOST: "0.0.0.0"
@@ -48,13 +51,36 @@ x-rpc-provider-environment: &rpc-provider-environment
 x-rpc-provider-runtime: &rpc-provider-runtime
   <<: *default-service
   image: igranetwork/rpc-provider:${RPC_PROVIDER_VERSION}
+  restart: *service-restart-policy
   environment: *rpc-provider-environment
   expose:
     - "8535"
-  entrypoint: ["/app/igra-rpc-provider"]
+  entrypoint:
+    - sh
+    - -ec
+    - |
+      exec sh /app/watch-dependencies.sh \
+        --tcp execution-layer execution-layer 8545 \
+        --tcp-if READ_ONLY false kaswallet "$$KASWALLET_HOST" 8082 \
+        -- /app/igra-rpc-provider
+  volumes:
+    - *dependency-watch-volume
   networks:
     - igra-network
     - traefik-network
+  depends_on:
+    execution-layer:
+      condition: service_healthy
+  healthcheck:
+    <<: *default-healthcheck
+    test:
+      - CMD-SHELL
+      - >
+        bash -lc ': > /dev/tcp/127.0.0.1/8535' &&
+        bash -lc ': > /dev/tcp/execution-layer/8545' &&
+        if [ "$$READ_ONLY" = "false" ]; then
+          bash -lc ": > /dev/tcp/$$KASWALLET_HOST/8082";
+        fi
   labels:
     - "traefik.enable=true"
     - "traefik.http.routers.rpc0.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
@@ -87,6 +113,7 @@ x-rpc-provider-build: &rpc-provider-build
 x-kaswallet-runtime: &kaswallet-runtime
   <<: *default-service
   image: igranetwork/kaswallet:${KASWALLET_VERSION}
+  restart: *service-restart-policy
   expose:
     - "8082"
   environment:
@@ -96,16 +123,29 @@ x-kaswallet-runtime: &kaswallet-runtime
     - KASPAD_GRPC_PORT
   extra_hosts:
     - "host.docker.internal:host-gateway"
-  entrypoint: |
-    sh -c '
-    ARGS="--logs-level=$${RUST_LOG} --keys /app/keys.json --server grpc://$${KASPAD_HOST}:$${KASPAD_GRPC_PORT} --listen 0.0.0.0:8082"
-    if [ "$${NETWORK}" = "mainnet" ]; then
-      ARGS="--enable-mainnet-pre-launch $$ARGS"
-    else
-      ARGS="--$${NETWORK} $$ARGS"
-    fi
-    exec /app/kaswallet-daemon $$ARGS
-    '
+  depends_on:
+    kaspad:
+      condition: service_healthy
+  entrypoint:
+    - sh
+    - -ec
+    - |
+      ARGS="--logs-level=$$RUST_LOG --keys /app/keys.json --server grpc://$$KASPAD_HOST:$$KASPAD_GRPC_PORT --listen 0.0.0.0:8082"
+      if [ "$$NETWORK" = "mainnet" ]; then
+        ARGS="--enable-mainnet-pre-launch $$ARGS"
+      else
+        ARGS="--$$NETWORK $$ARGS"
+      fi
+      exec sh /app/watch-dependencies.sh \
+        --tcp kaspad "$$KASPAD_HOST" "$$KASPAD_GRPC_PORT" \
+        -- /app/kaswallet-daemon $$ARGS
+  healthcheck:
+    <<: *default-healthcheck
+    test:
+      - CMD-SHELL
+      - >
+        bash -lc ': > /dev/tcp/127.0.0.1/8082' &&
+        bash -lc ": > /dev/tcp/$$KASPAD_HOST/$$KASPAD_GRPC_PORT"
 
 # Build config (extends runtime) - for primary service only
 x-kaswallet-build: &kaswallet-build
@@ -126,8 +166,12 @@ services:
       ssh:
         - default
     image: igranetwork/kaspad:${KASPAD_VERSION}
-    profiles: ["kaspad", "backend"]
+    restart: *service-restart-policy
+    profiles: ["kaspad", "backend", "frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
     container_name: kaspad
+    depends_on:
+      execution-layer:
+        condition: service_healthy
     ports:
       - "${KASPAD_GRPC_PORT}:${KASPAD_GRPC_PORT}"
       - "${KASPAD_P2P_PORT}:${KASPAD_P2P_PORT}"
@@ -147,83 +191,85 @@ services:
       - POST_FORK_LOCK_SCRIPT_PUBKEY
       - LOCK_SCRIPT_FORK_DAA_SCORE
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
-    entrypoint: |
-      sh -c '
-      # Base kaspad arguments
-      ARGS="--disable-upnp \
-        --rpclisten-borsh=0.0.0.0 \
-        --rpclisten=0.0.0.0 \
-        --rpclisten-json=0.0.0.0 \
-        --listen=0.0.0.0 \
-        --utxoindex \
-        --logdir=/app/logs \
-        --appdir=/app/data"
+    entrypoint:
+      - sh
+      - -ec
+      - |
+        ARGS="--disable-upnp \
+          --rpclisten-borsh=0.0.0.0 \
+          --rpclisten=0.0.0.0 \
+          --rpclisten-json=0.0.0.0 \
+          --listen=0.0.0.0 \
+          --utxoindex \
+          --logdir=/app/logs \
+          --appdir=/app/data"
 
-      # Network-specific flags (mainnet is default, no flag needed)
-      if [ "$${NETWORK}" != "mainnet" ]; then
-        ARGS="--$${NETWORK} --nodnsseed $$ARGS"
-      fi
-
-      # IGRA-specific arguments
-      IGRA_ENABLED="$${IGRA_ENABLE:-true}"
-      if [ "$$IGRA_ENABLED" = "true" ]; then
-        ARGS="$$ARGS \
-          --igra-enable \
-          --atan-listen \
-          --atan-transaction-id-prefix=${TX_ID_PREFIX} \
-          --viaduct-start-daa-score=${IGRA_LAUNCH_DAA_SCORE} \
-          --igra-l1-reference-timestamp=${L1_REFERENCE_TIMESTAMP} \
-          --igra-l1-reference-daa-score=${L1_REFERENCE_DAA_SCORE} \
-          --igra-genesis-hash=${GENESIS_BLOCK_HASH} \
-          --igra-min-fee-per-gas-gwei=${MIN_PROTOCOL_FEE_PER_GAS_GWEI} \
-          --igra-jwt-path=/app/jwt.hex \
-          --igra-lock-script-pubkey=${IGRA_LOCK_SCRIPT_PUBKEY} \
-          --igra-entry-min-amount=${IGRA_ENTRY_MIN_AMOUNT} \
-          --igra-el-host=http://execution-layer"
-
-        # Optional IGRA diagnostics flags
-        [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ] && ARGS="$$ARGS --igra-enable-perf-diagnostics"
-        [ "$$ENABLE_EVENT_LOGGING" = "true" ] && ARGS="$$ARGS --igra-enable-event-logging"
-        [ -n "$$WARM_START_BLOCK" ] && ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
-        [ "$$IGRA_SKIP_LOCK_SCRIPT_CHECK" = "true" ] && ARGS="$$ARGS --igra-skip-lock-script-check"
-        if [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && [ -z "$$LOCK_SCRIPT_FORK_DAA_SCORE" ]; then
-          echo "Error: LOCK_SCRIPT_FORK_DAA_SCORE must be set when POST_FORK_LOCK_SCRIPT_PUBKEY is set" >&2; exit 1
+        if [ "$$NETWORK" != "mainnet" ]; then
+          ARGS="--$$NETWORK --nodnsseed $$ARGS"
         fi
-        if [ -z "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ]; then
-          echo "Error: POST_FORK_LOCK_SCRIPT_PUBKEY must be set when LOCK_SCRIPT_FORK_DAA_SCORE is set" >&2; exit 1
-        fi
-        [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && ARGS="$$ARGS --igra-post-fork-lock-script-pubkey=$$POST_FORK_LOCK_SCRIPT_PUBKEY"
-        [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ] && ARGS="$$ARGS --igra-lock-script-fork-daa-score=$$LOCK_SCRIPT_FORK_DAA_SCORE"
 
-        # Auto-construct ATAN import URL from NETWORK and TX_ID_PREFIX, allow override via env
-        if [ -n "$$ATAN_IMPORT_URL" ]; then
-          ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"
-        elif [ -n "$$CDN_BASE_URL" ] && [ -n "$$NETWORK" ] && [ -n "$$TX_ID_PREFIX" ]; then
-          ARGS="$$ARGS --atan-import-url=$$CDN_BASE_URL/$$NETWORK/$$TX_ID_PREFIX/index.pb"
+        IGRA_ENABLED="$${IGRA_ENABLE:-true}"
+        if [ "$$IGRA_ENABLED" = "true" ]; then
+          ARGS="$$ARGS \
+            --igra-enable \
+            --atan-listen \
+            --atan-transaction-id-prefix=${TX_ID_PREFIX} \
+            --viaduct-start-daa-score=${IGRA_LAUNCH_DAA_SCORE} \
+            --igra-l1-reference-timestamp=${L1_REFERENCE_TIMESTAMP} \
+            --igra-l1-reference-daa-score=${L1_REFERENCE_DAA_SCORE} \
+            --igra-genesis-hash=${GENESIS_BLOCK_HASH} \
+            --igra-min-fee-per-gas-gwei=${MIN_PROTOCOL_FEE_PER_GAS_GWEI} \
+            --igra-jwt-path=/app/jwt.hex \
+            --igra-lock-script-pubkey=${IGRA_LOCK_SCRIPT_PUBKEY} \
+            --igra-entry-min-amount=${IGRA_ENTRY_MIN_AMOUNT} \
+            --igra-el-host=http://execution-layer"
+
+          [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ] && ARGS="$$ARGS --igra-enable-perf-diagnostics"
+          [ "$$ENABLE_EVENT_LOGGING" = "true" ] && ARGS="$$ARGS --igra-enable-event-logging"
+          [ -n "$$WARM_START_BLOCK" ] && ARGS="$$ARGS --igra-warm-start-block=$$WARM_START_BLOCK"
+          [ "$$IGRA_SKIP_LOCK_SCRIPT_CHECK" = "true" ] && ARGS="$$ARGS --igra-skip-lock-script-check"
+          if [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && [ -z "$$LOCK_SCRIPT_FORK_DAA_SCORE" ]; then
+            echo "Error: LOCK_SCRIPT_FORK_DAA_SCORE must be set when POST_FORK_LOCK_SCRIPT_PUBKEY is set" >&2; exit 1
+          fi
+          if [ -z "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ]; then
+            echo "Error: POST_FORK_LOCK_SCRIPT_PUBKEY must be set when LOCK_SCRIPT_FORK_DAA_SCORE is set" >&2; exit 1
+          fi
+          [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && ARGS="$$ARGS --igra-post-fork-lock-script-pubkey=$$POST_FORK_LOCK_SCRIPT_PUBKEY"
+          [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ] && ARGS="$$ARGS --igra-lock-script-fork-daa-score=$$LOCK_SCRIPT_FORK_DAA_SCORE"
+
+          if [ -n "$$ATAN_IMPORT_URL" ]; then
+            ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"
+          elif [ -n "$$CDN_BASE_URL" ] && [ -n "$$NETWORK" ] && [ -n "$$TX_ID_PREFIX" ]; then
+            ARGS="$$ARGS --atan-import-url=$$CDN_BASE_URL/$$NETWORK/$$TX_ID_PREFIX/index.pb"
+          else
+            echo "Error: CDN_BASE_URL, NETWORK and TX_ID_PREFIX must be set for ATAN import" >&2
+            exit 1
+          fi
+        fi
+
+        if [ -n "$$KASPAD_ADD_PEER" ]; then
+          ARGS="$$ARGS --addpeer=$$KASPAD_ADD_PEER"
         else
-          echo "Error: CDN_BASE_URL, NETWORK and TX_ID_PREFIX must be set for ATAN import" >&2
-          exit 1
+          ARGS="$$ARGS --enable-unsynced-mining"
         fi
-      fi
 
-      # Peer configuration
-      if [ -n "$$KASPAD_ADD_PEER" ]; then
-        ARGS="$$ARGS --addpeer=$$KASPAD_ADD_PEER"
-      else
-        ARGS="$$ARGS --enable-unsynced-mining"
-      fi
-
-      exec /app/kaspad $$ARGS
-      '
+        exec sh /app/watch-dependencies.sh \
+          --tcp execution-layer execution-layer 8545 \
+          -- /app/kaspad $$ARGS
     volumes:
       - kaspad_data:/app/data/
       - ./logs/kaspad/:/app/logs/  # Event logs when ENABLE_EVENT_LOGGING=true
       - ./keys/jwt.hex:/app/jwt.hex:ro
+      - *dependency-watch-volume
     networks:
       - igra-network
     healthcheck:
       <<: *default-healthcheck
-      test: ["CMD", "bash", "-c", "echo hello > /dev/tcp/kaspad/${KASPAD_GRPC_PORT}"]
+      test:
+        - CMD-SHELL
+        - >
+          bash -lc ': > /dev/tcp/127.0.0.1/${KASPAD_GRPC_PORT}' &&
+          bash -lc ': > /dev/tcp/execution-layer/8545'
 
   execution-layer:
     <<: *default-service
@@ -235,9 +281,9 @@ services:
       args:
         BUILD_PROFILE: release
     image: igranetwork/reth:${RETH_VERSION}
-    restart: "no"
+    restart: *service-restart-policy
     container_name: execution-layer
-    profiles: ["execution-layer", "backend"]
+    profiles: ["execution-layer", "kaspad", "backend", "frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
     entrypoint: /app/run-igra-el.sh
     ports:
       - "127.0.0.1:9545:8545"  # open 8545 on localhost for blockscout
@@ -278,7 +324,11 @@ services:
       - "traefik.http.services.el_stats_svc.loadbalancer.server.port=9001"
     healthcheck:
       <<: *default-healthcheck
-      test: ["CMD", "bash", "-c", "test -S /app/socket/auth.ipc"]
+      test:
+        - CMD-SHELL
+        - >
+          test -S /app/socket/auth.ipc &&
+          bash -lc ': > /dev/tcp/127.0.0.1/8545'
 
   node-health-check-client:
     image: igranetwork/node-health-check-client:${NODE_HEALTH_CHECK_VERSION}
@@ -309,22 +359,10 @@ services:
     container_name: rpc-provider-0
     environment:
       <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-0
       WALLET_DAEMON_URI: http://kaswallet-0:8082
       WALLET_TO_ADDRESS: ${W0_WALLET_TO_ADDRESS}
       KASWALLET_PASSWORD: ${W0_KASWALLET_PASSWORD}
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8535 && \
-          echo hello > /dev/tcp/execution-layer/8545 && \
-          echo hello > /dev/tcp/kaswallet-0/8082",
-        ]
-    depends_on:
-      kaswallet-0:
-        condition: service_healthy
 
   kaswallet-0:
     <<: *kaswallet-build
@@ -334,15 +372,7 @@ services:
       - "127.0.0.1:8082:8082"  # open 8082 on localhost for entry transactions
     volumes:
       - ./keys/keys.kaswallet-0.json:/app/keys.json
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8082 && \
-          echo hello > /dev/tcp/${KASPAD_HOST}/${KASPAD_GRPC_PORT}",
-        ]
+      - *dependency-watch-volume
 
   rpc-provider-1:
     <<: *rpc-provider-runtime
@@ -350,22 +380,10 @@ services:
     container_name: rpc-provider-1
     environment:
       <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-1
       WALLET_DAEMON_URI: http://kaswallet-1:8082
       WALLET_TO_ADDRESS: ${W1_WALLET_TO_ADDRESS}
       KASWALLET_PASSWORD: ${W1_KASWALLET_PASSWORD}
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8535 && \
-          echo hello > /dev/tcp/execution-layer/8545 && \
-          echo hello > /dev/tcp/kaswallet-1/8082",
-        ]
-    depends_on:
-      kaswallet-1:
-        condition: service_healthy
 
   kaswallet-1:
     <<: *kaswallet-runtime
@@ -373,15 +391,7 @@ services:
     container_name: kaswallet-1
     volumes:
       - ./keys/keys.kaswallet-1.json:/app/keys.json
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8082 && \
-          echo hello > /dev/tcp/${KASPAD_HOST}/${KASPAD_GRPC_PORT}",
-        ]
+      - *dependency-watch-volume
 
   rpc-provider-2:
     <<: *rpc-provider-runtime
@@ -389,22 +399,10 @@ services:
     container_name: rpc-provider-2
     environment:
       <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-2
       WALLET_DAEMON_URI: http://kaswallet-2:8082
       WALLET_TO_ADDRESS: ${W2_WALLET_TO_ADDRESS}
       KASWALLET_PASSWORD: ${W2_KASWALLET_PASSWORD}
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8535 && \
-          echo hello > /dev/tcp/execution-layer/8545 && \
-          echo hello > /dev/tcp/kaswallet-2/8082",
-        ]
-    depends_on:
-      kaswallet-2:
-        condition: service_healthy
 
   kaswallet-2:
     <<: *kaswallet-runtime
@@ -412,15 +410,7 @@ services:
     container_name: kaswallet-2
     volumes:
       - ./keys/keys.kaswallet-2.json:/app/keys.json
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8082 && \
-          echo hello > /dev/tcp/${KASPAD_HOST}/${KASPAD_GRPC_PORT}",
-        ]
+      - *dependency-watch-volume
 
   rpc-provider-3:
     <<: *rpc-provider-runtime
@@ -428,22 +418,10 @@ services:
     container_name: rpc-provider-3
     environment:
       <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-3
       WALLET_DAEMON_URI: http://kaswallet-3:8082
       WALLET_TO_ADDRESS: ${W3_WALLET_TO_ADDRESS}
       KASWALLET_PASSWORD: ${W3_KASWALLET_PASSWORD}
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8535 && \
-          echo hello > /dev/tcp/execution-layer/8545 && \
-          echo hello > /dev/tcp/kaswallet-3/8082",
-        ]
-    depends_on:
-      kaswallet-3:
-        condition: service_healthy
 
   kaswallet-3:
     <<: *kaswallet-runtime
@@ -451,15 +429,7 @@ services:
     container_name: kaswallet-3
     volumes:
       - ./keys/keys.kaswallet-3.json:/app/keys.json
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8082 && \
-          echo hello > /dev/tcp/${KASPAD_HOST}/${KASPAD_GRPC_PORT}",
-        ]
+      - *dependency-watch-volume
 
   rpc-provider-4:
     <<: *rpc-provider-runtime
@@ -467,22 +437,10 @@ services:
     container_name: rpc-provider-4
     environment:
       <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-4
       WALLET_DAEMON_URI: http://kaswallet-4:8082
       WALLET_TO_ADDRESS: ${W4_WALLET_TO_ADDRESS}
       KASWALLET_PASSWORD: ${W4_KASWALLET_PASSWORD}
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8535 && \
-          echo hello > /dev/tcp/execution-layer/8545 && \
-          echo hello > /dev/tcp/kaswallet-4/8082",
-        ]
-    depends_on:
-      kaswallet-4:
-        condition: service_healthy
 
   kaswallet-4:
     <<: *kaswallet-runtime
@@ -490,22 +448,23 @@ services:
     container_name: kaswallet-4
     volumes:
       - ./keys/keys.kaswallet-4.json:/app/keys.json
-    healthcheck:
-      <<: *default-healthcheck
-      test: [
-          "CMD",
-          "bash",
-          "-c",
-          "echo hello > /dev/tcp/$$HOSTNAME/8082 && \
-          echo hello > /dev/tcp/${KASPAD_HOST}/${KASPAD_GRPC_PORT}",
-        ]
+      - *dependency-watch-volume
 
   # Traefik Service
   traefik:
     <<: *default-service
     image: traefik:v3
+    restart: *service-restart-policy
     profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
     container_name: traefik
+    entrypoint:
+      - sh
+      - /app/watch-dependencies.sh
+      - --http-any
+      - rpc-backends
+      - http://rpc-provider-0:8535/health,http://rpc-provider-1:8535/health,http://rpc-provider-2:8535/health,http://rpc-provider-3:8535/health,http://rpc-provider-4:8535/health
+      - --
+      - traefik
     command:
       - "--api.dashboard=true"
       - "--api.insecure=true"
@@ -534,6 +493,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/traefik:/etc/traefik
       - traefik_certs:/letsencrypt
+      - *dependency-watch-volume
     networks:
       - igra-network
       - traefik-network
@@ -558,8 +518,18 @@ services:
       - "traefik.http.routers.websecure-router.tls.certresolver=myresolver"
     healthcheck:
       <<: *default-healthcheck
-      test: ["CMD", "wget", "--spider", "http://localhost:8080"]
-      timeout: 5s
+      test:
+        - CMD-SHELL
+        - >
+          wget --quiet --spider --tries=1 --timeout=2 http://localhost:8080 &&
+          (
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-0:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-1:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-2:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-3:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-4:8535/health
+          )
+      timeout: 12s
 
   # Miscellaneous Services
   kaspa-miner:

--- a/scripts/lib/setup-common.sh
+++ b/scripts/lib/setup-common.sh
@@ -91,6 +91,46 @@ run_docker_compose() {
     fi
 }
 
+wait_for_container_ready() {
+    local name="$1"
+    local timeout_seconds="${2:-300}"
+    local waited=0
+    local state
+    local health
+
+    while (( waited < timeout_seconds )); do
+        state="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || true)"
+        health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$name" 2>/dev/null || true)"
+
+        if [[ "$state" == "running" && ( "$health" == "healthy" || "$health" == "none" ) ]]; then
+            return 0
+        fi
+
+        if [[ "$state" == "exited" || "$state" == "dead" ]]; then
+            error "$name exited before becoming ready"
+            return 1
+        fi
+
+        sleep 2
+        waited=$((waited + 2))
+    done
+
+    error "Timed out waiting for $name to become ready"
+    return 1
+}
+
+wait_for_backend_readiness() {
+    log "Waiting for backend services to become ready..."
+
+    if ! wait_for_container_ready execution-layer 300; then
+        return 1
+    fi
+
+    if ! wait_for_container_ready kaspad 300; then
+        return 1
+    fi
+}
+
 print_help() {
     local script_name
     script_name="$(basename "$0")"
@@ -287,8 +327,9 @@ start_services() {
     log "Backend services started"
     echo
 
-    log "Waiting 10 seconds for backend services to initialize..."
-    sleep 10
+    if ! wait_for_backend_readiness; then
+        die "Backend services did not become ready."
+    fi
 
     log "Starting worker services ($num_workers workers)..."
     if ! run_docker_compose --profile "frontend-w${num_workers}" up -d --no-build; then
@@ -311,6 +352,9 @@ print_summary() {
     echo
     echo "NOTE: kaswallet services may NOT start until kaspad completes IBD sync."
     echo "      This typically takes 4-6 hours for initial sync."
+    echo
+    echo "Core services exit when a required upstream dependency disappears."
+    echo "Mainnet templates restart them automatically; testnet and dev do not."
     echo
     echo "Useful commands:"
     echo "  docker compose logs -f kaspad                   # Monitor kaspad sync progress"

--- a/scripts/lib/watch-dependencies.sh
+++ b/scripts/lib/watch-dependencies.sh
@@ -1,0 +1,339 @@
+#!/bin/sh
+#
+# Wrap a child command and stop it when a declared dependency disappears.
+# Usage: ./watch-dependencies.sh [dependency options] -- command [args...]
+#
+# Supported dependency types:
+#   --tcp, --http, --http-any, --tcp-if, --http-if
+#
+# Environment knobs:
+#   DEPENDENCY_CHECK_INTERVAL_SECONDS
+#   DEPENDENCY_TCP_TIMEOUT_SECONDS
+#   DEPENDENCY_HTTP_TIMEOUT_SECONDS
+#
+# Examples:
+#   ./watch-dependencies.sh --tcp execution-layer execution-layer 8545 -- /app/kaspad
+#   ./watch-dependencies.sh --http-any rpc-backends http://rpc-provider-0:8535/health,http://rpc-provider-1:8535/health -- traefik
+#   ./watch-dependencies.sh --help
+set -eu
+
+interval="${DEPENDENCY_CHECK_INTERVAL_SECONDS:-5}"
+tcp_timeout="${DEPENDENCY_TCP_TIMEOUT_SECONDS:-2}"
+http_timeout="${DEPENDENCY_HTTP_TIMEOUT_SECONDS:-2}"
+dependencies=""
+child_pid=""
+
+log() {
+    printf '[watch-dependencies] %s\n' "$*" >&2
+}
+
+print_help() {
+    script_name="$(basename "$0")"
+    cat <<EOF
+Usage: ./$script_name [OPTIONS] -- command [args...]
+
+Wrap a child command and stop it when a declared dependency disappears.
+The child command only starts after all declared dependencies are ready.
+
+Options:
+  --interval <seconds>
+      Override the dependency poll interval.
+
+  --tcp <label> <host> <port>
+      Require a TCP endpoint.
+
+  --http <label> <url>
+      Require a single HTTP endpoint.
+
+  --http-any <label> <url1,url2,...>
+      Require at least one healthy HTTP endpoint from a comma-separated list.
+
+  --tcp-if <env_name> <expected_value> <label> <host> <port>
+      Add a TCP dependency only when the named environment variable matches.
+
+  --http-if <env_name> <expected_value> <label> <url>
+      Add an HTTP dependency only when the named environment variable matches.
+
+  -h, --help
+      Show this help and exit.
+
+Environment:
+  DEPENDENCY_CHECK_INTERVAL_SECONDS  Poll interval between dependency checks (default: 5)
+  DEPENDENCY_TCP_TIMEOUT_SECONDS     TCP probe timeout in seconds (default: 2)
+  DEPENDENCY_HTTP_TIMEOUT_SECONDS    HTTP probe timeout in seconds (default: 2)
+
+Examples:
+  ./$script_name -- /bin/true
+
+  ./$script_name \\
+    --tcp execution-layer execution-layer 8545 \\
+    -- /app/kaspad
+
+  ./$script_name \\
+    --tcp-if READ_ONLY false kaswallet "\$KASWALLET_HOST" 8082 \\
+    -- /app/igra-rpc-provider
+
+  ./$script_name \\
+    --http-any rpc-backends \\
+    http://rpc-provider-0:8535/health,http://rpc-provider-1:8535/health \\
+    -- traefik
+EOF
+}
+
+usage_error() {
+    log "$1"
+    printf '[watch-dependencies] run with --help to see usage examples\n' >&2
+    exit 2
+}
+
+add_dependency() {
+    entry="$1|$2|$3|$4"
+    if [ -z "$dependencies" ]; then
+        dependencies="$entry"
+    else
+        dependencies="$dependencies
+$entry"
+    fi
+}
+
+normalize_timeout() {
+    value="$1"
+    fallback="$2"
+
+    case "$value" in
+        ''|*[!0-9]*)
+            printf '%s' "$fallback"
+            ;;
+        *)
+            if [ "$value" -gt 0 ]; then
+                printf '%s' "$value"
+            else
+                printf '%s' "$fallback"
+            fi
+            ;;
+    esac
+}
+
+valid_env_name() {
+    case "$1" in
+        ''|[0-9]*|*[!A-Za-z0-9_]*)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+resolve_env() {
+    name="$1"
+    if ! valid_env_name "$name"; then
+        log "invalid environment variable name: $name"
+        return 1
+    fi
+    eval "printf '%s' \"\${$name:-}\""
+}
+
+valid_host() {
+    case "$1" in
+        ''|*[!A-Za-z0-9.-]*)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+valid_port() {
+    case "$1" in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+        *)
+            [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+            ;;
+    esac
+}
+
+check_tcp() {
+    host="$1"
+    port="$2"
+
+    if ! valid_host "$host" || ! valid_port "$port"; then
+        log "invalid tcp target: $host:$port"
+        return 1
+    fi
+
+    if ! command -v bash > /dev/null 2>&1; then
+        log "bash is required for tcp dependency checks"
+        return 1
+    fi
+
+    bash -lc 'exec 3<>"/dev/tcp/$1/$2"' _ "$host" "$port" > /dev/null 2>&1 &
+    probe_pid="$!"
+    (
+        sleep "$tcp_timeout"
+        kill -TERM "$probe_pid" 2>/dev/null || true
+    ) &
+    timeout_pid="$!"
+
+    if wait "$probe_pid"; then
+        result=0
+    else
+        result=$?
+    fi
+
+    kill -TERM "$timeout_pid" 2>/dev/null || true
+    wait "$timeout_pid" 2>/dev/null || true
+
+    [ "$result" -eq 0 ]
+}
+
+check_http() {
+    wget --quiet --spider --tries=1 --timeout="$http_timeout" "$1" > /dev/null 2>&1
+}
+
+check_http_any() {
+    urls="$1"
+    old_ifs="$IFS"
+    IFS=','
+    set -- $urls
+    IFS="$old_ifs"
+
+    for url in "$@"; do
+        if check_http "$url"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+dependencies_ready() {
+    if [ -z "$dependencies" ]; then
+        return 0
+    fi
+
+    old_ifs="$IFS"
+    IFS='
+'
+    for dep in $dependencies; do
+        IFS='|'
+        set -- $dep
+        IFS="$old_ifs"
+
+        type="$1"
+        label="$2"
+        value1="$3"
+        value2="${4:-}"
+
+        case "$type" in
+            tcp)
+                if ! check_tcp "$value1" "$value2"; then
+                    log "$label is unavailable at $value1:$value2"
+                    return 1
+                fi
+                ;;
+            http)
+                if ! check_http "$value1"; then
+                    log "$label is unavailable at $value1"
+                    return 1
+                fi
+                ;;
+            http-any)
+                if ! check_http_any "$value1"; then
+                    log "$label has no healthy endpoints in $value1"
+                    return 1
+                fi
+                ;;
+            *)
+                log "unknown dependency type: $type"
+                return 1
+                ;;
+        esac
+    done
+    IFS="$old_ifs"
+}
+
+terminate_child() {
+    if [ -n "$child_pid" ] && kill -0 "$child_pid" 2>/dev/null; then
+        kill -TERM "$child_pid" 2>/dev/null || true
+        wait "$child_pid" 2>/dev/null || true
+    fi
+}
+
+tcp_timeout="$(normalize_timeout "$tcp_timeout" 2)"
+http_timeout="$(normalize_timeout "$http_timeout" 2)"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        --interval)
+            interval="$2"
+            shift 2
+            ;;
+        --tcp)
+            add_dependency "tcp" "$2" "$3" "$4"
+            shift 4
+            ;;
+        --http)
+            add_dependency "http" "$2" "$3" ""
+            shift 3
+            ;;
+        --http-any)
+            add_dependency "http-any" "$2" "$3" ""
+            shift 3
+            ;;
+        --tcp-if)
+            resolved_env_value="$(resolve_env "$2")" || exit 2
+            if [ "$resolved_env_value" = "$3" ]; then
+                add_dependency "tcp" "$4" "$5" "$6"
+            fi
+            shift 6
+            ;;
+        --http-if)
+            resolved_env_value="$(resolve_env "$2")" || exit 2
+            if [ "$resolved_env_value" = "$3" ]; then
+                add_dependency "http" "$4" "$5" ""
+            fi
+            shift 5
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            usage_error "unknown argument: $1"
+            ;;
+    esac
+done
+
+if [ "$#" -eq 0 ]; then
+    usage_error "missing command"
+fi
+
+command="$1"
+shift
+
+trap 'terminate_child; exit 143' INT TERM
+
+until dependencies_ready; do
+    sleep "$interval"
+done
+
+"$command" "$@" &
+child_pid="$!"
+
+while kill -0 "$child_pid" 2>/dev/null; do
+    if ! dependencies_ready; then
+        terminate_child
+        exit 1
+    fi
+    sleep "$interval"
+done
+
+wait "$child_pid"


### PR DESCRIPTION
## Summary
Enforce fail-fast behavior across Orchestra so downstream services stop when required upstream services disappear instead of continuing in a degraded state. Add environment-driven restart policies so mainnet can recover automatically while testnet and dev remain stopped for inspection. Keep worker-only profile selections valid after wiring the new cross-service dependencies.

### Changes
- Add `scripts/lib/watch-dependencies.sh` and wrap `kaspad`, `kaswallet-*`, `rpc-provider-*`, and `traefik` with runtime dependency checks
- Tighten `depends_on` and health checks in `docker-compose.yml`, including the conditional `rpc-provider` dependency on `kaswallet` when `RPC_READ_ONLY=false`
- Introduce `SERVICE_RESTART_POLICY` in the env templates and replace the fixed backend startup sleep with readiness polling in `scripts/lib/setup-common.sh`
- Expand `kaspad` and `execution-layer` profiles to include `frontend-w*` so worker profile renders remain valid with the new dependency chain

### Security and Reliability
- Downstream services stop when core dependencies vanish instead of serving stale or partial state
- Mainnet can auto-restart after fail-fast exits via `SERVICE_RESTART_POLICY=unless-stopped`, while non-mainnet remains stopped for inspection

## Test Plan
- [x] `sh -n scripts/lib/watch-dependencies.sh`
- [x] Render Compose config with `.env.galleon-testnet.example` and `versions.testnet.env`
- [x] Render `frontend-w5` profile with `.env.galleon-testnet.example` and `versions.testnet.env`
- [x] Render `kaspad` profile with `.env.galleon-testnet.example` and `versions.testnet.env`
- [x] Smoke test `watch-dependencies.sh --http-any` against a local HTTP server