### PR TITLE
[ENG-1038] feat(toccata): make IGRA_LANE_ID an explicit post-KIP21 opt-in

### DIFF
--- a/.env.atan.example
+++ b/.env.atan.example
@@ -18,12 +18,12 @@ KASPAD_JSON_PORT=18110
 
 # --- ATAN Configuration ---
 TX_ID_PREFIX=97b1
-IGRA_LANE_ID=97b1000000000000000000000000000000000000
+# Post-KIP21 dedicated IGRA lane id. Empty by default; set only after KIP-21
+# fork when enabling dedicated IGRA lane mode (see
+# doc/node-operations/enable-kip21-lane-mode.md).
+# IGRA_LANE_ID=97b1000000000000000000000000000000000000
+IGRA_LANE_ID=
 CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
-# Optional post-KIP21 dedicated IGRA lane id. When set, kaspad receives
-# --igra-lane-id and the auto-constructed import URL uses IGRA_LANE_ID instead
-# of TX_ID_PREFIX.
-#
 # Override auto-constructed import URL:
 # - {CDN_BASE_URL}/{NETWORK}/{IGRA_LANE_ID}/index.pb when IGRA_LANE_ID is set
 # - {CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb otherwise

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -16,10 +16,12 @@ NETWORK=testnet
 # Valid formats: 97b1, aabb, 00ff (must be valid hexadecimal without 0x prefix)
 TX_ID_PREFIX=97b1
 
-# Optional post-KIP21 dedicated IGRA lane id. When set, kaspad receives
-# --igra-lane-id and ATAN CDN paths use this value instead of TX_ID_PREFIX.
+# Post-KIP21 dedicated IGRA lane id. Empty by default; set only after KIP-21
+# fork when enabling dedicated IGRA lane mode (see
+# doc/node-operations/enable-kip21-lane-mode.md).
 # Valid format: 20-byte hex string without 0x prefix.
-IGRA_LANE_ID=97b1000000000000000000000000000000000000
+# IGRA_LANE_ID=97b1000000000000000000000000000000000000
+IGRA_LANE_ID=
 
 # --- HTTPS Domain Settings ---
 IGRA_ORCHESTRA_DOMAIN=stage.igralabs.com

--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -24,9 +24,12 @@ IGRA_CHAIN_ID=38836
 IGRA_LAUNCH_DAA_SCORE=368045400
 GENESIS_BLOCK_HASH=0x9816ede09a09a8e89c3c0158db66c3ea9ee16a81dfc7f2b80f7f38be5b1c28f2
 TX_ID_PREFIX=97b4
-# Post-KIP21 dedicated IGRA lane id. Galleon keeps the explicit legacy
-# ATAN_IMPORT_URL below until lane-based ATAN data is published.
-IGRA_LANE_ID=97b1000000000000000000000000000000000000
+# Post-KIP21 dedicated IGRA lane id. Empty by default; set only after KIP-21
+# fork when enabling dedicated IGRA lane mode (see
+# doc/node-operations/enable-kip21-lane-mode.md). Galleon also keeps the
+# explicit legacy ATAN_IMPORT_URL below until lane-based ATAN data is published.
+# IGRA_LANE_ID=97b1000000000000000000000000000000000000
+IGRA_LANE_ID=
 L1_REFERENCE_TIMESTAMP=1768475045
 L1_REFERENCE_DAA_SCORE=361004030
 MIN_PROTOCOL_FEE_PER_GAS_GWEI=2000

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -24,9 +24,11 @@ IGRA_CHAIN_ID=38833
 IGRA_LAUNCH_DAA_SCORE=366020000
 GENESIS_BLOCK_HASH=0x5e8f8cf83aff01f82ccb35509186b1fef48043caab1d587c4209457a3c01866b
 TX_ID_PREFIX=97b1
