### PR TITLE
[ENG-1007] feat: add frontend-w20 profile and wallet address sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ docker compose build
 docker compose --profile kaspad up -d
 docker compose --profile backend up -d
 # 6. Start worker services based on your needs
-docker compose --profile frontend-w1 up -d  # 1 worker
+docker compose --profile frontend-w1 up -d   # 1 worker
 # OR
-docker compose --profile frontend-w2 up -d  # 2 workers
+docker compose --profile frontend-w2 up -d   # 2 workers
 # OR
-docker compose --profile frontend-w3 up -d  # 3 workers
+docker compose --profile frontend-w5 up -d   # 5 workers
 # OR
-docker compose --profile frontend-w4 up -d  # 4 workers
+docker compose --profile frontend-w10 up -d  # 10 workers
 # OR
-docker compose --profile frontend-w5 up -d  # 5 workers
+docker compose --profile frontend-w20 up -d  # 20 workers
 ```
 
 ## Initial Setup
@@ -154,7 +154,15 @@ Follow these steps before the first run:
     ```
 
 4.  **Create worker keys:**
-    Generate the necessary key files for the wallet services. At minimum, you need `keys.kaswallet-0.json` for one worker. Additional workers require corresponding files (e.g., `keys.kaswallet-1.json`, `keys.kaswallet-2.json`).
+    Generate the necessary key files for the wallet services. At minimum, you need `keys.kaswallet-0.json` for one worker. Additional workers require corresponding files (e.g., `keys.kaswallet-1.json`, `keys.kaswallet-2.json`, up to `keys.kaswallet-19.json` for 20 workers).
+
+5.  **Sync wallet addresses (after wallets are running):**
+    Once the kaswallet containers are running (requires kaspad to have completed IBD sync), sync their addresses into `.env`:
+    ```bash
+    ./scripts/debug/sync-wallet-addresses.sh        # auto-detect running wallets
+    ./scripts/debug/sync-wallet-addresses.sh 10     # sync first 10 wallets
+    ```
+    This updates `W{N}_WALLET_TO_ADDRESS` entries in `.env` by querying each running kaswallet container. Restart workers after syncing to apply the new addresses.
 
 ## Docker Compose Configuration
 
@@ -170,15 +178,15 @@ The Docker Compose configuration uses profiles and YAML anchors for improved mai
 - **Kaspa Miner** (profile: `kaspa-miner`):
   - `kaspa-miner` - Kaspa mining service
 
-- **Worker Services** (profiles: `frontend-w1`, `frontend-w2`, `frontend-w3`, `frontend-w4`, `frontend-w5`):
-  - `rpc-provider-0` to `rpc-provider-4` - RPC endpoints for API requests
-  - `kaswallet-0` to `kaswallet-4` - Wallet services for transaction relay
+- **Worker Services** (profiles: `frontend-w1` through `frontend-w20`):
+  - `rpc-provider-0` to `rpc-provider-19` - RPC endpoints for API requests
+  - `kaswallet-0` to `kaswallet-19` - Wallet services for transaction relay
 
 - **Core Services** (profile: `backend`):
   - `kaspad` - Kaspa node with integrated Igra adapter (L1-L2 bridge and block building)
   - `execution-layer` - Ethereum-compatible execution layer
 
-- **Traefik** (profiles: `frontend-w1` through `frontend-w5`):
+- **Traefik** (profiles: `frontend-w1` through `frontend-w20`):
   - `traefik` - Reverse proxy and load balancer (starts with any worker profile)
 
 - **Node Health Check** (profile: `node-health-check-client` or `backend`):
@@ -232,17 +240,14 @@ The recommended way to run the IGRA Orchestra stack is:
    # For 1 worker
    docker compose --profile frontend-w1 up -d
 
-   # For 2 workers
-   docker compose --profile frontend-w2 up -d
-
-   # For 3 workers
-   docker compose --profile frontend-w3 up -d
-
-   # For 4 workers
-   docker compose --profile frontend-w4 up -d
-
    # For 5 workers
    docker compose --profile frontend-w5 up -d
+
+   # For 10 workers
+   docker compose --profile frontend-w10 up -d
+
+   # For 20 workers
+   docker compose --profile frontend-w20 up -d
    ```
 
 4. **Stopping Or Restarting Services**
@@ -260,7 +265,7 @@ The recommended way to run the IGRA Orchestra stack is:
    docker compose --profile frontend-w5 up -d
    ```
 
