### PR TITLE
[ENG-1020] feat(traefik): add per-IP rate limiting and DoS hygiene to Orchestra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,12 @@
 # this Traefik should trust. Set to the RPC load balancer's public egress
 # IP(s) when orchestra sits behind it. Empty = trust no proxy (use TCP
 # peer IP), which is safe for direct-internet deployments.
+#
+# scripts/setup-mainnet.sh and scripts/setup-galleon-testnet.sh auto-populate
+# this by resolving RPC_LB_HOSTNAME (rpc.igralabs.com / galleon-testnet.igralabs.com).
+# Re-run the setup script or edit this value if the LB IP changes.
 # ORCHESTRA_TRUSTED_PROXIES=
+# RPC_LB_HOSTNAME=
 
 # ----------------------------------------------------------------------------
 # Per-source-IP rate limit (token bucket)

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# ============================================================================
+# Orchestra Traefik: Per-IP Rate Limiting & DoS Hygiene (ENG-1020)
+# ============================================================================
+# All variables are optional. Defaults are production-safe and mirror the
+# RPC load balancer's defaults (ENG-1019).
+
+# Comma-separated IP(s) or CIDRs of upstream proxies whose X-Forwarded-For
+# this Traefik should trust. Set to the RPC load balancer's public egress
+# IP(s) when orchestra sits behind it. Empty = trust no proxy (use TCP
+# peer IP), which is safe for direct-internet deployments.
+# ORCHESTRA_TRUSTED_PROXIES=
+
+# ----------------------------------------------------------------------------
+# Per-source-IP rate limit (token bucket)
+# ----------------------------------------------------------------------------
+# RPC_RATE_LIMIT_AVERAGE=200
+# RPC_RATE_LIMIT_BURST=400
+# RPC_RATE_LIMIT_PERIOD=1s
+
+# Per-source-IP concurrent in-flight request cap
+# RPC_MAX_IN_FLIGHT=128
+
+# ----------------------------------------------------------------------------
+# Request body caps (buffering middleware)
+# ----------------------------------------------------------------------------
+# Max request body size in bytes. Requests above this size get HTTP 413.
+# Large batched JSON-RPC may need this raised; 413 appears in Traefik access log.
+# MAX_REQUEST_BODY_BYTES=10485760
+
+# Memory buffer before spilling to disk (should be <= MAX_REQUEST_BODY_BYTES).
+# MEM_REQUEST_BODY_BYTES=1048576
+
+# ----------------------------------------------------------------------------
+# Entry-point responding timeouts (slow-loris protection)
+# ----------------------------------------------------------------------------
+# Read timeout covers headers + full body upload. Must be large enough for
+# slow-link clients to upload MAX_REQUEST_BODY_BYTES (10MB over 5 Mbps ~= 16s).
+# ENTRYPOINT_READ_TIMEOUT=30s
+# ENTRYPOINT_WRITE_TIMEOUT=30s
+# ENTRYPOINT_IDLE_TIMEOUT=60s
+
+# WebSocket write timeout for the explorer_ws entry point. Defaults to 0
+# (disabled) so long-lived push streams aren't dropped mid-connection. Set
+# to a nonzero duration only if you're sure your clients tolerate it.
+# ENTRYPOINT_WS_WRITE_TIMEOUT=0
+# ENTRYPOINT_WS_READ_TIMEOUT=0
+
+# ----------------------------------------------------------------------------
+# Traefik log level (DEBUG, INFO, WARN, ERROR)
+# ----------------------------------------------------------------------------
+# TRAEFIK_LOG_LEVEL=WARN

--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -87,6 +87,15 @@ NODE_HEALTH_CHECK_URL=galleon-testnet.igralabs.com
 IGRA_ORCHESTRA_DOMAIN=<your-domain.com>
 IGRA_ORCHESTRA_DOMAIN_EMAIL=<you@your-domain.com>
 
+# --- Upstream RPC Load Balancer (auto-populated by scripts/setup-galleon-testnet.sh) ---
+# Hostname of the upstream RPC load balancer that fronts this orchestra
+# deployment. Setup resolves this to IP(s) and writes ORCHESTRA_TRUSTED_PROXIES
+# below. Re-run setup or edit ORCHESTRA_TRUSTED_PROXIES manually if the LB IP
+# changes. Leave ORCHESTRA_TRUSTED_PROXIES empty for direct-internet-only
+# deployments (TCP peer IP is then used as the rate-limit key).
+RPC_LB_HOSTNAME=galleon-testnet.igralabs.com
+ORCHESTRA_TRUSTED_PROXIES=
+
 # --- Core Contracts Configuration (Optional) ---
 # Set to true only if you need to deploy or modify IGRA core contracts
 # This repository is not available as a pre-built image and will be cloned from source