-# Post-KIP21 dedicated IGRA lane id. When set, kaspad receives
-# --igra-lane-id and ATAN CDN paths use this value instead of TX_ID_PREFIX.
-IGRA_LANE_ID=97b1000000000000000000000000000000000000
+# Post-KIP21 dedicated IGRA lane id. Empty by default; set only after KIP-21
+# fork when enabling dedicated IGRA lane mode (see
+# doc/node-operations/enable-kip21-lane-mode.md).
+# IGRA_LANE_ID=97b1000000000000000000000000000000000000
+IGRA_LANE_ID=
 L1_REFERENCE_TIMESTAMP=1771977542
 L1_REFERENCE_DAA_SCORE=365578320
 MIN_PROTOCOL_FEE_PER_GAS_GWEI=1000

--- a/README.md
+++ b/README.md
@@ -387,9 +387,12 @@ IGRA_SKIP_LOCK_SCRIPT_CHECK=false
 TX_ID_PREFIX=97b1
 
 # Optional post-KIP21 dedicated IGRA lane id (20-byte hex, no 0x).
-# When set, kaspad receives --igra-lane-id and ATAN import/upload paths use
-# this value instead of TX_ID_PREFIX.
-IGRA_LANE_ID=97b1000000000000000000000000000000000000
+# Empty by default. Set only after KIP-21 fork — see
+# doc/node-operations/enable-kip21-lane-mode.md. When set, kaspad/kaswallet
+# receive --igra-lane-id and ATAN import/upload paths use this value instead
+# of TX_ID_PREFIX.
+# IGRA_LANE_ID=97b1000000000000000000000000000000000000
+IGRA_LANE_ID=
 
 # CDN base URL for ATAN data (required)
 CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net

--- a/doc/node-operations/atan-only.md
+++ b/doc/node-operations/atan-only.md
@@ -15,9 +15,10 @@ Run kaspad saving finality periods without the full IGRA execution layer stack. 
    `DATADIR=/app/data/kaspa-testnet-10/datadir`, and keep
    `ATAN_IMPORT_URL=https://dyehoijgeqfp8.cloudfront.net/testnet/97b4/index.pb`
    until the `/testnet-10/97b4/index.pb` CDN object is published.
-   For post-KIP21 lane-based networks, keep `IGRA_LANE_ID` set to the
-   canonical 20-byte IGRA lane id. The auto-import path will use
-   `IGRA_LANE_ID` instead of `TX_ID_PREFIX`.
+   `IGRA_LANE_ID` is empty by default. For post-KIP21 lane-based networks,
+   set it to the canonical 20-byte IGRA lane id — see
+   [Enable KIP-21 Lane Mode](enable-kip21-lane-mode.md). When set, the
+   auto-import path uses `IGRA_LANE_ID` instead of `TX_ID_PREFIX`.
 
 3. Start kaspad with ATAN:
 
@@ -50,7 +51,7 @@ See `.env.atan.example` at the repository root for all available variables. Key 
 |----------|---------|-------------|
 | `NETWORK` | `mainnet` | Network to connect to |
 | `TX_ID_PREFIX` | `97b1` | Legacy transaction ID prefix for ATAN filtering and fallback import namespace |
-| `IGRA_LANE_ID` | `97b1000000000000000000000000000000000000` | Post-KIP21 dedicated IGRA lane id; used for `--igra-lane-id` and ATAN import/upload namespace |
+| `IGRA_LANE_ID` | (empty) | Optional post-KIP21 dedicated IGRA lane id (canonical: `97b1000000000000000000000000000000000000`); when set, used for `--igra-lane-id` and the ATAN import/upload namespace. See [Enable KIP-21 Lane Mode](enable-kip21-lane-mode.md) |
 | `CDN_BASE_URL` | CloudFront URL | CDN for ATAN data import |
 | `ATAN_IMPORT_URL` | (empty) | Optional full import URL override; required for Galleon testnet-10 until the new CDN path is published |
 | `KASPAD_ADD_PEER` | (empty) | Optional peer to connect to |

