### PR TITLE
[ENG-787] fix: decouple frontend profiles from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The recommended way to run the IGRA Orchestra stack is:
    ```
 
 3. **Start Worker Services**
-   Choose the profile based on how many workers you need:
+   Choose the profile based on how many workers you need. This assumes the backend profile is already running. If you want to start the full stack in one command, include both profiles (for example `docker compose --profile backend --profile frontend-w5 up -d`).
    ```bash
    # For 1 worker
    docker compose --profile frontend-w1 up -d
@@ -245,14 +245,22 @@ The recommended way to run the IGRA Orchestra stack is:
    docker compose --profile frontend-w5 up -d
    ```
 
-4. **Stopping Services**
+4. **Stopping Or Restarting Services**
    ```bash
    # Stop all services
    docker compose down
 
-   # Stop specific profile
-   docker compose --profile <profile-name> down
+   # Restart frontend only (5 workers)
+   docker compose --profile frontend-w5 restart
+
+   # Stop frontend only (5 workers) without touching backend
+   docker compose --profile frontend-w5 down
+
+   # Start frontend again
+   docker compose --profile frontend-w5 up -d
    ```
+
+   For fewer workers, replace `frontend-w5` with `frontend-w1` through `frontend-w4`.
 
 ## Logs and Monitoring
 
@@ -347,6 +355,7 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser igranetwork
 - [Kaspa Wallet Guide](doc/kaspa-wallet.md) - Wallet setup for all networks
 - [Log Management](doc/log-management.md) - Automated log cleanup for servers
 - [Docker Volume Permissions](doc/troubleshooting/docker-volume-permissions.md) - Fix permission denied errors
+- [Service Restart Debugging](doc/troubleshooting/service-restart-debugging.md) - Diagnose fail-fast exits, restart loops, and Docker log persistence
 - [SSL Certificate Issues](doc/troubleshooting/ssl-certificate.md) - Fix Traefik certificate resolver errors
 
 ## Troubleshooting

--- a/doc/index.md
+++ b/doc/index.md
@@ -17,6 +17,7 @@ Choose your deployment guide:
 ## Troubleshooting
 
 - **[Docker Volume Permissions](troubleshooting/docker-volume-permissions.md)** - Fix permission denied errors
+- **[Service Restart Debugging](troubleshooting/service-restart-debugging.md)** - Diagnose fail-fast exits, restart loops, and Docker log persistence
 - **[SSL Certificate Issues](troubleshooting/ssl-certificate.md)** - Fix Traefik certificate resolver errors
 
 ## Requirements

--- a/doc/quick-setup-galleon-testnet.md
+++ b/doc/quick-setup-galleon-testnet.md
@@ -182,6 +182,12 @@ For all 5 workers:
 docker compose --profile frontend-w5 up -d --no-build
 ```
 
+This assumes the backend profile is already running. To start backend and frontend together in one command:
+
+```bash
+docker compose --profile backend --profile frontend-w5 up -d --no-build
+```
+
 Or start with fewer workers:
 - 1 worker: `--profile frontend-w1`
 - 2 workers: `--profile frontend-w2`
@@ -266,10 +272,18 @@ docker compose --profile frontend-w5 up -d --no-build
 
 ## Maintenance
 
-Restart services:
+Restart frontend services without touching backend:
 ```bash
-docker compose --profile backend --profile frontend-w5 restart
+docker compose --profile frontend-w5 restart
 ```
+
+Stop frontend only without touching backend:
+```bash
+docker compose --profile frontend-w5 down
+docker compose --profile frontend-w5 up -d --no-build
+```
+
+For fewer workers, replace `frontend-w5` with `frontend-w1` through `frontend-w4`.
 
 Update to latest images:
 ```bash

--- a/doc/quick-setup-mainnet.md
+++ b/doc/quick-setup-mainnet.md
@@ -148,6 +148,12 @@ For all 5 workers:
 docker compose --profile frontend-w5 up -d --no-build
 ```
 