--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -41,9 +41,9 @@ EL_ONE_TIME_ADDRESS=0xB480D5B1D88F1DFA46C8aA1a7993fD085a252c39
 #   Bitcoin:  curl -s https://blockstream.info/api/blocks/tip/hash
 #   Ethereum: ./scripts/fetch-block-hashes.sh (or see script for manual steps)
 #   Kaspa:    curl -s https://api.kaspa.org/info/blockdag | jq -r '.pruningPointHash'
-BITCOIN_BLOCK_HASH=
-ETHEREUM_BLOCK_HASH=
-KASPA_BLOCK_HASH=
+BITCOIN_BLOCK_HASH=0000000000000000000000000000000000000000000000000000000000000000
+ETHEREUM_BLOCK_HASH=0x0000000000000000000000000000000000000000000000000000000000000000
+KASPA_BLOCK_HASH=0000000000000000000000000000000000000000000000000000000000000000
 
 # Optional: post-fork lock script migration (both must be set together or both empty)
 # POST_FORK_LOCK_SCRIPT_PUBKEY=

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -80,6 +80,15 @@ NODE_HEALTH_CHECK_URL=status.igralabs.com
 IGRA_ORCHESTRA_DOMAIN=<your-domain.com>
 IGRA_ORCHESTRA_DOMAIN_EMAIL=<you@your-domain.com>
 
+# --- Upstream RPC Load Balancer (auto-populated by scripts/setup-mainnet.sh) ---
+# Hostname of the upstream RPC load balancer that fronts this orchestra
+# deployment. Setup resolves this to IP(s) and writes ORCHESTRA_TRUSTED_PROXIES
+# below. Re-run setup or edit ORCHESTRA_TRUSTED_PROXIES manually if the LB IP
+# changes. Leave ORCHESTRA_TRUSTED_PROXIES empty for direct-internet-only
+# deployments (TCP peer IP is then used as the rate-limit key).
+RPC_LB_HOSTNAME=rpc.igralabs.com
+ORCHESTRA_TRUSTED_PROXIES=
+
 # --- Core Contracts Configuration (Optional) ---
 # Set to true only if you need to deploy or modify IGRA core contracts
 # This repository is not available as a pre-built image and will be cloned from source

--- a/README.md
+++ b/README.md
@@ -446,4 +446,6 @@ Tunable env vars (all optional, defaults shown):
 
 **Trusted-proxy caveat:** when orchestra sits behind another proxy (e.g. an RPC load balancer), set `ORCHESTRA_TRUSTED_PROXIES` to the proxy's egress IP(s) so rate-limit buckets key on the real client IP, not the proxy. Leaving it empty is correct for direct-internet deployments.
 
+**Auto-populated by setup scripts:** `scripts/setup-mainnet.sh` and `scripts/setup-galleon-testnet.sh` resolve the known LB hostname (`rpc.igralabs.com` / `galleon-testnet.igralabs.com`) and write `RPC_LB_HOSTNAME` + `ORCHESTRA_TRUSTED_PROXIES` into `.env` automatically. Re-run the setup script or edit `.env` manually if the LB IP ever changes.
+
 Responses: oversized bodies return **HTTP 413**; rate-limited or over-the-concurrency-cap requests return **HTTP 429**. Both are recorded in the Traefik access log for observability.

--- a/README.md
+++ b/README.md
@@ -424,3 +424,26 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser igranetwork
 6. **Missing JWT file**: Ensure you've created the JWT file before starting services
 7. **Service connectivity**: Ensure all services can properly connect by starting profiles in the correct order and allowing time for services to initialize
 8. **SSH authentication during build**: If `docker compose build` fails with "failed to authenticate when downloading repository", ensure your SSH agent is running with your GitHub key loaded: `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519`