--- a/doc/node-operations/enable-kip21-lane-mode.md
+++ b/doc/node-operations/enable-kip21-lane-mode.md
@@ -1,0 +1,145 @@
+# Enable KIP-21 Lane Mode
+
+## Who this is for
+
+Operators on a network whose KIP-21 fork has activated (or is imminent) and
+who want kaspad/kaswallet to operate on the dedicated IGRA lane namespace.
+
+The shipped `.env.<network>.example` templates default `IGRA_LANE_ID=` empty
+so a routine `cp` does **not** silently switch a pre-fork stack into lane
+mode. Frigate (`testnet-12`) is the one exception — it is KIP-21 active from
+genesis and ships with the canonical lane id pre-filled. If you operate
+Frigate, you can skip this runbook.
+
+## What enabling lane mode does
+
+When `IGRA_LANE_ID` is non-empty:
+
+- **kaspad** receives `--igra-lane-id=$IGRA_LANE_ID` on its command line.
+- **kaswallet** (each replica) receives `--igra-lane-id=$IGRA_LANE_ID`.
+- **rpc-provider** sees `IGRA_LANE_ID` in its environment.
+- The **ATAN auto-import path** switches from
+  `{CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb`
+  to
+  `{CDN_BASE_URL}/{NETWORK}/{IGRA_LANE_ID}/index.pb`.
+- The **ATAN uploader** uploads under the same lane-id namespace.
+
+Pre-fork operators leaving `IGRA_LANE_ID` empty behave exactly as before.
+
+## Prerequisites
+
+- KIP-21-capable kaspad, kaswallet, and rpc-provider images already pulled
+  (update the relevant `versions.<network>.env` tags first).
+- Canonical IGRA lane id for your network confirmed with Igra Labs ops. The
+  current value across published networks is
+  `97b1000000000000000000000000000000000000`.
+- The lane-namespaced ATAN CDN object exists for your network — i.e.
+  `{CDN_BASE_URL}/{NETWORK}/{IGRA_LANE_ID}/index.pb` is reachable. If not,
+  keep a pinned `ATAN_IMPORT_URL` override (see step 4). kaspad will now
+  refuse to start if `ATAN_IMPORT_URL` is set but does not contain
+  `IGRA_LANE_ID` — that mismatch was the main pre-flip footgun this runbook
+  guards against.
+- A recent `.env` backup, in case you need to roll back.
+
+## Steps
+
+1. Stop the stack:
+
+   ```bash
+   docker compose --profile backend --profile frontend-w5 down
+   ```
+
+   Adjust the `frontend-w*` profile to match the worker count you run.
+
+2. Update image tags to KIP-21-lane-capable versions in
+   `versions.<network>.env` (or directly in `.env` if you append the
+   versions file). Pull:
+
+   ```bash
+   docker compose --profile backend --profile frontend-w5 pull
+   ```
+
+3. Set `IGRA_LANE_ID` in `.env`:
+
+   ```env
+   IGRA_LANE_ID=97b1000000000000000000000000000000000000
+   ```
+
+   Use the canonical value confirmed in Prerequisites.
+
+4. Reconcile `ATAN_IMPORT_URL`:
+
+   - **Recommended**: comment out / remove `ATAN_IMPORT_URL=` so kaspad
+     auto-constructs the lane-id path from `CDN_BASE_URL`, `NETWORK`, and
+     `IGRA_LANE_ID`.
+   - **Override**: if you must keep a pinned URL, point it at
+     `{CDN_BASE_URL}/{NETWORK}/{IGRA_LANE_ID}/index.pb`. The substring
+     `IGRA_LANE_ID` must appear in the URL — kaspad's startup safety check
+     exits 1 otherwise (the ATAN-only compose downgrades this to a warning).
+
+5. Start the stack:
+
+   ```bash
+   docker compose --profile backend --profile frontend-w5 up -d --no-build
+   docker compose logs -f kaspad
+   ```
+
+## Verify
+
+After the stack is up, confirm lane mode is plumbed through every consumer.
+
+- **kaspad** — its resolved command line includes `--igra-lane-id`:
+
+  ```bash
+  docker compose exec kaspad sh -c 'ps -o args= -p 1' | tr ' ' '\n' | grep igra-lane-id
+  ```
+
+  Should print `--igra-lane-id=97b1000000000000000000000000000000000000`.
+
+- **kaswallet** — same check on any worker:
+
+  ```bash
+  docker compose exec kaswallet-0 sh -c 'ps -o args= 1' | tr ' ' '\n' | grep igra-lane-id
+  ```
+
+- **rpc-provider** — env contains the lane id:
+
+  ```bash
+  docker compose exec rpc-provider-0 env | grep '^IGRA_LANE_ID='
+  ```
+
+- **ATAN import URL** — kaspad's startup log should show the resolved
+  `--atan-import-url` flag using the lane id segment:
+
+  ```bash
+  docker compose logs kaspad | grep -E 'atan-import-url|atan_import_url' | head -5
+  ```
+
+  Expect the path ending in `/$IGRA_LANE_ID/index.pb`, not
+  `/$TX_ID_PREFIX/index.pb`.
+
+## Rollback
+
+Lane mode is a runtime-only switch — no volume or chain-state changes.
+
+1. Stop the stack:
+
+   ```bash
+   docker compose --profile backend --profile frontend-w5 down
+   ```
+
+2. In `.env`, set `IGRA_LANE_ID=` empty and restore your previous
+   `ATAN_IMPORT_URL` if you changed it.
+
+3. (Optional) Revert image tags in `versions.<network>.env` to the pre-fork
+   versions.
+
+4. Start the stack:
+
+   ```bash
+   docker compose --profile backend --profile frontend-w5 up -d --no-build
+   ```
+
+kaspad/kaswallet return to passing `--atan-transaction-id-prefix=$TX_ID_PREFIX`
+without a lane flag, and the ATAN import URL auto-constructs back under the
+`TX_ID_PREFIX` namespace.

