### PR TITLE
[ENG-1151] feat: devnet toccata activation igra lane

### DIFF
--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -14,6 +14,24 @@ FINALITY_PERIOD_SECONDS=600
 # Transaction ID prefix for ATAN (hex-encoded, even number of chars)
 TX_ID_PREFIX=97b1
 
+# --- Toccata / KIP-21 transition ---
+# DAA score at which the Toccata hardfork (KIP-21 boundary) activates. Devnet is
+# mined from genesis (DAA ~ blue score) at 10 BPS, so 1000 activates Toccata after
+# ~1000 mined blocks (~100s) — short and predictable, leaving a pre-fork window past
+# coinbase_maturity (200) for entry transactions. setup-devnet.sh writes this as
+# toccata_activation into overrides/devnet.json. Like finality_depth it is baked into
+# kaspad's consensus DB on first run; changing it later requires
+#   docker compose -f docker-compose.devnet.yml down -v
+# (destroys the local chain). Leave EMPTY to disable Toccata (no fork; IGRA_LANE_ID
+# then not required). Separate from LOCK_SCRIPT_FORK_DAA_SCORE (a different mechanism).
+TOCCATA_ACTIVATION_DAA_SCORE=1000
+
+# IGRA lane (subnetwork) id used post-KIP21/Toccata. 4-byte namespace (8 hex) or full
+# 20-byte SubnetworkId (40 hex). Here it mirrors TX_ID_PREFIX (97b1) + 0000. kaspad
+# requires this whenever ATAN is enabled and Toccata is scheduled (non-empty
+# TOCCATA_ACTIVATION_DAA_SCORE above).
+IGRA_LANE_ID=97b10000
+
 # --- Docker Configuration ---
 LOGGING_DRIVER=json-file
 SERVICE_RESTART_POLICY=unless-stopped

--- a/README.md
+++ b/README.md
@@ -91,9 +91,21 @@ Traefik/TLS), read-only by default (`RPC_READ_ONLY=true`). Project name
 (`igra-devnet`) and container names (`*-devnet`) are distinct from the
 production stack.
 