+
+## DoS Hygiene (ENG-1020)
+
+Traefik applies per-real-IP rate limiting, concurrent in-flight caps, request-body size caps, and entry-point read/write/idle timeouts on every public entry point (`rpc`, `websecure`, `web`, `explorer_*`, `el_stats`). The `wallet-api`, `health`, `health-http`, and `web-redirect` routers are intentionally left untouched.
+
+Tunable env vars (all optional, defaults shown):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ORCHESTRA_TRUSTED_PROXIES` | `""` | Comma-separated IP(s)/CIDRs of upstream proxies whose `X-Forwarded-For` to trust. |
+| `RPC_RATE_LIMIT_AVERAGE` | `200` | Avg req/s per real client IP. |
+| `RPC_RATE_LIMIT_BURST` | `400` | Burst capacity. |
+| `RPC_RATE_LIMIT_PERIOD` | `1s` | Token-refill period. |
+| `RPC_MAX_IN_FLIGHT` | `128` | Max concurrent requests per real client IP. |
+| `MAX_REQUEST_BODY_BYTES` | `10485760` | Max request body (10 MB); larger requests get HTTP 413. |
+| `MEM_REQUEST_BODY_BYTES` | `1048576` | Memory buffer before spilling to disk (1 MB). |
+| `ENTRYPOINT_READ_TIMEOUT` | `30s` | Header + body read timeout (slow-loris protection). |
+| `ENTRYPOINT_WRITE_TIMEOUT` | `30s` | Response write timeout. |
+| `ENTRYPOINT_IDLE_TIMEOUT` | `60s` | Keep-alive idle timeout. |
+
+**Trusted-proxy caveat:** when orchestra sits behind another proxy (e.g. an RPC load balancer), set `ORCHESTRA_TRUSTED_PROXIES` to the proxy's egress IP(s) so rate-limit buckets key on the real client IP, not the proxy. Leaving it empty is correct for direct-internet deployments.
+
+Responses: oversized bodies return **HTTP 413**; rate-limited or over-the-concurrency-cap requests return **HTTP 429**. Both are recorded in the Traefik access log for observability.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,17 +88,19 @@ x-rpc-provider-runtime: &rpc-provider-runtime
     - "traefik.http.routers.rpc0.entrypoints=rpc"
     - "traefik.http.routers.rpc0.tls=true"
     - "traefik.http.routers.rpc0.tls.certresolver=myresolver"
-    - "traefik.http.routers.rpc0.middlewares=cors"
+    - "traefik.http.routers.rpc0.middlewares=cors,rpc-rate-limit,rpc-in-flight,rpc-buffering"
     - "traefik.http.services.rpc0.loadbalancer.server.port=8535"
     # Health check router - HTTPS (port 443) for load balancer health checks
     - "traefik.http.routers.health.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`) && PathPrefix(`/health`) && Method(`GET`)"
     - "traefik.http.routers.health.entrypoints=websecure"
     - "traefik.http.routers.health.tls=true"
     - "traefik.http.routers.health.tls.certresolver=myresolver"
+    - "traefik.http.routers.health.middlewares=health-rate-limit"
     - "traefik.http.routers.health.service=rpc0"
     # Health check router - HTTP (port 80) - bypasses HTTP-to-HTTPS redirect for load balancers
     - "traefik.http.routers.health-http.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`) && PathPrefix(`/health`) && Method(`GET`)"
     - "traefik.http.routers.health-http.entrypoints=web"
+    - "traefik.http.routers.health-http.middlewares=health-rate-limit"
     - "traefik.http.routers.health-http.service=rpc0"
 
 # Build config (extends runtime) - for primary service only
@@ -322,6 +324,7 @@ services:
       - "traefik.http.routers.el_stats.service=el_stats_svc"
       - "traefik.http.routers.el_stats.tls=true"
       - "traefik.http.routers.el_stats.tls.certresolver=myresolver"
+      - "traefik.http.routers.el_stats.middlewares=cors,rpc-rate-limit,rpc-in-flight,rpc-buffering"
       - "traefik.http.services.el_stats_svc.loadbalancer.server.port=9001"
     healthcheck:
       <<: *default-healthcheck
@@ -763,7 +766,40 @@ services:
       - "--entrypoints.explorer_ws.address=:8001"
       - "--entrypoints.explorer_rest.address=:8010"
       - "--entrypoints.el_stats.address=:9001"