--- a/doc/node-operations/environment-reference.md
+++ b/doc/node-operations/environment-reference.md
@@ -26,7 +26,7 @@ All operational variables across the stack.
 |----------|-------|-------------|
 | `NETWORK` | `.env` | Network to connect to (mainnet, testnet) |
 | `TX_ID_PREFIX` | `.env` | Legacy transaction ID prefix for ATAN filtering and fallback ATAN import namespace |
-| `IGRA_LANE_ID` | `.env` | Canonical post-KIP21 dedicated IGRA lane id, currently `97b1000000000000000000000000000000000000`; passed to kaspad as `--igra-lane-id` and used as the ATAN import/upload namespace |
+| `IGRA_LANE_ID` | `.env` | Optional post-KIP21 dedicated IGRA lane id, canonical value `97b1000000000000000000000000000000000000`. Empty by default; set explicitly post-fork — see [Enable KIP-21 Lane Mode](enable-kip21-lane-mode.md). When set, passed to kaspad/kaswallet as `--igra-lane-id` and used as the ATAN import/upload namespace |
 | `CDN_BASE_URL` | `.env` | CDN base URL for ATAN data import |
 | `ATAN_IMPORT_URL` | `.env` | Optional override for auto-constructed import URL |
 | `KASPAD_ADD_PEER` | `.env` | Optional peer address |

--- a/doc/node-operations/index.md
+++ b/doc/node-operations/index.md
@@ -8,3 +8,4 @@ Operational reference for running Igra Orchestra nodes.
 - **[ATAN-Only Mode](atan-only.md)** - Run kaspad saving finality periods without the full IGRA stack
 - **[Environment Reference](environment-reference.md)** - All operational environment variables
 - **[Galleon → testnet-10 Migration](migrate-galleon-to-testnet-10.md)** - One-shot upgrade for existing Galleon operators on `NETWORK=testnet` to the uniform `NETWORK=testnet-10` schema (preserves IBD state)
