### PR TITLE
[ENG-0] fix(setup): network-specific versions for prebuilt image pulls

### DIFF
--- a/scripts/dev/setup-repos.sh
+++ b/scripts/dev/setup-repos.sh
@@ -201,15 +201,31 @@ if [[ "$USE_PREBUILT_IMAGES" == "true" ]]; then
     log ""
     log "Pulling pre-built images from Docker Hub..."
 
-    # Source image versions
-    if [[ -f "$PROJECT_DIR/versions.mainnet.env" ]]; then
+    # Pick the same version file docker-compose and the deployment guides use per network.
+    # Without this, testnet (Galleon) users still pulled mainnet-pinned tags if those files diverge.
+    network="${NETWORK:-mainnet}"
+    case "$network" in
+        mainnet)
+            versions_file="$PROJECT_DIR/versions.mainnet.env"
+            ;;
+        testnet)
+            versions_file="$PROJECT_DIR/versions.testnet.env"
+            ;;
+        *)
+            log "NETWORK=$network is not mainnet or testnet; using versions.mainnet.env for image pulls"
+            versions_file="$PROJECT_DIR/versions.mainnet.env"
+            ;;
+    esac
+
+    if [[ -f "$versions_file" ]]; then
+        log "Sourcing image versions from $(basename "$versions_file") (NETWORK=$network)"
         # shellcheck source=/dev/null
-        source "$PROJECT_DIR/versions.mainnet.env"
+        source "$versions_file"
     else
-        panic "versions.mainnet.env not found in $PROJECT_DIR"
+        panic "Version file not found: $versions_file (NETWORK=$network)"
     fi
 
-    # Pull and tag images (versions from versions.mainnet.env)
+    # Pull and tag images (versions from the selected versions.*.env)
     # Format: "image_name:version:local_tag"
     images=(
         "kaspad:${KASPAD_VERSION}:kaspad"


### PR DESCRIPTION
## what changed

when \USE_PREBUILT_IMAGES=true\, \setup-repos.sh\ always sourced \ersions.mainnet.env\ before pulling and tagging docker images. galleon testnet (and any \NETWORK=testnet\ prebuilt flow) is documented to use \ersions.testnet.env\ instead. if those files ever diverge, testnet operators would pull the wrong tags.

this change maps \NETWORK=mainnet\ → \ersions.mainnet.env\, \NETWORK=testnet\ → \ersions.testnet.env\, with a safe default and a log line for unknown \NETWORK\ values.

## testing

- shell syntax checked with git bash \ash -n\

---

made by mooncitydev
