### PR TITLE
[ENG-1009] feat: add wallet balance API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,55 @@ The Docker Compose configuration uses profiles and YAML anchors for improved mai
 - **ATAN Uploader** (profile: `atan-uploader`):
   - `atan-uploader` - Uploads ATAN chain data to S3 and maintains index
 
+- **Wallet Balance API** (profile: `wallet-api`):
+  - `wallet-balance-api` - HTTP endpoint that returns live wallet balances as JSON
+
+## Wallet Balance API
+
+The `wallet-api` profile starts a lightweight HTTP service that queries all running kaswallet containers and returns their addresses and balances as JSON. It is exposed through Traefik with HTTPS and BasicAuth protection.
+
+### Setup
+
+1. Generate BasicAuth credentials (requires `htpasswd` -- from `apache2-utils` on Debian/Ubuntu or `httpd` on macOS via Homebrew):
+    ```bash
+    htpasswd -nb admin your-secure-password | sed 's/\$/\$\$/g'
+    ```
+    The `sed` command escapes `$` to `$$` which is required for Docker Compose environment variable interpolation.
+
+2. Add the output to your `.env` file as `WALLET_API_BASICAUTH` (do not wrap the value in quotes):
+    ```bash
+    WALLET_API_BASICAUTH=admin:$$apr1$$...
+    ```
+
+3. Start the service:
+    ```bash
+    docker compose --profile wallet-api up -d
+    ```
+
+4. Query wallet balances:
+    ```bash
+    curl -u admin:your-secure-password https://your-domain/internal/wallets
+    ```
+
+### Response Format
+
+```json
+{
+  "wallets": [
+    {
+      "index": 0,
+      "default_address": "kaspatest:qpt9pq...",
+      "total": {
+        "available_sompi": 93156363183,
+        "available_kas": 931.56363183,
+        "pending_sompi": 0,
+        "pending_kas": 0
+      }
+    }
+  ]
+}
+```
+
 ## Configuration
 
 This project uses a `.env` file to manage environment variables. A `.env.dev.example` file is provided with defaults.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -797,9 +797,10 @@ services:
       - "traefik.http.routers.web-redirect.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
       - "traefik.http.routers.web-redirect.entrypoints=web"
       - "traefik.http.routers.web-redirect.middlewares=redirect-to-https"
-      # Define a router for websecure (HTTPS)
+      # Define a router for websecure (HTTPS) — low priority so specific path routers win
       - "traefik.http.routers.websecure-router.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
       - "traefik.http.routers.websecure-router.entrypoints=websecure"
+      - "traefik.http.routers.websecure-router.priority=1"
       - "traefik.http.routers.websecure-router.tls=true"
       - "traefik.http.routers.websecure-router.tls.certresolver=myresolver"
     healthcheck:
@@ -831,6 +832,43 @@ services:
             wget --quiet --spider --tries=1 --timeout=2 http://rpc-provider-19:8535/health
           )
       timeout: 12s