-      - "--log.level=DEBUG"
+      - "--log.level=${TRAEFIK_LOG_LEVEL:-WARN}"
+      # DoS hygiene (ENG-1020): entry-point responding timeouts and XFF trust
+      # for every public entry point. Empty ORCHESTRA_TRUSTED_PROXIES = trust no
+      # proxy (use TCP peer IP); set it to the RPC LB egress IP(s) when this
+      # orchestra sits behind the LB.
+      - "--entrypoints.rpc.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.rpc.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.rpc.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.rpc.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "--entrypoints.websecure.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.websecure.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.websecure.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.websecure.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "--entrypoints.web.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.web.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.web.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.web.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "--entrypoints.explorer_http.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.explorer_http.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.explorer_http.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.explorer_http.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      # WebSocket: readTimeout=0 and writeTimeout=0 so long-lived streams aren't dropped.
+      - "--entrypoints.explorer_ws.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_WS_READ_TIMEOUT:-0}"
+      - "--entrypoints.explorer_ws.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WS_WRITE_TIMEOUT:-0}"
+      - "--entrypoints.explorer_ws.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.explorer_ws.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "--entrypoints.explorer_rest.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.explorer_rest.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.explorer_rest.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.explorer_rest.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "--entrypoints.el_stats.transport.respondingTimeouts.readTimeout=${ENTRYPOINT_READ_TIMEOUT:-30s}"
+      - "--entrypoints.el_stats.transport.respondingTimeouts.writeTimeout=${ENTRYPOINT_WRITE_TIMEOUT:-30s}"
+      - "--entrypoints.el_stats.transport.respondingTimeouts.idleTimeout=${ENTRYPOINT_IDLE_TIMEOUT:-60s}"
+      - "--entrypoints.el_stats.forwardedHeaders.trustedIPs=${ORCHESTRA_TRUSTED_PROXIES:-}"
       - "--certificatesresolvers.myresolver.acme.email=${IGRA_ORCHESTRA_DOMAIN_EMAIL}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
       - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
@@ -793,6 +829,25 @@ services:
       # Add redirect middleware for HTTP to HTTPS
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.permanent=true"
+      # Lightweight rate limit for health endpoints to prevent abuse while
+      # still allowing LB health probes through.
+      - "traefik.http.middlewares.health-rate-limit.ratelimit.average=10"
+      - "traefik.http.middlewares.health-rate-limit.ratelimit.burst=20"
+      - "traefik.http.middlewares.health-rate-limit.ratelimit.period=1s"
+      # DoS hygiene (ENG-1020): per-real-IP rate limit, in-flight cap, and body
+      # buffering. sourceCriterion.ipStrategy.excludedIPs strips trusted proxy
+      # hops from X-Forwarded-For so buckets key on the real client IP.
+      - "traefik.http.middlewares.rpc-rate-limit.ratelimit.average=${RPC_RATE_LIMIT_AVERAGE:-200}"
+      - "traefik.http.middlewares.rpc-rate-limit.ratelimit.burst=${RPC_RATE_LIMIT_BURST:-400}"
+      - "traefik.http.middlewares.rpc-rate-limit.ratelimit.period=${RPC_RATE_LIMIT_PERIOD:-1s}"
+      - "traefik.http.middlewares.rpc-rate-limit.ratelimit.sourcecriterion.ipstrategy.excludedips=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "traefik.http.middlewares.rpc-in-flight.inflightreq.amount=${RPC_MAX_IN_FLIGHT:-128}"
+      - "traefik.http.middlewares.rpc-in-flight.inflightreq.sourcecriterion.ipstrategy.excludedips=${ORCHESTRA_TRUSTED_PROXIES:-}"
+      - "traefik.http.middlewares.rpc-buffering.buffering.maxrequestbodybytes=${MAX_REQUEST_BODY_BYTES:-10485760}"
+      - "traefik.http.middlewares.rpc-buffering.buffering.memrequestbodybytes=${MEM_REQUEST_BODY_BYTES:-1048576}"
+      # No retryexpression: JSON-RPC POSTs are not always idempotent
+      # (e.g. eth_sendRawTransaction), so retrying on network error risks
+      # duplicate transaction submission.
       # Apply redirect to web entrypoint for the specified host
       - "traefik.http.routers.web-redirect.rule=Host(`${IGRA_ORCHESTRA_DOMAIN}`)"
       - "traefik.http.routers.web-redirect.entrypoints=web"
@@ -803,6 +858,7 @@ services:
       - "traefik.http.routers.websecure-router.priority=1"
       - "traefik.http.routers.websecure-router.tls=true"
       - "traefik.http.routers.websecure-router.tls.certresolver=myresolver"
+      - "traefik.http.routers.websecure-router.middlewares=rpc-rate-limit,rpc-in-flight,rpc-buffering"
     healthcheck:
       <<: *default-healthcheck
       test:

--- a/scripts/lib/setup-common.sh
+++ b/scripts/lib/setup-common.sh
@@ -210,6 +210,30 @@ check_prerequisites() {
     fi
 }
 