-**Reset.** `finality_depth` is baked into kaspad's consensus DB on first run, so
-changing `FINALITY_PERIOD_SECONDS` requires a fresh kaspad volume. To wipe all
-state:
+**Toccata / KIP-21 rehearsal.** The devnet activates the Toccata hardfork after a
+short, predictable number of mined blocks so you can rehearse crossing the KIP-21
+boundary locally. `TOCCATA_ACTIVATION_DAA_SCORE` (default `1000` ≈ ~100s / ~1000
+blocks at 10 BPS) is written as `toccata_activation` into `overrides/devnet.json`;
+kaspad is started with ATAN enabled and `--igra-lane-id=$IGRA_LANE_ID` (default
+`97b10000`, a 4-byte namespace mirroring `TX_ID_PREFIX`). Whenever ATAN is enabled
+(`IGRA_ENABLE=true`) and Toccata is scheduled, the lane id is mandatory. `setup-devnet.sh`
+fails early on a missing or invalid lane, score, or finality value; the compose entrypoint
+re-checks the lane on a direct `docker compose up` (presence plus a hex/length format check,
+with kaspad validating the exact lane shape at startup). Set `TOCCATA_ACTIVATION_DAA_SCORE=`
+(empty) to opt out (no fork). This is independent of `LOCK_SCRIPT_FORK_DAA_SCORE`.
+
+**Reset.** Consensus override params (`finality_depth`, `toccata_activation`) are
+baked into kaspad's consensus DB on first run, so changing `FINALITY_PERIOD_SECONDS`
+or `TOCCATA_ACTIVATION_DAA_SCORE` requires a fresh kaspad volume. To wipe all state:
 
 ```bash
 # remove containers AND the kaspad_data named volume (destroys the chain):

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -58,6 +58,7 @@ services:
       - CDN_BASE_URL
       - NETWORK
       - TX_ID_PREFIX
+      - IGRA_LANE_ID
       - IGRA_ENABLE
       - POST_FORK_LOCK_SCRIPT_PUBKEY
       - LOCK_SCRIPT_FORK_DAA_SCORE
@@ -107,6 +108,22 @@ services:
           fi
           [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && ARGS="$$ARGS --igra-post-fork-lock-script-pubkey=$$POST_FORK_LOCK_SCRIPT_PUBKEY"
           [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ] && ARGS="$$ARGS --igra-lock-script-fork-daa-score=$$LOCK_SCRIPT_FORK_DAA_SCORE"
+          # Toccata/KIP-21 lane: required whenever Toccata is scheduled (the override
+          # file carries toccata_activation). Fail early on a misconfig reached via a
+          # direct `docker compose up` that bypassed setup-devnet.sh's validation.
+          if [ -f /app/overrides/devnet.json ] && grep -q '"toccata_activation"' /app/overrides/devnet.json && [ -z "$$IGRA_LANE_ID" ]; then
+            echo "Error: IGRA_LANE_ID must be set when toccata_activation is scheduled in overrides/devnet.json" >&2; exit 1
+          fi
+          if [ -n "$$IGRA_LANE_ID" ]; then
+            case "$$IGRA_LANE_ID" in
+              *[!0-9a-fA-F]*) echo "Error: IGRA_LANE_ID must be hex (got: $$IGRA_LANE_ID)" >&2; exit 1 ;;
+            esac
+            case "$${#IGRA_LANE_ID}" in
+              8|40) ;;
+              *) echo "Error: IGRA_LANE_ID must be 8 or 40 hex chars (got: $$IGRA_LANE_ID)" >&2; exit 1 ;;
+            esac
+            ARGS="$$ARGS --igra-lane-id=$$IGRA_LANE_ID"
+          fi
 
           # Devnet has no ATAN data source: missing config is a warning, not fatal.
           if [ -n "$$ATAN_IMPORT_URL" ]; then
@@ -223,6 +240,7 @@ services:
       - NETWORK
       - KASPAD_HOST
       - KASPAD_GRPC_PORT
+      - IGRA_LANE_ID
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -238,6 +256,9 @@ services:
           ARGS="--enable-mainnet-pre-launch $$ARGS"
         else
           ARGS="--$$NETWORK $$ARGS"
+        fi
+        if [ -n "$$IGRA_LANE_ID" ]; then
+          ARGS="$$ARGS --subnetwork-id=$$IGRA_LANE_ID"
         fi
         exec sh /app/watch-dependencies.sh \
           --tcp kaspad "$$KASPAD_HOST" "$$KASPAD_GRPC_PORT" \
@@ -276,6 +297,7 @@ services:
       READ_ONLY: ${RPC_READ_ONLY}
       MIN_PROTOCOL_FEE_PER_GAS_GWEI: ${MIN_PROTOCOL_FEE_PER_GAS_GWEI}
       TX_ID_PREFIX: ${TX_ID_PREFIX}
+      IGRA_LANE_ID: ${IGRA_LANE_ID:-}
       KASWALLET_HOST: kaswallet-0
       WALLET_DAEMON_URI: http://kaswallet-0:8082
       WALLET_TO_ADDRESS: ${W0_WALLET_TO_ADDRESS}

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -33,11 +33,89 @@ export COMPOSE_FILE="docker-compose.devnet.yml"
 # Single worker by default (devnet runs only kaswallet-0 / rpc-provider-0).
 export NUM_WORKERS="${NUM_WORKERS:-1}"
 
+# Resolve devnet knobs from .env (else the committed example) before generating the
+# override JSON, so a value set in .env reaches it. Inline `VAR=...` still wins.
+DEVNET_ENV_FILE="$SCRIPT_DIR/../.env"
+[ -f "$DEVNET_ENV_FILE" ] || DEVNET_ENV_FILE="$SCRIPT_DIR/../$ENV_FILE"
+
+read_devnet_env() {
+    local key="$1" file="$2" line val found=1
+    [ -f "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key"=*)
+                val="${line#*=}"
+                val="${val#"${val%%[![:space:]]*}"}"
+                val="${val%"${val##*[![:space:]]}"}"
+                case "$val" in
+                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
+                esac
+                found=0
+                ;;
+        esac
+    done < "$file"
+    [ "$found" -eq 0 ] && printf '%s' "$val"
+    return "$found"
+}
+
+# Precedence: inline env (set, even if empty) > env file > default.
+resolve_devnet_var() {
+    local name="$1" default="$2" val
+    [ -n "${!name+set}" ] && return 0
+    if val="$(read_devnet_env "$name" "$DEVNET_ENV_FILE")"; then
+        printf -v "$name" '%s' "$val"
+    else
+        printf -v "$name" '%s' "$default"
+    fi
+}
+
 # Generate kaspad override-params JSON. Default: 600s finality (= 6000-block depth at BPS=10).
+resolve_devnet_var FINALITY_PERIOD_SECONDS 600
 FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-600}"
+# Empty TOCCATA_ACTIVATION_DAA_SCORE opts out of Toccata; defaults match .env.devnet.example.
+resolve_devnet_var TOCCATA_ACTIVATION_DAA_SCORE 1000
+resolve_devnet_var IGRA_LANE_ID 97b10000
+resolve_devnet_var IGRA_LAUNCH_DAA_SCORE 0
+
+# Fail before build/up if the KIP-21 transition config is invalid or incomplete.
+# Toccata is optional: an empty TOCCATA_ACTIVATION_DAA_SCORE opts out (no fork). But
+# when Toccata IS scheduled, a lane id is mandatory (kaspad requires it post-Toccata).
+validate_toccata_and_lane() {
+    local toccata="$1" lane="$2" launch="$3"
+    if [ -n "$toccata" ]; then
+        if ! [[ "$toccata" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: TOCCATA_ACTIVATION_DAA_SCORE must be a positive integer with no leading zeros, or empty to disable Toccata (got: $toccata)" >&2
+            exit 1
+        fi
+        if (( toccata > 920000 )); then
+            echo "ERROR: TOCCATA_ACTIVATION_DAA_SCORE=$toccata is implausibly large (> 920000); likely a typo. Lower it or set it empty to disable Toccata." >&2
+            exit 1
+        fi
+        if [ -z "$lane" ]; then
+            echo "ERROR: IGRA_LANE_ID is required when TOCCATA_ACTIVATION_DAA_SCORE is set (Toccata scheduled)" >&2
+            exit 1
+        fi
+        if [[ "$launch" =~ ^[0-9]+$ ]] && (( launch >= toccata )); then
+            echo "ERROR: IGRA_LAUNCH_DAA_SCORE ($launch) must be < TOCCATA_ACTIVATION_DAA_SCORE ($toccata) so the pre-fork entry window opens before the fork" >&2
+            exit 1
+        fi
+    fi
+    if [ -n "$lane" ]; then
+        if ! [[ "$lane" =~ ^([0-9a-f]{8}|[0-9a-f]{40})$ ]]; then
+            echo "ERROR: IGRA_LANE_ID must be 8 or 40 lowercase hex chars (got: $lane); kaspad validates the exact lane shape at startup" >&2
+            exit 1
+        fi
+        if [[ "$lane" =~ ^0+$ ]]; then
+            echo "ERROR: IGRA_LANE_ID must not be all-zero (reserved SUBNETWORK_ID_NATIVE shape)" >&2
+            exit 1
+        fi
+    fi
+}
 
 generate_devnet_overrides() {
     local seconds="$1"
+    local toccata="$2"
     # Upper bound is below pruning_depth/BPS (= 108000s): kaspad's effective
     # finalization window is finality_depth + merge_depth + anticone overhead
     # (~159k blocks with these params). Capping at 92000s keeps finality_depth
@@ -52,6 +130,13 @@ generate_devnet_overrides() {
     mkdir -p "$out_dir"
     # blockrate mirrors the kaspad devnet defaults; only finality_depth is tuned.
     # crescendo_activation=0 keeps post-Crescendo consensus active from genesis.
+    # toccata_activation is appended as the last field only when scheduled, so the
+    # JSON has no trailing comma when Toccata is disabled (empty score).
+    local toccata_line=""
+    if [ -n "$toccata" ]; then
+        toccata_line=",
+  \"toccata_activation\": $toccata"
+    fi
     cat > "$out_dir/devnet.json" <<EOF
 {
   "blockrate": {
@@ -66,10 +151,14 @@ generate_devnet_overrides() {
     "pruning_depth": 1080000,
     "coinbase_maturity": 200
   },
-  "crescendo_activation": 0
+  "crescendo_activation": 0$toccata_line
 }
 EOF
-    echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS)"
+    if [ -n "$toccata" ]; then
+        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), toccata_activation=$toccata"
+    else
+        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), toccata_activation disabled (never)"
+    fi
 }
 
 # finality_depth is baked into kaspad's consensus DB on first run and lives in the
@@ -82,9 +171,10 @@ warn_if_finality_baked() {
         cat >&2 <<EOF
 
 WARNING: existing kaspad volume '$volume' found.
-         finality_depth is baked into the consensus DB on first run; re-running
-         setup with a different FINALITY_PERIOD_SECONDS will NOT take effect until
-         the volume is wiped. To apply a new finality:
+         Consensus override params (finality_depth, toccata_activation) are baked
+         into the consensus DB on first run; re-running setup with a different
+         FINALITY_PERIOD_SECONDS or TOCCATA_ACTIVATION_DAA_SCORE will NOT take effect
+         until the volume is wiped. To apply new values:
 
            docker compose -f docker-compose.devnet.yml down -v
 
@@ -94,7 +184,8 @@ EOF
     fi
 }
 
-generate_devnet_overrides "$FINALITY_PERIOD_SECONDS"
+validate_toccata_and_lane "$TOCCATA_ACTIVATION_DAA_SCORE" "$IGRA_LANE_ID" "$IGRA_LAUNCH_DAA_SCORE"
+generate_devnet_overrides "$FINALITY_PERIOD_SECONDS" "$TOCCATA_ACTIVATION_DAA_SCORE"
 warn_if_finality_baked
 
 # Build the stack from source. kaspad's --override-params-file is only on the


### PR DESCRIPTION
Adds Toccata (KIP-21) hardfork rehearsal support to the local devnet stack so the pre-/post-fork boundary can be exercised end-to-end before mainnet.

  What's included:
  - TOCCATA_ACTIVATION_DAA_SCORE (default 1000) is written as toccata_activation into overrides/devnet.json, activating the fork after a short, predictable number of mined blocks. Set it empty to opt out.
  - IGRA_LANE_ID is wired through the whole stack: kaspad (--igra-lane-id), kaswallet (--subnetwork-id), and rpc-provider, so the bundled wallet emits post-Toccata (v1) lane transactions instead of
  native-subnetwork (v0) ones the fork would reject.
  - setup-devnet.sh resolves config from .env/.env.devnet.example before generating the override JSON and validates it up front: Toccata score format/range, lane format (lowercase hex, no all-zero), the
  lane-required-when-scheduled rule, and the launch-DAA-before-fork ordering.
  - The compose entrypoint re-checks the lane format on a direct docker compose up (the path that bypasses the script), and the README documents the rehearsal flow and opt-out.