+
+  # Wallet Balance API
+  wallet-balance-api:
+    <<: *default-service
+    image: docker:27-cli
+    profiles: ["wallet-api"]
+    container_name: wallet-balance-api
+    restart: *service-restart-policy
+    environment:
+      - WALLET_API_BASICAUTH
+    entrypoint: ["sh", "/app/serve.sh"]
+    volumes:
+      # Docker socket for querying kaswallet containers (same pattern as Traefik).
+      # Protected by Traefik BasicAuth + rate limiting.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./scripts/wallet-balance-api.sh:/app/serve.sh:ro
+    expose:
+      - "8090"
+    networks:
+      - igra-network
+      - traefik-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wallet-api.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`) && Path(`/internal/wallets`)"
+      - "traefik.http.routers.wallet-api.priority=200"
+      - "traefik.http.routers.wallet-api.entrypoints=websecure"
+      - "traefik.http.routers.wallet-api.tls=true"
+      - "traefik.http.routers.wallet-api.tls.certresolver=myresolver"
+      - "traefik.http.routers.wallet-api.middlewares=wallet-ratelimit,wallet-auth"
+      - "traefik.http.middlewares.wallet-ratelimit.ratelimit.average=5"
+      - "traefik.http.middlewares.wallet-ratelimit.ratelimit.period=10s"
+      - "traefik.http.middlewares.wallet-ratelimit.ratelimit.burst=10"
+      - "traefik.http.middlewares.wallet-auth.basicauth.users=${WALLET_API_BASICAUTH}"
+      - "traefik.http.services.wallet-api.loadbalancer.server.port=8090"
+    # Note: no healthcheck — Traefik filters containers with failing/starting healthchecks,
+    # and the apk install at startup delays socat readiness. Traefik will route to this
+    # container as soon as it's running. The /health endpoint is still available internally.
 
   # Miscellaneous Services
   kaspa-miner:

--- a/scripts/wallet-balance-api.sh
+++ b/scripts/wallet-balance-api.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# shellcheck shell=sh
+# Note: runs in BusyBox ash which supports read -t (non-POSIX but available)
+
+# Wallet Balance API — lightweight HTTP server that returns kaswallet balances as JSON.
+# Runs inside a docker:cli (Alpine) container with the Docker socket mounted.
+# Dependencies: jq, socat (installed at startup via apk).
+#
+# When invoked without arguments: installs deps and starts socat listener on port 8090.
+# When invoked with --handle: acts as the per-connection HTTP handler (called by socat).
+
+set -eu
+
+MAX_WORKERS=20
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+send_response() {
+  status_code="$1"
+  status_text="$2"
+  body="$3"
+  content_length=$(printf '%s' "$body" | wc -c | tr -d ' ')
+  printf "HTTP/1.1 %s %s\r\n" "$status_code" "$status_text"
+  printf "Content-Type: application/json\r\n"
+  printf "Content-Length: %d\r\n" "$content_length"
+  printf "Connection: close\r\n"
+  printf "\r\n"
+  printf '%s' "$body"
+}
+
+# ── Wallet query (reuses jq pattern from scripts/debug/wallet-status.sh) ─────
+
+query_wallets() {
+  # Pre-fetch running kaswallet containers in a single Docker API call
+  running=$(docker ps --filter "name=^kaswallet-" --filter "status=running" --format '{{.Names}}' 2>&1) || {
+    printf '{"error":"docker unavailable: %s"}' "$running"
+    return 1
+  }
+
+  # Early return if no wallets are running
+  if [ -z "$running" ]; then
+    printf '{"wallets":[]}'
+    return
+  fi
+
+  # Collect wallet JSON objects into a temp file, then merge in one jq call
+  tmpfile=$(mktemp)
+  for i in $(seq 0 $((MAX_WORKERS - 1))); do
+    container="kaswallet-$i"
+
+    # Skip containers that are not running
+    echo "$running" | grep -qx "$container" || continue
+
+    output=$(docker exec "$container" /app/kaswallet-cli address-balances 2>/dev/null) || continue
+
+    printf '%s' "$output" | jq --argjson index "$i" '{
+      index: $index,
+      default_address: .default_address,
+      total: {
+        available_sompi: .total_available,
+        available_kas: (.total_available / 100000000),
+        pending_sompi: .total_pending,
+        pending_kas: (.total_pending / 100000000)
+      }
+    }' 2>/dev/null >> "$tmpfile" || continue
+  done
+
+  jq -s '{wallets: .}' "$tmpfile"
+  rm -f "$tmpfile"
+}
+
+# ── Per-connection handler mode ───────────────────────────────────────────────
+
+if [ "${1:-}" = "--handle" ]; then
+  # Read the HTTP request line (5s timeout to avoid blocking on misbehaving clients)
+  if ! read -r -t 5 method path _version; then
+    send_response 408 "Request Timeout" '{"error":"request timeout"}'
+    exit 0
+  fi
+
+  # Trim trailing carriage return
+  method=$(printf '%s' "$method" | tr -d '\r')
+  path=$(printf '%s' "$path" | tr -d '\r')
+
+  # Reject paths with unsafe characters (defense-in-depth)
+  case "$path" in
+    *[!a-zA-Z0-9/_-.]*)
+      send_response 400 "Bad Request" '{"error":"invalid path"}'
+      exit 0
+      ;;
+  esac
+
+  # Consume remaining headers (read until empty line)
+  while read -r -t 5 header; do
+    header=$(printf '%s' "$header" | tr -d '\r')
+    [ -z "$header" ] && break
+  done
+
+  case "$method $path" in
+    "GET /health")
+      send_response 200 "OK" '{"status":"ok"}'
+      ;;
+    "GET /internal/wallets")
+      if body=$(query_wallets); then
+        send_response 200 "OK" "$body"
+      else
+        send_response 503 "Service Unavailable" "$body"
+      fi
+      ;;
+    *)
+      send_response 404 "Not Found" '{"error":"not found"}'
+      ;;
+  esac
+
+  exit 0
+fi
+
+# ── Server startup mode (default) ────────────────────────────────────────────
+
+# Fail-fast: require BasicAuth env var (used by Traefik for endpoint protection)
+if [ -z "${WALLET_API_BASICAUTH:-}" ]; then
+  echo "ERROR: WALLET_API_BASICAUTH is not set." >&2
+  echo "  This variable is required by Traefik for BasicAuth on /internal/wallets." >&2
+  echo "  Generate it with: htpasswd -nb admin YOUR_PASSWORD | sed 's/\$/\$\$/g'" >&2
+  exit 1
+fi
+
+# Install runtime dependencies
+apk add --no-cache jq socat >/dev/null || { echo "ERROR: failed to install dependencies (jq, socat)" >&2; exit 1; }
+
+echo "Wallet Balance API listening on port 8090..."
+exec socat TCP-LISTEN:8090,reuseaddr,fork,max-children=10 SYSTEM:"sh /app/serve.sh --handle"


### PR DESCRIPTION
## Summary
- Add authenticated HTTP endpoint returning live kaswallet addresses and balances as JSON
- New opt-in Docker Compose profile `wallet-api` using `docker:cli` image with Docker socket access
- Protected by Traefik HTTPS + BasicAuth + rate limiting (5 req/10s)

## Changes
- **scripts/wallet-balance-api.sh**: Shell-based HTTP handler using socat, queries running kaswallet containers via `docker exec`, returns JSON with wallet index, default_address, and balance totals
- **docker-compose.yml**: New `wallet-balance-api` service with `wallet-api` profile, Traefik labels for routing/auth/rate-limiting, Docker socket mount, and health check
- **README.md**: Documentation for wallet-api profile setup (htpasswd generation, .env config, curl usage)

## Test plan
- [ ] Set `WALLET_API_BASICAUTH` in `.env` via `htpasswd -nb admin password | sed 's/$/\$\$/g'`
- [ ] `docker compose --profile wallet-api up -d` starts the service
- [ ] `curl -u admin:password https://domain/internal/wallets` returns JSON with wallet balances
- [ ] `curl https://domain/internal/wallets` returns 401 Unauthorized
- [ ] Service without `WALLET_API_BASICAUTH` exits with clear error message
- [ ] Rate limiting kicks in after rapid requests (429 Too Many Requests)