+# Resolves a hostname to its A/AAAA records, comma-joined. Empty on
+# resolution failure — caller decides whether that's fatal. Tries getent
+# first (reliable on Linux); falls back to dig on macOS where getent is
+# present but doesn't actually resolve via the system resolver.
+resolve_lb_ips() {
+    local host="$1"
+    local v4 v6 ips=""
+    if command -v getent &> /dev/null; then
+        ips=$(
+            {
+                getent ahostsv4 "$host" 2>/dev/null
+                getent ahostsv6 "$host" 2>/dev/null
+            } | awk '{print $1}' | sort -u | paste -sd, -
+        )
+    fi
+    if [[ -z "$ips" ]] && command -v dig &> /dev/null; then
+        log "getent returned empty for $host, trying dig..."
+        v4=$(dig +short A "$host" 2>/dev/null | grep -E '^[0-9.]+$' || true)
+        v6=$(dig +short AAAA "$host" 2>/dev/null | grep -E '^[0-9a-fA-F:]+$' || true)
+        ips=$(printf '%s\n%s\n' "$v4" "$v6" | grep -v '^$' | sort -u | paste -sd, - || true)
+    fi
+    printf '%s' "$ips"
+}
+
 update_env_var() {
     local file="$1"
     local var="$2"
@@ -469,6 +493,25 @@ run_setup() {
     cat "$PROJECT_DIR/$VERSIONS_FILE" >> .env
     chmod 600 .env  # Protect .env file containing sensitive credentials
     log "Created .env from template (with image versions)"
+
+    # Auto-populate upstream RPC load balancer trust config (ENG-1020).
+    # setup-mainnet.sh / setup-galleon-testnet.sh export RPC_LB_HOSTNAME;
+    # we resolve it to IPs so orchestra's Traefik trusts XFF from the LB.
+    if [[ -n "${RPC_LB_HOSTNAME:-}" ]]; then
+        update_env_var .env "RPC_LB_HOSTNAME" "$RPC_LB_HOSTNAME"
+        local lb_ips
+        lb_ips=$(resolve_lb_ips "$RPC_LB_HOSTNAME")
+        if [[ -n "$lb_ips" ]]; then
+            update_env_var .env "ORCHESTRA_TRUSTED_PROXIES" "$lb_ips"
+            log "Resolved $RPC_LB_HOSTNAME -> $lb_ips (ORCHESTRA_TRUSTED_PROXIES)"
+        else
+            echo >&2
+            echo "WARN: could not resolve $RPC_LB_HOSTNAME; ORCHESTRA_TRUSTED_PROXIES left empty." >&2
+            echo "      Rate limiting will key on proxy IP, not real client IP if behind an LB." >&2
+            echo "      Edit .env manually once DNS is reachable, or re-run this script." >&2
+            echo >&2
+        fi
+    fi
 
     # Configure Environment
     echo

--- a/scripts/setup-galleon-testnet.sh
+++ b/scripts/setup-galleon-testnet.sh
@@ -18,6 +18,12 @@ NODE_ID_PREFIX="GTN-"
 # shellcheck disable=SC2034
 KASWALLET_FLAG="--testnet"
 
+# Upstream RPC load balancer hostname for this network. setup-common.sh
+# resolves this and writes ORCHESTRA_TRUSTED_PROXIES into .env so orchestra's
+# Traefik trusts the LB's X-Forwarded-For header (ENG-1020).
+# shellcheck disable=SC2034
+RPC_LB_HOSTNAME="galleon-testnet.igralabs.com"
+
 # Version file for this network
 VERSIONS_FILE="versions.testnet.env"
 

--- a/scripts/setup-mainnet.sh
+++ b/scripts/setup-mainnet.sh
@@ -18,6 +18,12 @@ NODE_ID_PREFIX="MN-"
 # shellcheck disable=SC2034
 KASWALLET_FLAG="--enable-mainnet-pre-launch"
 
+# Upstream RPC load balancer hostname for this network. setup-common.sh
+# resolves this and writes ORCHESTRA_TRUSTED_PROXIES into .env so orchestra's
+# Traefik trusts the LB's X-Forwarded-For header (ENG-1020).
+# shellcheck disable=SC2034
+RPC_LB_HOSTNAME="rpc.igralabs.com"
+
 # Version file for this network
 VERSIONS_FILE="versions.mainnet.env"
 


### PR DESCRIPTION
## Summary

Mirrors ENG-1019 at orchestra's own Traefik so clients who bypass the RPC load balancer and hit a `caravel-N` host directly are still rate-limited. Each orchestra deployment is directly internet-reachable — before this PR it had zero abuse protection on the bypass path.

- `rpc-rate-limit` (rateLimit, 200 avg / 400 burst / 1s) and `rpc-in-flight` (128 concurrent) middlewares.
- `rpc-buffering` — 10MB body cap, 1MB memory buffer.
- Entry-point `respondingTimeouts` (30s read/write, 60s idle) on every public entry point.
- `forwardedHeaders.trustedIPs` on every public entry point + `sourceCriterion.ipStrategy.excludedIPs` on both rate limiters, both bound to `${ORCHESTRA_TRUSTED_PROXIES}`. Both paths converge on the real client IP as the bucket key:
  - **Via LB**: TCP peer = LB (trusted), XFF = real client → keyed on real client.
  - **Direct**: TCP peer = real client, no XFF → keyed on real client.

## Attached routers

| Router | Entry point | Middleware chain |
|---|---|---|
| `rpc0` | `rpc` (8545) | `cors,rpc-rate-limit,rpc-in-flight,rpc-buffering` |
| `websecure-router` | `websecure` (443) | `rpc-rate-limit,rpc-in-flight,rpc-buffering` |
| `el_stats` | `el_stats` (9001) | `rpc-rate-limit,rpc-in-flight,rpc-buffering` |

Deliberately untouched: `health`, `health-http` (LB monitoring), `web-redirect` (HTTPS redirect), `wallet-api` (already has stricter 5/10s limit + basic auth).

## Notable design choices (from code review)

- **CORS first** on `rpc0` so browser preflight OPTIONS aren't rejected with a missing `Access-Control-Allow-Origin` header when rate-limit fires.
- **`explorer_ws` writeTimeout=0** via a separate `ENTRYPOINT_WS_WRITE_TIMEOUT` knob so long-lived WebSocket push streams aren't dropped mid-connection.

## Tunable knobs (all env, defaults)

| Variable | Default |
|---|---|
| `ORCHESTRA_TRUSTED_PROXIES` | `""` (no proxy trusted) |
| `RPC_RATE_LIMIT_AVERAGE` | `200` |
| `RPC_RATE_LIMIT_BURST` | `400` |
| `RPC_RATE_LIMIT_PERIOD` | `1s` |
| `RPC_MAX_IN_FLIGHT` | `128` |
| `MAX_REQUEST_BODY_BYTES` | `10485760` (10MB) |
| `MEM_REQUEST_BODY_BYTES` | `1048576` (1MB) |
| `ENTRYPOINT_READ_TIMEOUT` | `30s` |
| `ENTRYPOINT_WRITE_TIMEOUT` | `30s` |
| `ENTRYPOINT_IDLE_TIMEOUT` | `60s` |
| `ENTRYPOINT_WS_WRITE_TIMEOUT` | `0` (disabled) |

Set `ORCHESTRA_TRUSTED_PROXIES` to the RPC LB's egress IP(s)/CIDR on each deploy host once the LB is in front, otherwise XFF is ignored and rate-limit keys on TCP peer (LB IP) — collapsing the bucket.

## Test plan

- [x] `docker compose --env-file .env.mainnet.example -f docker-compose.yml config -q` → exit 0.
- [x] Middleware definitions + router chain grep confirmed in `docker-compose.yml`.
- [ ] `docker compose up` on staging; Traefik logs clean, dashboard shows the new middlewares.
- [ ] Direct burst (500 POSTs to `:8545`) returns mix of 200/429; 1 req/s steady state returns 100% 200.
- [ ] LB-forwarded burst with `ORCHESTRA_TRUSTED_PROXIES` set + `curl -H "X-Forwarded-For: <ip>"` from a matching source → different XFF values get separate buckets.
- [ ] Large-body (11MB POST) returns 413.
- [ ] Slow-loris (`nc` partial headers) connection closed within `ENTRYPOINT_READ_TIMEOUT`.
- [ ] Long-lived `explorer_ws` WebSocket stream stays connected past 30s of idle.
- [ ] Regression: `wallet-api` still uses its own 5/10s limit; `/health` on both `web` and `websecure` still reachable.

## Ticket

[ENG-1020](https://app.clickup.com/t/86agyfahg)

## Related

Companion PR in the RPC load balancer: IgraLabs/rpc-load-balancer#17 (ENG-1019).