### PR TITLE
[ENG-1103] fix(node-health-check): override broken ps-based healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -420,6 +420,11 @@ services:
       - RPC_PROVIDER_VERSION=${RPC_PROVIDER_VERSION}
       - NODE_HEALTH_CHECK_VERSION=${NODE_HEALTH_CHECK_VERSION}
       - ATAN_UPLOADER_VERSION=${ATAN_UPLOADER_VERSION}
+    # Image lacks ps/pgrep, so its baked-in ps-based HEALTHCHECK always fails
+    # ("sh: 1: ps: not found"). App runs as PID 1; check /proc/1/cmdline with grep instead.
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD-SHELL", "grep -qa node-health-check-client /proc/1/cmdline || exit 1"]
     restart: unless-stopped
 
   # Worker Services


### PR DESCRIPTION
## Summary

`node-health-check-client` reports Docker status **`unhealthy`** on every IGRA deployment running `igranetwork/node-health-check-client:2.1`, even though the client is fully functional. This overrides the broken healthcheck so container status reflects reality.

Ticket: ENG-1103 (https://app.clickup.com/t/86ahxn5n2)

## Root cause

The healthcheck is **baked into the image** (not compose):

```
HEALTHCHECK ["CMD" "sh" "-c" "ps aux | grep -v grep | grep node-health-check-client || exit 1"]
```

The image is Debian 12 (bookworm) and ships **without `ps` or `pgrep`**, so the probe fails on every run:

```
$ docker inspect -f '{{json .State.Health}}' node-health-check-client
... "FailingStreak": 316, "ExitCode": 1, "Output": "sh: 1: ps: not found\n" ...
```

Meanwhile the app itself is healthy (`status: healthy`, 100% consensus, `restart_count=0`). The compose service had no `healthcheck:` override, so it fell back to the broken baked-in probe. This affects **every** deployment using this image, not just one host.

## Fix

Override the healthcheck in `docker-compose.yml` using only what the image ships (`grep` + `/proc`; no `ps`/`pgrep`/`curl`). The client runs as PID 1, so:

```yaml
healthcheck:
  <<: *default-healthcheck
  test: ["CMD-SHELL", "grep -qa node-health-check-client /proc/1/cmdline || exit 1"]
```

A compose `healthcheck` overrides the image's baked-in `HEALTHCHECK`. Uses the repo's shared `*default-healthcheck` anchor (interval 10s / timeout 2s / retries 3 / start_period 5s), matching the pattern `atan-uploader` already uses.

## Validation

- Ran the new probe inside the live container on `igra_stage_7`: `grep -qa node-health-check-client /proc/1/cmdline` → `exit=0`.
- Confirmed `grep` present at `/usr/bin/grep`; `ps` / `pgrep` / `curl` absent.
- YAML parses and the anchor merges correctly (resolved healthcheck = anchor's interval/timeout/retries/start_period + the new test).

## Deploy (operator)

Healthcheck changes apply only after the container is recreated:

```bash
docker compose --profile backend up -d --no-deps node-health-check-client
docker inspect -f '{{.State.Health.Status}}' node-health-check-client   # expect: healthy
```

Brief restart of the push client (a few-second gap in monitor reporting; the node itself is unaffected).