+- **[Enable KIP-21 Lane Mode](enable-kip21-lane-mode.md)** - Post-fork procedure for switching kaspad/kaswallet/rpc to the dedicated IGRA lane namespace

--- a/doc/quick-setup-frigate-testnet.md
+++ b/doc/quick-setup-frigate-testnet.md
@@ -53,7 +53,7 @@ and copy the published values into `.env` rather than this table.
 | `NETWORK` | testnet-12 |
 | `IGRA_CHAIN_ID` | _(pending)_ |
 | `TX_ID_PREFIX` | _(pending)_ |
-| `IGRA_LANE_ID` | 97b1000000000000000000000000000000000000 |
+| `IGRA_LANE_ID` | 97b1000000000000000000000000000000000000 (post-KIP21 from genesis) |
 | `IGRA_LAUNCH_DAA_SCORE` | _(pending)_ |
 | `GENESIS_BLOCK_HASH` | _(pending)_ |
 | `L1_REFERENCE_DAA_SCORE` | _(pending)_ |

--- a/doc/quick-setup-galleon-testnet.md
+++ b/doc/quick-setup-galleon-testnet.md
@@ -28,7 +28,7 @@ If the automated script above doesn't work for your environment, follow these ma
 | `NETWORK` | testnet-10 |
 | `IGRA_CHAIN_ID` | 38836 |
 | `TX_ID_PREFIX` | 97b4 |
-| `IGRA_LANE_ID` | 97b1000000000000000000000000000000000000 |
+| `IGRA_LANE_ID` | (empty until KIP-21 fork — see [Enable KIP-21 Lane Mode](node-operations/enable-kip21-lane-mode.md); canonical post-fork value: `97b1000000000000000000000000000000000000`) |
 | `IGRA_LAUNCH_DAA_SCORE` | 368045400 |
 | `GENESIS_BLOCK_HASH` | 0xfa870bcc16b6fbb3225bcc89a92f38e02c95fdc3e3b51a58d066ac7e1e4162a2 |
 | `L1_REFERENCE_DAA_SCORE` | 361004030 |

--- a/doc/quick-setup-mainnet.md
+++ b/doc/quick-setup-mainnet.md
@@ -28,7 +28,7 @@ If the automated script above doesn't work for your environment, follow these ma
 | `NETWORK` | mainnet |
 | `IGRA_CHAIN_ID` | 38833 |
 | `TX_ID_PREFIX` | 97b1 |
-| `IGRA_LANE_ID` | 97b1000000000000000000000000000000000000 |
+| `IGRA_LANE_ID` | (empty until KIP-21 fork — see [Enable KIP-21 Lane Mode](node-operations/enable-kip21-lane-mode.md); canonical post-fork value: `97b1000000000000000000000000000000000000`) |
 | `IGRA_LAUNCH_DAA_SCORE` | 366020000 |
 | `GENESIS_BLOCK_HASH` | 0x5e8f8cf83aff01f82ccb35509186b1fef48043caab1d587c4209457a3c01866b |
 | `L1_REFERENCE_DAA_SCORE` | 365578320 |

--- a/docker-compose.atan.yml
+++ b/docker-compose.atan.yml
@@ -70,6 +70,15 @@ services:
 
         [ -n "$$IGRA_LANE_ID" ] && ARGS="$$ARGS --igra-lane-id=$$IGRA_LANE_ID"
 
+        if [ -n "$$IGRA_LANE_ID" ] && [ -n "$$ATAN_IMPORT_URL" ]; then
+          case "$$ATAN_IMPORT_URL" in
+            *"$$IGRA_LANE_ID"*) ;;
+            *)
+              echo "Warning: ATAN_IMPORT_URL is set but does not contain IGRA_LANE_ID; this may import legacy prefix data while lane mode is enabled." >&2
+              ;;
+          esac
+        fi
+
         ATAN_IMPORT_KEY="$${IGRA_LANE_ID:-$$TX_ID_PREFIX}"
         if [ -n "$$ATAN_IMPORT_URL" ]; then
           ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ x-kaswallet-runtime: &kaswallet-runtime
           ARGS="$$ARGS --testnet-suffix=$$KASPA_NETSUFFIX"
         fi
       fi