+This assumes the backend profile is already running. To start backend and frontend together in one command:
+
+```bash
+docker compose --profile backend --profile frontend-w5 up -d --no-build
+```
+
 Or start with fewer workers:
 - 1 worker: `--profile frontend-w1`
 - 2 workers: `--profile frontend-w2`
@@ -231,10 +237,18 @@ docker compose --profile frontend-w5 up -d --no-build
 
 ## Maintenance
 
-Restart services:
+Restart frontend services without touching backend:
 ```bash
-docker compose --profile backend --profile frontend-w5 restart
+docker compose --profile frontend-w5 restart
 ```
+
+Stop frontend only without touching backend:
+```bash
+docker compose --profile frontend-w5 down
+docker compose --profile frontend-w5 up -d --no-build
+```
+
+For fewer workers, replace `frontend-w5` with `frontend-w1` through `frontend-w4`.
 
 Update to latest images:
 ```bash

--- a/doc/troubleshooting/service-restart-debugging.md
+++ b/doc/troubleshooting/service-restart-debugging.md
@@ -1,0 +1,256 @@
+# Debug: Service Restarts And Dependency Exits
+
+Use this guide when a service unexpectedly exits, keeps restarting, or appears to hang while waiting for another component.
+
+## What Controls Restart Behavior
+
+There are two layers involved:
+
+1. `scripts/lib/watch-dependencies.sh`
+   This wrapper waits for declared dependencies before starting the real process. If a dependency disappears later, it stops the child process and exits with status `1`.
+
+2. Docker restart policy
+   Most core services in `docker-compose.yml` use `SERVICE_RESTART_POLICY`.
+
+Default behavior by environment:
+
+- Mainnet: `SERVICE_RESTART_POLICY=unless-stopped`
+- Galleon testnet: `SERVICE_RESTART_POLICY=no`
+- Dev: `SERVICE_RESTART_POLICY=no`
+
+Two services currently pin `restart: unless-stopped` directly in Compose:
+
+- `node-health-check-client`
+- `atan-uploader`
+
+## Dependency Map
+
+```mermaid
+flowchart LR
+  executionLayer["execution-layer"] --> kaspad["kaspad"]
+  executionLayer --> rpcProvider["rpc-provider-*"]
+  kaspad --> kaswallet["kaswallet-*"]
+  kaswallet -->|"RPC_READ_ONLY=false"| rpcProvider
+  rpcProvider --> traefik["traefik"]
+```
+
+## Restart Frontend Without Touching Backend
+
+`frontend-w*` profiles do not need to activate backend services directly. For a full stack start, bring up both profiles:
+
+```bash
+docker compose --profile backend --profile frontend-w5 up -d --no-build
+```
+
+If backend is already running and you only want to bounce frontend services, restart the frontend profile directly:
+
+```bash
+docker compose --profile frontend-w5 restart
+```
+
+To remove and recreate frontend containers without touching backend:
+
+```bash
+docker compose --profile frontend-w5 down
+docker compose --profile frontend-w5 up -d --no-build
+```
+
+For fewer workers, replace `frontend-w5` with `frontend-w1` through `frontend-w4`.
+
+This works because `kaspad` and `execution-layer` are not part of the `frontend-w*` profile set, so profile-scoped `restart` and `down` only target frontend services.
+
+## Quick Triage
+
+### 1. Check current container state
+
+```bash
+docker compose ps
+```
+
+This tells you whether the container is currently `Up`, `Exited`, or flapping.
+
+### 2. Check whether Docker actually restarted it
+
+```bash
+docker inspect -f 'name={{.Name}} restart_count={{.RestartCount}} status={{.State.Status}} exit_code={{.State.ExitCode}} started={{.State.StartedAt}} finished={{.State.FinishedAt}} error={{.State.Error}}' rpc-provider-0
+```
+
+Interpretation:
+
+- `restart_count=0` with `status=running`: the container has not restarted yet
+- `restart_count=0` with `status=exited`: it exited and stayed down
+- `restart_count>0`: Docker restarted the same container at least once
+
+### 3. Read recent logs with timestamps
+
+```bash
+docker compose logs --timestamps --since 30m rpc-provider-0
+docker compose logs --timestamps --since 30m kaspad
+docker compose logs --timestamps --since 30m traefik
+```
+
+Use `-f` if you want to keep watching:
+
+```bash
+docker compose logs --timestamps --since 10m -f rpc-provider-0 traefik
+```
+
+### 4. Check Docker restart events
+
+```bash
+docker events --since 30m --filter container=rpc-provider-0
+```
+
+This helps confirm whether Docker restarted the container or whether it simply stayed up and kept polling for dependencies.
+
+## How To Tell What Happened
+
+### Service is waiting for a dependency
+
+Typical signals:
+
+- `docker compose ps` shows the container as `Up`
+- `restart_count=0`
+- logs repeatedly show `[watch-dependencies] ... unavailable ...`
+- you do not see the real application startup logs yet
+
+This means the wrapper is still running and the child command has not started.
+
+### Service exited and stayed down
+
+Typical signals:
+
+- `docker compose ps` shows `Exited`
+- `restart_count=0`
+- logs end with a dependency-loss message from `watch-dependencies.sh`
+
+This is expected when restart policy is `no`.
+
+### Service restarted after an error
+
+Typical signals:
+
+- `restart_count>0`
+- logs contain an earlier failure, then a fresh startup sequence later
+- `docker events` shows restart-related lifecycle events
+
+This is expected on mainnet for services using `SERVICE_RESTART_POLICY=unless-stopped`.
+
+## Are Logs Persistent After Restart
+
+Yes, in the current default setup they are.
+
+The environment examples set:
+
+```bash
+LOGGING_DRIVER=json-file
+```
+
+With the `json-file` driver:
+
+- `docker logs` and `docker compose logs` continue to show earlier log lines after a restart of the same container
+- the log stream is appended across restarts of that container
+- log rotation still applies because Compose sets `max-size`, `max-file`, and `compress`
+
+Important distinction:
+
+- Restarted container: same container, logs remain visible via `docker logs`
+- Recreated container: new container ID, old logs stay attached to the old container until it is removed
+
+To compare container identity:
+
+```bash
+docker inspect -f 'id={{.Id}} created={{.Created}} started={{.State.StartedAt}}' rpc-provider-0
+```
+
+If you switch to `LOGGING_DRIVER=syslog`, persistence depends on the host logging system instead of Docker's `json-file` storage.
+
+## Common Signatures
+
+### `[watch-dependencies] execution-layer is unavailable at execution-layer:8545`
+
+Meaning:
+
+- the wrapper could not reach the execution layer TCP endpoint
+
+What to check:
+
+```bash
+docker compose ps
+docker compose logs --timestamps --since 15m execution-layer
+docker inspect -f 'restart_count={{.RestartCount}} status={{.State.Status}}' execution-layer
+```
+
+### `[watch-dependencies] rpc-backends has no healthy endpoints in ...`
+
+Meaning:
+
+- none of the configured RPC health URLs responded successfully
+
+What to check:
+
+```bash
+docker compose ps
+docker compose logs --timestamps --since 15m rpc-provider-0 rpc-provider-1 traefik
+```
+
+Note:
+
+- `traefik` uses `--http-any`, so only one healthy RPC backend is required
+- if you run `watch-dependencies.sh` manually from the host shell, Docker-internal names like `rpc-provider-0` only work if they resolve from your current network context
+
+### `[watch-dependencies] missing command`
+
+Meaning:
+
+- the wrapper was invoked directly without `-- command ...`
+
+Correct pattern:
+
+```bash
+./scripts/lib/watch-dependencies.sh -- /bin/true
+```
+
+### Repeated dependency messages every few seconds
+
+Meaning:
+
+- the wrapper is still polling and has not started the child process yet
+
+The poll interval is controlled by:
+
+```bash
+DEPENDENCY_CHECK_INTERVAL_SECONDS
+```
+
+Optional timeout knobs:
+
+```bash
+DEPENDENCY_TCP_TIMEOUT_SECONDS
+DEPENDENCY_HTTP_TIMEOUT_SECONDS
+```
+
+## Recommended Debug Flow
+
+When a service looks unhealthy:
+
+1. Run `docker compose ps`
+2. Inspect `RestartCount` and state timestamps
+3. Read recent logs with `--timestamps --since ...`
+4. Check the upstream service named in the `watch-dependencies` message
+5. Use `docker events` if you need to confirm actual restart behavior
+
+For example, if `rpc-provider-0` is failing:
+
+```bash
+docker compose ps
+docker inspect -f 'restart_count={{.RestartCount}} status={{.State.Status}} started={{.State.StartedAt}} finished={{.State.FinishedAt}}' rpc-provider-0
+docker compose logs --timestamps --since 15m rpc-provider-0 execution-layer kaswallet-0
+docker events --since 15m --filter container=rpc-provider-0
+```
+
+## Related Docs
+
+- [Log Management](../log-management.md)
+- [Mainnet Deployment Guide](../quick-setup-mainnet.md)
+- [Galleon Testnet Deployment Guide](../quick-setup-galleon-testnet.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ x-rpc-provider-runtime: &rpc-provider-runtime
   depends_on:
     execution-layer:
       condition: service_healthy
+      required: false
   healthcheck:
     <<: *default-healthcheck
     test:
@@ -126,6 +127,7 @@ x-kaswallet-runtime: &kaswallet-runtime
   depends_on:
     kaspad:
       condition: service_healthy
+      required: false
   entrypoint:
     - sh
     - -ec
@@ -167,7 +169,7 @@ services:
         - default
     image: igranetwork/kaspad:${KASPAD_VERSION}
     restart: *service-restart-policy
-    profiles: ["kaspad", "backend", "frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["kaspad", "backend"]
     container_name: kaspad
     depends_on:
       execution-layer:
@@ -283,7 +285,7 @@ services:
     image: igranetwork/reth:${RETH_VERSION}
     restart: *service-restart-policy
     container_name: execution-layer
-    profiles: ["execution-layer", "kaspad", "backend", "frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["execution-layer", "kaspad", "backend"]
     entrypoint: /app/run-igra-el.sh
     ports:
       - "127.0.0.1:9545:8545"  # open 8545 on localhost for blockscout

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,4 +49,5 @@ nav:
     - Log Management: log-management.md
   - Troubleshooting:
     - Docker Volume Permissions: troubleshooting/docker-volume-permissions.md
+    - Service Restart Debugging: troubleshooting/service-restart-debugging.md
     - SSL Certificate: troubleshooting/ssl-certificate.md


### PR DESCRIPTION
## Summary
The fail-fast dependency handling for `ENG-787` is already in `main`. This PR finishes frontend/backend profile decoupling by removing the remaining backend service from `frontend-w*`, so profile-scoped frontend `restart` and `down` only touch frontend services. It also updates the operator docs to use profile-based frontend maintenance commands.

## Changes
- remove `execution-layer` from the `frontend-w*` profile set so both backend services stay outside frontend profile activation
- keep the cross-profile `depends_on` edges optional with `required: false` so frontend profile rendering stays valid
- update the README and the mainnet/Galleon guides to recommend `docker compose --profile frontend-w5 restart/down/up`
- update the restart-debugging guide to explain why profile-scoped frontend `restart` and `down` are safe

## Test Plan
- [x] `tmp_env=$(mktemp); cat .env.galleon-testnet.example versions.testnet.env > "$tmp_env"; ! docker compose --env-file "$tmp_env" --profile frontend-w5 config --services | rg -x '(execution-layer|kaspad)'; /bin/rm -f "$tmp_env"`
- [x] `tmp_env=$(mktemp); cat .env.galleon-testnet.example versions.testnet.env > "$tmp_env"; docker compose --env-file "$tmp_env" --profile frontend-w5 config; /bin/rm -f "$tmp_env"`
- [x] `tmp_env=$(mktemp); cat .env.galleon-testnet.example versions.testnet.env > "$tmp_env"; docker compose --env-file "$tmp_env" --profile backend --profile frontend-w5 config; /bin/rm -f "$tmp_env"`
- [x] `mkdocs build --strict`