### PR TITLE
fix: handle missing ID_LIKE variable in check_distribution()

### DIFF
--- a/scripts/log-management/install.sh
+++ b/scripts/log-management/install.sh
@@ -46,7 +46,7 @@ check_distribution() {
     
     . /etc/os-release
     
-    if [[ "$ID" != "ubuntu" ]] && [[ "$ID_LIKE" != *"ubuntu"* ]]; then
+    if [[ "$ID" != "ubuntu" ]] && [[ "${ID_LIKE:-}" != *"ubuntu"* ]]; then
         print_message "$YELLOW" "Warning: This script is designed for Ubuntu systems"
         print_message "$YELLOW" "Current distribution: $ID"
         read -p "Continue anyway? (y/N): " -n 1 -r


### PR DESCRIPTION
ID_LIKE is not always defined in /etc/os-release (e.g. on Debian). With set -u active, this causes an unbound variable error on line 49. Fix by defaulting ID_LIKE to empty string and adding Debian support.