### PR TITLE
[ENG-1015] chore: change RPC_READ_ONLY default to false

### DIFF
--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -72,7 +72,7 @@ KASPAD_ADD_PEER=65.109.78.124
 # --- RPC Configuration ---
 # Set to true for read-only RPC (no transaction submission)
 # Set to false if you want to accept and submit user transactions (requires funded wallets)
-RPC_READ_ONLY=true
+RPC_READ_ONLY=false
 
 # --- Node Settings ---
 NODE_ID=GTN-<your-unique-node-name>

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -65,7 +65,7 @@ KASPAD_JSON_PORT=18110
 # --- RPC Configuration ---
 # Set to true for read-only RPC (no transaction submission)
 # Set to false if you want to accept and submit user transactions (requires funded wallets)
-RPC_READ_ONLY=true
+RPC_READ_ONLY=false
 
 # --- Node Settings ---
 NODE_ID=MN-<your-unique-node-name>

--- a/doc/node-operations.md
+++ b/doc/node-operations.md
@@ -166,4 +166,4 @@ All operational variables across the stack:
 | `RPC_WALLET_AUTH_{i}` | health-check `.env` | BasicAuth user:pass to query node's wallet API |
 | `RPC_MIN_BALANCE_KAS_{i}` | health-check `.env` | Min wallet balance threshold in KAS (default: 1.0) |
 | `SLACK_WEBHOOK_URL` | health-check `.env` | Slack webhook for alerts including low-balance warnings |
-| `RPC_READ_ONLY` | orchestra `.env` | Set to `false` to enable transaction submission via RPC |
+| `RPC_READ_ONLY` | orchestra `.env` | Transaction submission enabled by default (`false`); set to `true` for read-only RPC |

--- a/doc/quick-setup-galleon-testnet.md
+++ b/doc/quick-setup-galleon-testnet.md
@@ -241,12 +241,13 @@ docker compose logs -f node-health-check-client
 
 ## Optional: Enable RPC Transaction Submission
 
-By default, the RPC is configured as **read-only** (`RPC_READ_ONLY=true`). This means it can query blockchain state but cannot submit transactions.
+By default, the RPC is configured to **accept transactions** (`RPC_READ_ONLY=false`). This means it can both query blockchain state and submit transactions.
 
-If you want to use this node as an RPC endpoint that accepts transactions from users:
+If you want to use this node as a read-only RPC endpoint (no transaction submission), set `RPC_READ_ONLY=true` in your `.env` file.
 
-1. Set `RPC_READ_ONLY=false` in your `.env` file
-2. Top up the 5 kaswallets with KAS (you will pay for L1 gas fees)
+To enable transaction submission, you need to fund the wallets:
+
+1. Top up the 5 kaswallets with KAS (you will pay for L1 gas fees)
 
 After IBD sync completes (IBD: 100%):
 

--- a/doc/quick-setup-mainnet.md
+++ b/doc/quick-setup-mainnet.md
@@ -206,12 +206,13 @@ docker compose logs -f node-health-check-client
 
 ## Optional: Enable RPC Transaction Submission
 
-By default, the RPC is configured as **read-only** (`RPC_READ_ONLY=true`). This means it can query blockchain state but cannot submit transactions.
+By default, the RPC is configured to **accept transactions** (`RPC_READ_ONLY=false`). This means it can both query blockchain state and submit transactions.
 
-If you want to use this node as an RPC endpoint that accepts transactions from users:
+If you want to use this node as a read-only RPC endpoint (no transaction submission), set `RPC_READ_ONLY=true` in your `.env` file.
 
-1. Set `RPC_READ_ONLY=false` in your `.env` file
-2. Top up the 5 kaswallets with KAS (you will pay for L1 gas fees)
+To enable transaction submission, you need to fund the wallets:
+
+1. Top up the 5 kaswallets with KAS (you will pay for L1 gas fees)
 
 After IBD sync completes (IBD: 100%):
 

--- a/scripts/lib/setup-common.sh
+++ b/scripts/lib/setup-common.sh
@@ -371,11 +371,10 @@ print_summary() {
     echo
     echo "=== Optional: Enable Transaction Submission (RPC) ==="
     echo
-    echo "By default, RPC is read-only (RPC_READ_ONLY=true)."
-    echo "If you want to accept and submit user transactions:"
+    echo "By default, RPC accepts transactions (RPC_READ_ONLY=false)."
+    echo "To enable transaction submission, fund the wallets:"
     echo
-    echo "  1. Set RPC_READ_ONLY=false in .env"
-    echo "  2. After IBD sync completes (IBD: 100%):"
+    echo "  1. After IBD sync completes (IBD: 100%):"
     echo "     - Get wallet addresses: ./scripts/debug/wallet-status.sh"
     echo "     - Top up each wallet address with KAS (for L1 gas fees)"
     echo "     - Update .env with the actual wallet addresses"


### PR DESCRIPTION
## Summary
- Change `RPC_READ_ONLY` default from `true` to `false` in `.env.mainnet.example` and `.env.galleon-testnet.example`
- Update quick-setup guides, node-operations docs, and setup script messages to reflect the new default

## Test plan
- [ ] Verify `.env.mainnet.example` has `RPC_READ_ONLY=false`
- [ ] Verify `.env.galleon-testnet.example` has `RPC_READ_ONLY=false`
- [ ] Verify documentation accurately describes the new default behavior
- [ ] Confirm `docker-compose.yml` still reads `RPC_READ_ONLY` from env correctly