-   For fewer workers, replace `frontend-w5` with `frontend-w1` through `frontend-w4`.
+   All profiles from `frontend-w1` through `frontend-w20` are available. Replace `frontend-w5` with your desired worker count.
 
 ## Logs and Monitoring
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -356,7 +356,7 @@ services:
   # Worker Services
   rpc-provider-0:
     <<: *rpc-provider-build
-    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: rpc-provider-0
     environment:
       <<: *rpc-provider-environment
@@ -367,7 +367,7 @@ services:
 
   kaswallet-0:
     <<: *kaswallet-build
-    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-0
     ports:
       - "127.0.0.1:8082:8082"  # open 8082 on localhost for entry transactions
@@ -377,7 +377,7 @@ services:
 
   rpc-provider-1:
     <<: *rpc-provider-runtime
-    profiles: ["frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: rpc-provider-1
     environment:
       <<: *rpc-provider-environment
@@ -388,7 +388,7 @@ services:
 
   kaswallet-1:
     <<: *kaswallet-runtime
-    profiles: ["frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-1
     volumes:
       - ./keys/keys.kaswallet-1.json:/app/keys.json
@@ -396,7 +396,7 @@ services:
 
   rpc-provider-2:
     <<: *rpc-provider-runtime
-    profiles: ["frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: rpc-provider-2
     environment:
       <<: *rpc-provider-environment
@@ -407,7 +407,7 @@ services:
 
   kaswallet-2:
     <<: *kaswallet-runtime
-    profiles: ["frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-2
     volumes:
       - ./keys/keys.kaswallet-2.json:/app/keys.json
@@ -415,7 +415,7 @@ services:
 
   rpc-provider-3:
     <<: *rpc-provider-runtime
-    profiles: ["frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: rpc-provider-3
     environment:
       <<: *rpc-provider-environment
@@ -426,7 +426,7 @@ services:
 
   kaswallet-3:
     <<: *kaswallet-runtime
-    profiles: ["frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-3
     volumes:
       - ./keys/keys.kaswallet-3.json:/app/keys.json
@@ -434,7 +434,7 @@ services:
 
   rpc-provider-4:
     <<: *rpc-provider-runtime
-    profiles: ["frontend-w5"]
+    profiles: ["frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: rpc-provider-4
     environment:
       <<: *rpc-provider-environment
@@ -445,10 +445,295 @@ services:
 
   kaswallet-4:
     <<: *kaswallet-runtime
-    profiles: ["frontend-w5"]
+    profiles: ["frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-4
     volumes:
       - ./keys/keys.kaswallet-4.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-5:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-5
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-5
+      WALLET_DAEMON_URI: http://kaswallet-5:8082
+      WALLET_TO_ADDRESS: ${W5_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W5_KASWALLET_PASSWORD}
+
+  kaswallet-5:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-5
+    volumes:
+      - ./keys/keys.kaswallet-5.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-6:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-6
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-6
+      WALLET_DAEMON_URI: http://kaswallet-6:8082
+      WALLET_TO_ADDRESS: ${W6_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W6_KASWALLET_PASSWORD}
+
+  kaswallet-6:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-6
+    volumes:
+      - ./keys/keys.kaswallet-6.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-7:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-7
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-7
+      WALLET_DAEMON_URI: http://kaswallet-7:8082
+      WALLET_TO_ADDRESS: ${W7_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W7_KASWALLET_PASSWORD}
+
+  kaswallet-7:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-7
+    volumes:
+      - ./keys/keys.kaswallet-7.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-8:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-8
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-8
+      WALLET_DAEMON_URI: http://kaswallet-8:8082
+      WALLET_TO_ADDRESS: ${W8_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W8_KASWALLET_PASSWORD}
+
+  kaswallet-8:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-8
+    volumes:
+      - ./keys/keys.kaswallet-8.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-9:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-9
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-9
+      WALLET_DAEMON_URI: http://kaswallet-9:8082
+      WALLET_TO_ADDRESS: ${W9_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W9_KASWALLET_PASSWORD}
+
+  kaswallet-9:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-9
+    volumes:
+      - ./keys/keys.kaswallet-9.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-10:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-10
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-10
+      WALLET_DAEMON_URI: http://kaswallet-10:8082
+      WALLET_TO_ADDRESS: ${W10_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W10_KASWALLET_PASSWORD}
+
+  kaswallet-10:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-10
+    volumes:
+      - ./keys/keys.kaswallet-10.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-11:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-11
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-11
+      WALLET_DAEMON_URI: http://kaswallet-11:8082
+      WALLET_TO_ADDRESS: ${W11_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W11_KASWALLET_PASSWORD}
+
+  kaswallet-11:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-11
+    volumes:
+      - ./keys/keys.kaswallet-11.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-12:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-12
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-12
+      WALLET_DAEMON_URI: http://kaswallet-12:8082
+      WALLET_TO_ADDRESS: ${W12_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W12_KASWALLET_PASSWORD}
+
+  kaswallet-12:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-12
+    volumes:
+      - ./keys/keys.kaswallet-12.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-13:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-13
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-13
+      WALLET_DAEMON_URI: http://kaswallet-13:8082
+      WALLET_TO_ADDRESS: ${W13_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W13_KASWALLET_PASSWORD}
+
+  kaswallet-13:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-13
+    volumes:
+      - ./keys/keys.kaswallet-13.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-14:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-14
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-14
+      WALLET_DAEMON_URI: http://kaswallet-14:8082
+      WALLET_TO_ADDRESS: ${W14_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W14_KASWALLET_PASSWORD}
+
+  kaswallet-14:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-14
+    volumes:
+      - ./keys/keys.kaswallet-14.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-15:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-15
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-15
+      WALLET_DAEMON_URI: http://kaswallet-15:8082
+      WALLET_TO_ADDRESS: ${W15_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W15_KASWALLET_PASSWORD}
+
+  kaswallet-15:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-15
+    volumes:
+      - ./keys/keys.kaswallet-15.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-16:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-16
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-16
+      WALLET_DAEMON_URI: http://kaswallet-16:8082
+      WALLET_TO_ADDRESS: ${W16_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W16_KASWALLET_PASSWORD}
+
+  kaswallet-16:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-16
+    volumes:
+      - ./keys/keys.kaswallet-16.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-17:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-17
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-17
+      WALLET_DAEMON_URI: http://kaswallet-17:8082
+      WALLET_TO_ADDRESS: ${W17_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W17_KASWALLET_PASSWORD}
+
+  kaswallet-17:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w18", "frontend-w19", "frontend-w20"]
+    container_name: kaswallet-17
+    volumes:
+      - ./keys/keys.kaswallet-17.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-18:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w19", "frontend-w20"]
+    container_name: rpc-provider-18
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-18
+      WALLET_DAEMON_URI: http://kaswallet-18:8082
+      WALLET_TO_ADDRESS: ${W18_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W18_KASWALLET_PASSWORD}
+
+  kaswallet-18:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w19", "frontend-w20"]
+    container_name: kaswallet-18
+    volumes:
+      - ./keys/keys.kaswallet-18.json:/app/keys.json
+      - *dependency-watch-volume
+
+  rpc-provider-19:
+    <<: *rpc-provider-runtime
+    profiles: ["frontend-w20"]
+    container_name: rpc-provider-19
+    environment:
+      <<: *rpc-provider-environment
+      KASWALLET_HOST: kaswallet-19
+      WALLET_DAEMON_URI: http://kaswallet-19:8082
+      WALLET_TO_ADDRESS: ${W19_WALLET_TO_ADDRESS}
+      KASWALLET_PASSWORD: ${W19_KASWALLET_PASSWORD}
+
+  kaswallet-19:
+    <<: *kaswallet-runtime
+    profiles: ["frontend-w20"]
+    container_name: kaswallet-19
+    volumes:
+      - ./keys/keys.kaswallet-19.json:/app/keys.json
       - *dependency-watch-volume
 
   # Traefik Service
@@ -456,14 +741,14 @@ services:
     <<: *default-service
     image: traefik:v3
     restart: *service-restart-policy
-    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5"]
+    profiles: ["frontend-w1", "frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: traefik
     entrypoint:
       - sh
       - /app/watch-dependencies.sh
       - --http-any
       - rpc-backends
-      - http://rpc-provider-0:8535/health,http://rpc-provider-1:8535/health,http://rpc-provider-2:8535/health,http://rpc-provider-3:8535/health,http://rpc-provider-4:8535/health
+      - http://rpc-provider-0:8535/health,http://rpc-provider-1:8535/health,http://rpc-provider-2:8535/health,http://rpc-provider-3:8535/health,http://rpc-provider-4:8535/health,http://rpc-provider-5:8535/health,http://rpc-provider-6:8535/health,http://rpc-provider-7:8535/health,http://rpc-provider-8:8535/health,http://rpc-provider-9:8535/health,http://rpc-provider-10:8535/health,http://rpc-provider-11:8535/health,http://rpc-provider-12:8535/health,http://rpc-provider-13:8535/health,http://rpc-provider-14:8535/health,http://rpc-provider-15:8535/health,http://rpc-provider-16:8535/health,http://rpc-provider-17:8535/health,http://rpc-provider-18:8535/health,http://rpc-provider-19:8535/health
       - --
       - traefik
     command:
@@ -528,7 +813,22 @@ services:
             wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-1:8535/health ||
             wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-2:8535/health ||
             wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-3:8535/health ||
-            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-4:8535/health
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-4:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-5:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-6:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-7:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-8:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-9:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-10:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-11:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-12:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-13:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-14:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-15:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-16:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-17:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-18:8535/health ||
+            wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-19:8535/health
           )
       timeout: 12s
 

--- a/scripts/debug/sync-wallet-addresses.sh
+++ b/scripts/debug/sync-wallet-addresses.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# Sync wallet addresses from running kaswallet containers into .env
+# Queries kaswallet-0 through kaswallet-{count-1}, extracts the first address,
+# and updates W{N}_WALLET_TO_ADDRESS in the .env file.
+#
+# Usage: ./scripts/debug/sync-wallet-addresses.sh [count]
+#   count  Number of wallets to query, 1-20 (default: auto-detect running containers)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$PROJECT_DIR/.env"
+MAX_WORKERS=20
+
+# Check for required dependencies
+for cmd in docker jq; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo "Error: Required command '$cmd' not found" >&2
+        exit 1
+    fi
+done
+
+# Parse arguments
+WALLET_COUNT=""
+for arg in "$@"; do
+    case $arg in
+        [0-9]*)
+            if ! [[ "$arg" =~ ^[0-9]+$ ]]; then
+                echo "Error: count must be a positive integer, got '$arg'" >&2
+                exit 1
+            fi
+            WALLET_COUNT=$arg ;;
+        *) echo "Usage: $0 [count]" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -n "$WALLET_COUNT" ]] && { [[ "$WALLET_COUNT" -lt 1 ]] || [[ "$WALLET_COUNT" -gt "$MAX_WORKERS" ]]; }; then
+    echo "Error: count must be between 1 and $MAX_WORKERS" >&2
+    exit 1
+fi
+
+# Auto-detect running kaswallet containers if count not specified
+if [[ -z "$WALLET_COUNT" ]]; then
+    WALLET_COUNT=0
+    for i in $(seq 0 $((MAX_WORKERS - 1))); do
+        if docker inspect --format='{{.State.Running}}' "kaswallet-$i" 2>/dev/null | grep -q "true"; then
+            WALLET_COUNT=$((i + 1))
+        fi
+    done
+    if [[ "$WALLET_COUNT" -eq 0 ]]; then
+        echo "Error: No running kaswallet containers found" >&2
+        exit 1
+    fi
+    echo "Auto-detected running kaswallet containers (highest index: $((WALLET_COUNT - 1)), will query 0-$((WALLET_COUNT - 1)))"
+fi
+
+# Check .env file exists
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Error: .env file not found at $ENV_FILE" >&2
+    exit 1
+fi
+
+update_env_var() {
+    local file="$1"
+    local var="$2"
+    local value="$3"
+    local tmpfile
+
+    if grep -q "^${var}=" "$file"; then
+        tmpfile=$(mktemp) || { echo "Error: Failed to create temp file" >&2; return 1; }
+        chmod 600 "$tmpfile" || { rm -f "$tmpfile"; echo "Error: Failed to secure temp file" >&2; return 1; }
+
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == "${var}="* ]]; then
+                printf '%s=%s\n' "$var" "$value"
+            else
+                printf '%s\n' "$line"
+            fi
+        done < "$file" > "$tmpfile"
+
+        if ! mv "$tmpfile" "$file"; then
+            rm -f "$tmpfile"
+            echo "Error: Failed to update $file" >&2
+            return 1
+        fi
+    else
+        printf '%s=%s\n' "$var" "$value" >> "$file"
+    fi
+}
+
+updated=0
+failed=0
+skipped=0
+
+echo ""
+for i in $(seq 0 $((WALLET_COUNT - 1))); do
+    container="kaswallet-$i"
+    var_name="W${i}_WALLET_TO_ADDRESS"
+
+    # Check if container is running
+    if ! docker inspect --format='{{.State.Running}}' "$container" 2>/dev/null | grep -q "true"; then
+        echo "  SKIP  $container - not running"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Query wallet address
+    output=$(docker exec "$container" /app/kaswallet-cli address-balances 2>/dev/null) || {
+        echo "  FAIL  $container - failed to exec kaswallet-cli"
+        failed=$((failed + 1))
+        continue
+    }
+
+    # Extract first address, fall back to default_address if addresses array is empty
+    address=$(echo "$output" | jq -r '.addresses[0].address // .default_address // empty' 2>/dev/null) || {
+        echo "  FAIL  $container - failed to parse JSON output"
+        failed=$((failed + 1))
+        continue
+    }
+
+    if [[ -z "$address" ]]; then
+        echo "  FAIL  $container - no address found in output"
+        failed=$((failed + 1))
+        continue
+    fi
+
+    # Validate address format (kaspa/kaspatest/kaspadev prefix + bech32 chars)
+    if [[ ! "$address" =~ ^kaspa(test|dev)?:[a-z0-9]{50,80}$ ]]; then
+        echo "  FAIL  $container - unexpected address format: $address"
+        failed=$((failed + 1))
+        continue
+    fi
+
+    # Update .env
+    update_env_var "$ENV_FILE" "$var_name" "$address"
+    echo "  OK    $var_name=$address"
+    updated=$((updated + 1))
+done
+
+echo ""
+echo "Summary: $updated updated, $skipped skipped, $failed failed"
+
+if [[ "$updated" -gt 0 ]]; then
+    echo ""
+    echo "Wallet addresses have been written to $ENV_FILE"
+    echo "Restart workers to apply: docker compose --profile frontend-w<N> up -d"
+fi
+
+if [[ "$failed" -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/debug/wallet-status.sh
+++ b/scripts/debug/wallet-status.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Query all kaswallet containers (0-4) and output their status as JSON
+# Query running kaswallet containers and output their status as JSON
 # Requires: docker, jq
 # Usage: ./wallet-status.sh [count] [--debug]
+#   count  Number of wallets to query, 1-20 (default: auto-detect running containers)
 
 set -e
 
@@ -15,14 +16,40 @@ for cmd in docker jq; do
 done
 
 DEBUG=false
-WALLET_COUNT=5
+WALLET_COUNT=""
+MAX_WORKERS=20
 
 for arg in "$@"; do
     case $arg in
         --debug|-d) DEBUG=true ;;
-        [0-9]*) WALLET_COUNT=$arg ;;
+        [0-9]*)
+            if ! [[ "$arg" =~ ^[0-9]+$ ]]; then
+                echo "Error: count must be a positive integer, got '$arg'" >&2
+                exit 1
+            fi
+            WALLET_COUNT=$arg ;;
     esac
 done
+
+if [[ -n "$WALLET_COUNT" ]] && { [[ "$WALLET_COUNT" -lt 1 ]] || [[ "$WALLET_COUNT" -gt "$MAX_WORKERS" ]]; }; then
+    echo "Error: count must be between 1 and $MAX_WORKERS" >&2
+    exit 1
+fi
+
+# Auto-detect running kaswallet containers if count not specified
+if [[ -z "$WALLET_COUNT" ]]; then
+    WALLET_COUNT=0
+    for i in $(seq 0 $((MAX_WORKERS - 1))); do
+        if docker inspect --format='{{.State.Running}}' "kaswallet-$i" 2>/dev/null | grep -q "true"; then
+            WALLET_COUNT=$((i + 1))
+        fi
+    done
+    if [[ "$WALLET_COUNT" -eq 0 ]]; then
+        echo "Error: No running kaswallet containers found" >&2
+        exit 1
+    fi
+    echo "Auto-detected $WALLET_COUNT wallet(s) (querying kaswallet-0 through kaswallet-$((WALLET_COUNT - 1)))" >&2
+fi
 
 log_debug() {
     if $DEBUG; then
@@ -72,3 +99,11 @@ done
 
 # Output final JSON
 echo "$wallets_json" | jq '{wallets: .}'
+
+# Check for low-balance wallets (< 1 KAS)
+low_balance=$(echo "$wallets_json" | jq -r '.[] | select(.total.available_kas < 1) | "  WARNING: kaswallet-\(.index) balance is \(.total.available_kas) KAS"')
+if [[ -n "$low_balance" ]]; then
+    echo "" >&2
+    echo "Low balance wallets (< 1 KAS):" >&2
+    echo "$low_balance" >&2
+fi

--- a/scripts/lib/setup-common.sh
+++ b/scripts/lib/setup-common.sh
@@ -257,6 +257,7 @@ generate_wallet() {
     # Use expect to handle interactive password prompts
     # Pass password via environment variable to avoid command injection
     # Use --user to ensure files are created with correct ownership
+    # shellcheck disable=SC2016 # Variables are intentionally spliced via quote-breaking, not expanded inside single quotes
     if ! WALLET_PASS="$password" expect -c '
         log_user 0
         spawn docker run --rm -it --user '"$(id -u):$(id -g)"' \
@@ -378,7 +379,7 @@ print_summary() {
     echo "     - Get wallet addresses: ./scripts/debug/wallet-status.sh"
     echo "     - Top up each wallet address with KAS (for L1 gas fees)"
     echo "     - Update .env with the actual wallet addresses"
-    echo "  3. Restart workers: docker compose --profile frontend-w5 up -d"
+    echo "  3. Restart workers: docker compose --profile frontend-w${NUM_WORKERS} up -d"
     echo
 }
 
@@ -456,7 +457,8 @@ run_setup() {
     if [[ -f .env ]]; then
         log "Existing .env file found. It will be replaced with the template."
         if prompt_confirm "Do you want to backup the existing .env first?" "y"; then
-            local backup_file=".env.backup.$(date +%Y%m%d_%H%M%S)"
+            local backup_file
+            backup_file=".env.backup.$(date +%Y%m%d_%H%M%S)"
             cp .env "$backup_file"
             log "Backed up to $backup_file"
         fi
@@ -531,8 +533,11 @@ run_setup() {
         log "JWT secret already exists: keys/jwt.hex"
     fi
 
-    # Number of workers (fixed at 5)
-    NUM_WORKERS=5
+    # Number of workers (configurable via NUM_WORKERS env var, default: 5, max: 20)
+    NUM_WORKERS="${NUM_WORKERS:-5}"
+    if ! [[ "$NUM_WORKERS" =~ ^[0-9]+$ ]] || [[ "$NUM_WORKERS" -lt 1 ]] || [[ "$NUM_WORKERS" -gt 20 ]]; then
+        die "NUM_WORKERS must be a number between 1 and 20 (got: $NUM_WORKERS)"
+    fi
 
     # Check for existing wallet files
     EXISTING_WALLETS=()


### PR DESCRIPTION
## Summary
- Extend docker-compose.yml from 5 to 20 RPC/KasWallet worker pairs with profiles `frontend-w6` through `frontend-w20`
- Add `scripts/sync-wallet-addresses.sh` to auto-sync wallet addresses from running kaswallet containers into `.env`, replacing manual copy-paste workflow
- Make `NUM_WORKERS` configurable via environment variable in `setup-common.sh` with validation (1-20 range)

## Changes
- **docker-compose.yml**: 15 new worker pairs (rpc-provider-5 to rpc-provider-19, kaswallet-5 to kaswallet-19), updated traefik health checks for all 20 providers
- **scripts/sync-wallet-addresses.sh**: New script that queries running kaswallet containers, extracts wallet addresses, and updates `.env` automatically
- **scripts/lib/setup-common.sh**: `NUM_WORKERS` now reads from env var (default: 5, max: 20) with bounds validation
- **README.md**: Updated profile documentation, worker ranges, and added sync script usage

## Test plan
- [ ] `docker compose --profile frontend-w20 config --services | wc -l` returns 41 (20 rpc + 20 kaswallet + traefik)
- [ ] `docker compose --profile frontend-w5 config --services | wc -l` returns 11 (unchanged)
- [ ] `docker compose --profile frontend-w10 config --services | wc -l` returns 21
- [ ] `NUM_WORKERS=20 ./scripts/setup-mainnet.sh` generates 20 wallet key files
- [ ] `./scripts/sync-wallet-addresses.sh` correctly syncs addresses from running containers
- [ ] `NUM_WORKERS=25` is rejected with validation error