+      [ -n "$$IGRA_LANE_ID" ] && ARGS="$$ARGS --igra-lane-id=$$IGRA_LANE_ID"
       exec sh /app/watch-dependencies.sh \
         --tcp kaspad "$$KASPAD_HOST" "$$KASPAD_GRPC_PORT" \
         -- /app/kaswallet-daemon $$ARGS
@@ -266,6 +267,16 @@ services:
           fi
           [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && ARGS="$$ARGS --igra-post-fork-lock-script-pubkey=$$POST_FORK_LOCK_SCRIPT_PUBKEY"
           [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ] && ARGS="$$ARGS --igra-lock-script-fork-daa-score=$$LOCK_SCRIPT_FORK_DAA_SCORE"
+
+          if [ -n "$$IGRA_LANE_ID" ] && [ -n "$$ATAN_IMPORT_URL" ]; then
+            case "$$ATAN_IMPORT_URL" in
+              *"$$IGRA_LANE_ID"*) ;;
+              *)
+                echo "Error: ATAN_IMPORT_URL is set but does not contain IGRA_LANE_ID; this may import legacy prefix data while lane mode is enabled." >&2
+                exit 1
+                ;;
+            esac
+          fi
 
           ATAN_IMPORT_KEY="$${IGRA_LANE_ID:-$$TX_ID_PREFIX}"
           if [ -n "$$ATAN_IMPORT_URL" ]; then


### PR DESCRIPTION
## Summary

- Ship `.env.{mainnet,galleon-testnet,dev,atan}.example` with `IGRA_LANE_ID` empty (was canonical hex by default). Frigate / testnet-12 keeps the canonical value — it is KIP-21 active from genesis.
- Forward `--igra-lane-id` to kaswallet when set (it was only plumbed into kaspad before).
- Add a startup safety check: if `IGRA_LANE_ID` is set but `ATAN_IMPORT_URL` doesn't contain it, kaspad fails fast (warn-only in `docker-compose.atan.yml`).
- New runbook `doc/node-operations/enable-kip21-lane-mode.md` documenting the post-fork enablement procedure; cross-linked from `README.md`, `environment-reference.md`, `atan-only.md`, and the three `quick-setup-*` guides.

## Why

Today every shipped env template sets `IGRA_LANE_ID=97b1000000000000000000000000000000000000`, so a routine `cp .env.<network>.example .env` silently switches kaspad to `--igra-lane-id` and pins ATAN CDN paths to the lane namespace — even on mainnet and Galleon where KIP-21 has not activated yet. This PR makes the switch explicit so operators flip it post-fork, after they've rolled lane-capable images and confirmed the lane-namespaced ATAN CDN object exists.

## Test plan

- [x] `docker compose --env-file .env.<n>.example --profile backend config` renders cleanly for mainnet / galleon / dev / frigate and `IGRA_LANE_ID:` resolves to `""` for the first three, canonical hex for frigate.
- [x] `docker compose -f docker-compose.atan.yml --env-file .env.atan.example config` renders with `IGRA_LANE_ID: ""` and the warn-style safety check.
- [x] Rendered kaswallet entrypoint contains the new `[ -n "$IGRA_LANE_ID" ] && ARGS="$ARGS --igra-lane-id=$IGRA_LANE_ID"` line in every replica.
- [x] Rendered kaspad entrypoint contains the `case` safety check with `exit 1` (main compose) / no-exit `Warning:` (ATAN-only).
- [ ] Smoke test on a host: set `IGRA_LANE_ID=…` and a deliberately mismatched `ATAN_IMPORT_URL` → expect kaspad to exit 1 with the new Error message; same env under `docker-compose.atan.yml` → expect Warning, container stays up.
- [ ] Doc walkthrough on staging post-fork: follow `doc/node-operations/enable-kip21-lane-mode.md` end-to-end.