### PR TITLE
[ENG-1152] feat(devnet):  Harden devnet setup validation and source provenance

### DIFF
--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -68,6 +68,10 @@ KASPAD_P2P_PORT=16611
 KASPAD_BORSH_PORT=17610
 KASPAD_JSON_PORT=18610
 
+# Host port for kaswallet-0; parameterized to coexist with a production/testnet
+# kaswallet, which also binds 8082.
+KASWALLET_HOST_PORT=8082
+
 IGRA_LOCK_SCRIPT_PUBKEY=20aeb014c0814f5c549bbea36638e08b1e8d4c1b8251780841fce1fdcbf72ee01dac
 IGRA_ENTRY_MIN_AMOUNT=100000000
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tasks/
 network-params/
 
 overrides/
+rehearsals/
 
 .DS_Store
 .cursor

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Built from source: configurable finality uses kaspad's `--override-params-file`,
 available on the `rusty-kaspa-private` v3.0 line only. `setup-devnet.sh` builds
 kaspad, reth, kaswallet and rpc-provider locally and starts the stack.
 
+`setup-devnet.sh` validates the full configuration and fails fast with a clear
+error summary before any image build or `docker compose up`. Build-time and
+runtime inputs come from one resolved env source: `.env` when present, otherwise
+`.env.devnet.example` (the committed template). Each run writes a timestamped
+source-revision manifest (branch/SHA/dirty for all five built repos) to
+`rehearsals/` so every rehearsal is reproducible.
+
 ```bash
 # clone sources (kaspad/kaswallet/rpc-provider on v3.0, reth on production):
 KASPAD_BRANCH=v3.0 KASWALLET_BRANCH=v3.0 IGRA_RPC_PROVIDER_BRANCH=v3.0 RETH_BRANCH=production \
@@ -87,9 +94,11 @@ docker compose -f docker-compose.devnet.yml --profile mining up -d --build kaspa
 
 Local-only: dedicated `docker-compose.devnet.yml`, RPC bound to
 `RPC_BIND_ADDR` (default `127.0.0.1`) on `RPC_PORT` (default 8555, no
-Traefik/TLS), read-only by default (`RPC_READ_ONLY=true`). Project name
-(`igra-devnet`) and container names (`*-devnet`) are distinct from the
-production stack.
+Traefik/TLS), read-only by default (`RPC_READ_ONLY=true`). Setting
+`RPC_BIND_ADDR=0.0.0.0` with `RPC_READ_ONLY=false` exposes the wallet-backed
+RPC off-box with no TLS/auth — `setup-devnet.sh` warns when this combination
+is detected. Project name (`igra-devnet`) and container names (`*-devnet`) are
+distinct from the production stack.
 
 **Toccata / KIP-21 rehearsal.** The devnet activates the Toccata hardfork after a
 short, predictable number of mined blocks so you can rehearse crossing the KIP-21

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ kaspad, reth, kaswallet and rpc-provider locally and starts the stack.
 error summary before any image build or `docker compose up`. Build-time and
 runtime inputs come from one resolved env source: `.env` when present, otherwise
 `.env.devnet.example` (the committed template). Each run writes a timestamped
-source-revision manifest (branch/SHA/dirty for all five built repos) to
-`rehearsals/` so every rehearsal is reproducible.
+source-revision manifest (branch/SHA/dirty for all four built repos) to
+`rehearsals/` so every rehearsal is reproducible (newest `REHEARSAL_KEEP`, default
+20, are retained).
 
 ```bash
 # clone sources (kaspad/kaswallet/rpc-provider on v3.0, reth on production):
@@ -88,8 +89,11 @@ KASPAD_BRANCH=v3.0 KASWALLET_BRANCH=v3.0 IGRA_RPC_PROVIDER_BRANCH=v3.0 RETH_BRAN
 # build from source and bring the stack up:
 FINALITY_PERIOD_SECONDS=600 ./scripts/setup-devnet.sh
 
-# start the in-stack miner once kaspad is healthy:
-docker compose -f docker-compose.devnet.yml --profile mining up -d --build kaspa-miner
+# kaspad mines no blocks on its own. The miner is not part of the stack; this
+# helper clones, builds and runs tmrlvi/kaspa-miner on the host against the
+# published devnet kaspad gRPC port (reads MINING_ADDRESS / MINING_THREADS /
+# KASPAD_GRPC_PORT from .env). Run it once kaspad is healthy:
+./scripts/dev/run-devnet-miner.sh
 ```
 
 Local-only: dedicated `docker-compose.devnet.yml`, RPC bound to
@@ -120,7 +124,7 @@ or `TOCCATA_ACTIVATION_DAA_SCORE` requires a fresh kaspad volume. To wipe all st
 # remove containers AND the kaspad_data named volume (destroys the chain):
 docker compose -f docker-compose.devnet.yml down -v
 # remove host-side state created by setup-devnet.sh (reth data is root-owned):
-sudo rm -rf data network-params logs overrides
+sudo rm -rf data network-params logs overrides rehearsals
 ```
 
 **Manual setup (alternative):**

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -62,6 +62,15 @@ services:
       - IGRA_ENABLE
       - POST_FORK_LOCK_SCRIPT_PUBKEY
       - LOCK_SCRIPT_FORK_DAA_SCORE
+      # Passed as runtime env (referenced as $$VAR below) rather than spliced
+      # compose-time, so a $(...) value is treated as data, not shell text.
+      - IGRA_LAUNCH_DAA_SCORE
+      - L1_REFERENCE_TIMESTAMP
+      - L1_REFERENCE_DAA_SCORE
+      - GENESIS_BLOCK_HASH
+      - MIN_PROTOCOL_FEE_PER_GAS_GWEI
+      - IGRA_LOCK_SCRIPT_PUBKEY
+      - IGRA_ENTRY_MIN_AMOUNT
       - RUST_LOG=info,kaspa_viaduct=trace,kaspa_igra_adapter=trace,kaspa_atan_core=trace,kaspa_atan_server=trace,kaspa_atan_storage=trace,kaspa_atan_validation=trace,kaspa_atan_client=trace,kaspa_atan_importer=trace
     entrypoint:
       - sh
@@ -85,15 +94,15 @@ services:
           ARGS="$$ARGS \
             --igra-enable \
             --atan-listen \
-            --atan-transaction-id-prefix=${TX_ID_PREFIX} \
-            --viaduct-start-daa-score=${IGRA_LAUNCH_DAA_SCORE} \
-            --igra-l1-reference-timestamp=${L1_REFERENCE_TIMESTAMP} \
-            --igra-l1-reference-daa-score=${L1_REFERENCE_DAA_SCORE} \
-            --igra-genesis-hash=${GENESIS_BLOCK_HASH} \
-            --igra-min-fee-per-gas-gwei=${MIN_PROTOCOL_FEE_PER_GAS_GWEI} \
+            --atan-transaction-id-prefix=$$TX_ID_PREFIX \
+            --viaduct-start-daa-score=$$IGRA_LAUNCH_DAA_SCORE \
+            --igra-l1-reference-timestamp=$$L1_REFERENCE_TIMESTAMP \
+            --igra-l1-reference-daa-score=$$L1_REFERENCE_DAA_SCORE \
+            --igra-genesis-hash=$$GENESIS_BLOCK_HASH \
+            --igra-min-fee-per-gas-gwei=$$MIN_PROTOCOL_FEE_PER_GAS_GWEI \
             --igra-jwt-path=/app/jwt.hex \
-            --igra-lock-script-pubkey=${IGRA_LOCK_SCRIPT_PUBKEY} \
-            --igra-entry-min-amount=${IGRA_ENTRY_MIN_AMOUNT} \
+            --igra-lock-script-pubkey=$$IGRA_LOCK_SCRIPT_PUBKEY \
+            --igra-entry-min-amount=$$IGRA_ENTRY_MIN_AMOUNT \
             --igra-el-host=http://execution-layer"
 
           [ "$$ENABLE_PERF_DIAGNOSTICS" = "true" ] && ARGS="$$ARGS --igra-enable-perf-diagnostics"
@@ -234,7 +243,9 @@ services:
     expose:
       - "8082"
     ports:
-      - "127.0.0.1:8082:8082"  # open 8082 on localhost for entry transactions
+      # Host side parameterized so the devnet can coexist with a production/testnet
+      # kaswallet, which also binds 8082.
+      - "127.0.0.1:${KASWALLET_HOST_PORT:-8082}:8082"
     environment:
       - RUST_LOG
       - NETWORK
@@ -294,7 +305,7 @@ services:
       SECURITY_ENABLE_WHITELIST: "true"
       # Off-box write exposure is prevented by RPC_READ_ONLY (default true) and
       # the loopback host bind below; flip RPC_READ_ONLY to enable writes.
-      READ_ONLY: ${RPC_READ_ONLY}
+      READ_ONLY: ${RPC_READ_ONLY:-true}
       MIN_PROTOCOL_FEE_PER_GAS_GWEI: ${MIN_PROTOCOL_FEE_PER_GAS_GWEI}
       TX_ID_PREFIX: ${TX_ID_PREFIX}
       IGRA_LANE_ID: ${IGRA_LANE_ID:-}
@@ -307,7 +318,7 @@ services:
     ports:
       # Loopback by default (no Traefik/TLS/auth on devnet). Set RPC_BIND_ADDR=0.0.0.0
       # only to deliberately expose the wallet-backed RPC to the LAN/internet.
-      - "${RPC_BIND_ADDR:-127.0.0.1}:${RPC_PORT}:8535"
+      - "${RPC_BIND_ADDR:-127.0.0.1}:${RPC_PORT:-8555}:8535"
     entrypoint:
       - sh
       - -ec
@@ -333,29 +344,4 @@ services:
             bash -lc ": > /dev/tcp/$$KASWALLET_HOST/8082";
           fi
 
-  kaspa-miner:
-    # "mining" profile so setup does not start it before it is built. Run manually:
-    #   docker compose --profile mining up -d --build kaspa-miner
-    profiles: ["mining"]
-    restart: *service-restart-policy
-    build:
-      context: build/repos/kaspa-miner
-      dockerfile: ../../Dockerfile.kaspa-miner
-    image: kaspa-miner
-    container_name: kaspa-miner-devnet
-    logging: *default-logging
-    environment:
-      - RUST_LOG
-      - REPLAY_ON_ERROR
-      - SYNC_THREADS
-    entrypoint: >
-      sh -c '
-      KASPAD=$$(getent ahostsv4 kaspad | grep kaspad | grep -Eo "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b") &&
-      exec /app/kaspa-miner
-      --mining-address ${MINING_ADDRESS:-}
-      --kaspad-address $$KASPAD
-      --port ${KASPAD_GRPC_PORT}
-      --threads ${MINING_THREADS:-1}
-      '
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+  # No kaspa-miner service: run one on the host via scripts/dev/run-devnet-miner.sh.

--- a/scripts/dev/run-devnet-miner.sh
+++ b/scripts/dev/run-devnet-miner.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# run-devnet-miner.sh - Set up and run a standalone kaspa-miner against the local
+# IGRA devnet, outside the docker-compose stack. Clones and builds
+# tmrlvi/kaspa-miner once, then runs it on the host against the devnet kaspad gRPC
+# port. Reads MINING_ADDRESS / MINING_THREADS / KASPAD_GRPC_PORT from .env.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Reuse predicates (is_port, is_positive_int, is_valid_mining_address).
+# shellcheck source=scripts/lib/devnet-preflight.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-preflight.sh"
+
+log()  { echo "[run-devnet-miner] $*"; }
+warn() { echo "[run-devnet-miner] WARNING: $*" >&2; }
+die()  { echo "[run-devnet-miner] ERROR: $*" >&2; exit 1; }
+
+print_help() {
+    cat <<'EOF'
+Usage: ./scripts/dev/run-devnet-miner.sh [--help]
+
+Clones and builds tmrlvi/kaspa-miner (once) and runs it against the local devnet
+kaspad gRPC port. Runs in the foreground; press Ctrl+C to stop.
+
+Configuration is read from .env (or .env.devnet.example if there is no .env);
+shell/CLI values take precedence over the file.
+
+Environment variables:
+  MINING_ADDRESS          Reward address; must be a devnet address (kaspadev:...).
+  MINING_THREADS          CPU miner threads (positive integer). Default: 1.
+  KASPAD_GRPC_PORT        Devnet kaspad gRPC port on the host. Default: 16610.
+  KASPAD_RPC_HOST         Host the miner dials. Default: 127.0.0.1 (NOT the
+                          compose-internal KASPAD_HOST, which is unreachable here).
+  MINE_WHEN_NOT_SYNCED    true|false. Default: true (a fresh single-node devnet
+                          reports "not synced"; pass the flag so it still mines).
+
+  MINER_REPO_URL          Default: https://github.com/tmrlvi/kaspa-miner.git
+  MINER_BRANCH            Branch/tag to clone. Default: repo default branch.
+  MINER_DIR               Clone/build location.
+                          Default: build/repos/tmrlvi-kaspa-miner
+  MINER_BUILD_GPU         auto|on|off. Default: auto (build GPU crates when CUDA/
+                          OpenCL toolchains are detected, fall back to CPU-only on
+                          build failure; otherwise build CPU-only directly).
+  MINER_EXTRA_ARGS        Extra flags appended verbatim to the miner invocation.
+  SKIP_BUILD=1            Reuse an existing release binary; skip clone/build.
+
+Examples:
+  ./scripts/dev/run-devnet-miner.sh
+  MINING_THREADS=4 ./scripts/dev/run-devnet-miner.sh
+  MINER_BUILD_GPU=off SKIP_BUILD=1 ./scripts/dev/run-devnet-miner.sh
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    print_help
+    exit 0
+fi
+
+# --- resolve config (shell/CLI > .env > .env.devnet.example > default) ---
+ENV_FILE="$PROJECT_DIR/.env"
+[ -f "$ENV_FILE" ] || ENV_FILE="$PROJECT_DIR/.env.devnet.example"
+
+# read_env KEY -> prints the trimmed, unquoted value from ENV_FILE; returns 1 if absent.
+read_env() {
+    local key="$1" line val found=1
+    [ -f "$ENV_FILE" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key"=*)
+                val="${line#*=}"
+                val="${val#"${val%%[![:space:]]*}"}"
+                val="${val%"${val##*[![:space:]]}"}"
+                case "$val" in
+                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
+                esac
+                found=0
+                ;;
+        esac
+    done < "$ENV_FILE"
+    [ "$found" -eq 0 ] && printf '%s' "$val"
+    return "$found"
+}
+
+# resolve NAME DEFAULT -> sets NAME from shell (if already set) else file else default.
+resolve() {
+    local name="$1" default="$2" val
+    [ -n "${!name+set}" ] && return 0
+    if val="$(read_env "$name")"; then
+        printf -v "$name" '%s' "$val"
+    else
+        printf -v "$name" '%s' "$default"
+    fi
+}
+
+[ -f "$ENV_FILE" ] && log "Reading config from $ENV_FILE (shell overrides win)"
+
+resolve MINING_ADDRESS ""
+resolve MINING_THREADS 1
+resolve KASPAD_GRPC_PORT 16610
+# Host loopback, not the compose-internal KASPAD_HOST (=kaspad).
+KASPAD_RPC_HOST="${KASPAD_RPC_HOST:-127.0.0.1}"
+MINE_WHEN_NOT_SYNCED="${MINE_WHEN_NOT_SYNCED:-true}"
+
+MINER_REPO_URL="${MINER_REPO_URL:-https://github.com/tmrlvi/kaspa-miner.git}"
+MINER_BRANCH="${MINER_BRANCH:-}"
+MINER_DIR="${MINER_DIR:-$PROJECT_DIR/build/repos/tmrlvi-kaspa-miner}"
+MINER_BUILD_GPU="${MINER_BUILD_GPU:-auto}"
+MINER_EXTRA_ARGS="${MINER_EXTRA_ARGS:-}"
+
+BIN="$MINER_DIR/target/release/kaspa-miner"
+
+# --- validate ---
+command -v git >/dev/null 2>&1 || die "git not found"
+is_valid_mining_address "$MINING_ADDRESS" || \
+    die "MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}'). Set it in .env or pass MINING_ADDRESS=..."
+is_positive_int "$MINING_THREADS" || \
+    die "MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')"
+is_port "$KASPAD_GRPC_PORT" || \
+    die "KASPAD_GRPC_PORT must be an integer in 1-65535 (got: '${KASPAD_GRPC_PORT:-<unset>}')"
+case "$MINER_BUILD_GPU" in auto|on|off) ;; *) die "MINER_BUILD_GPU must be auto|on|off (got: '$MINER_BUILD_GPU')" ;; esac
+
+# --- clone + build (unless SKIP_BUILD reuses an existing binary) ---
+has_opencl() {
+    command -v clinfo >/dev/null 2>&1 || [ -d /etc/OpenCL/vendors ]
+}
+
+build_miner() {
+    command -v cargo >/dev/null 2>&1 || \
+        die "cargo (Rust toolchain) not found; needed to build the miner. Install via https://rustup.rs, or set SKIP_BUILD=1 to reuse an existing binary."
+
+    if [ ! -d "$MINER_DIR/.git" ]; then
+        log "Cloning $MINER_REPO_URL -> $MINER_DIR"
+        if [ -n "$MINER_BRANCH" ]; then
+            git clone --depth 1 --branch "$MINER_BRANCH" "$MINER_REPO_URL" "$MINER_DIR"
+        else
+            git clone --depth 1 "$MINER_REPO_URL" "$MINER_DIR"
+        fi
+    else
+        log "Reusing existing clone at $MINER_DIR"
+    fi
+
+    local want_gpu=false
+    case "$MINER_BUILD_GPU" in
+        on) want_gpu=true ;;
+        off) want_gpu=false ;;
+        auto)
+            if command -v nvcc >/dev/null 2>&1 || has_opencl; then
+                want_gpu=true
+                log "GPU toolchain detected; attempting GPU build (will fall back to CPU-only on failure)."
+            else
+                log "No CUDA/OpenCL toolchain detected; building CPU-only."
+            fi
+            ;;
+    esac
+
+    log "Building kaspa-miner (release)..."
+    if $want_gpu; then
+        if cargo build --release --manifest-path "$MINER_DIR/Cargo.toml" \
+                -p kaspa-miner -p kaspacuda -p kaspaopencl; then
+            return 0
+        fi
+        warn "GPU build failed; retrying CPU-only."
+    fi
+    cargo build --release --manifest-path "$MINER_DIR/Cargo.toml" -p kaspa-miner
+}
+
+if [ "${SKIP_BUILD:-}" = "1" ]; then
+    [ -x "$BIN" ] || die "SKIP_BUILD=1 but no binary at $BIN; unset SKIP_BUILD to clone and build it."
+    log "SKIP_BUILD=1; reusing existing binary $BIN"
+else
+    build_miner
+    [ -x "$BIN" ] || die "miner binary not found at $BIN after build"
+fi
+
+# --- preflight: is the devnet kaspad reachable? (non-fatal; the miner retries) ---
+if timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
+    log "devnet kaspad gRPC reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT"
+else
+    warn "devnet kaspad gRPC not reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT yet."
+    warn "Start the stack first (./scripts/setup-devnet.sh); the miner will keep retrying."
+fi
+
+# --- run (foreground; Ctrl+C stops) ---
+args=(-a "$MINING_ADDRESS" -s "$KASPAD_RPC_HOST" -p "$KASPAD_GRPC_PORT" -t "$MINING_THREADS")
+[ "$MINE_WHEN_NOT_SYNCED" = "true" ] && args+=(--mine-when-not-synced)
+
+log "Starting miner -> $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT (address ${MINING_ADDRESS}, ${MINING_THREADS} threads)"
+log "Press Ctrl+C to stop."
+# Word-split MINER_EXTRA_ARGS so callers can pass multiple flags.
+# shellcheck disable=SC2086
+exec "$BIN" "${args[@]}" $MINER_EXTRA_ARGS

--- a/scripts/dev/test-devnet-preflight.sh
+++ b/scripts/dev/test-devnet-preflight.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# test-devnet-preflight.sh - plain-bash unit tests for scripts/lib/devnet-preflight.sh
+# Run: ./scripts/dev/test-devnet-preflight.sh   (exit 0 = all pass)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/devnet-preflight.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# ok DESC CMD...   -> expects CMD to succeed (exit 0)
+ok() {
+    local desc="$1"; shift
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if "$@"; then echo "PASS: $desc"; else
+        echo "FAIL: $desc (expected success)"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+
+# no DESC CMD...   -> expects CMD to fail (non-zero)
+no() {
+    local desc="$1"; shift
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if "$@"; then
+        echo "FAIL: $desc (expected failure)"; TESTS_FAILED=$((TESTS_FAILED + 1));
+    else echo "PASS: $desc"; fi
+}
+
+# --- predicate tests ---
+ok  "is_uint 0"            is_uint 0
+ok  "is_uint 123"          is_uint 123
+no  "is_uint empty"        is_uint ""
+no  "is_uint -5"           is_uint -5
+no  "is_uint abc"          is_uint abc
+
+ok  "is_positive_int 1"    is_positive_int 1
+no  "is_positive_int 0"    is_positive_int 0
+no  "is_positive_int x"    is_positive_int x
+
+ok  "is_hex 9ab1"          is_hex 9ab1
+no  "is_hex 0xff"          is_hex 0xff
+no  "is_hex empty"         is_hex ""
+
+ok  "is_hex_even 97b1"     is_hex_even 97b1
+no  "is_hex_even 97b"      is_hex_even 97b
+no  "is_hex_even zz"       is_hex_even zz
+
+ok  "is_port 8555"         is_port 8555
+ok  "is_port 1"            is_port 1
+ok  "is_port 65535"        is_port 65535
+no  "is_port 0"            is_port 0
+no  "is_port 70000"        is_port 70000
+no  "is_port empty"        is_port ""
+
+ok  "mining addr valid"    is_valid_mining_address "kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
+no  "mining addr mainnet"  is_valid_mining_address "kaspa:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
+no  "mining addr empty"    is_valid_mining_address ""
+
+# --- validate_devnet_env: a known-good baseline, then mutate one field per case ---
+# shellcheck disable=SC2034
+good_env() {
+    NETWORK=devnet
+    TX_ID_PREFIX=97b1
+    IGRA_LANE_ID=97b10000
+    FINALITY_PERIOD_SECONDS=600
+    TOCCATA_ACTIVATION_DAA_SCORE=1000
+    KASPAD_GRPC_PORT=16610 KASPAD_P2P_PORT=16611
+    KASPAD_BORSH_PORT=17610 KASPAD_JSON_PORT=18610
+    RPC_PORT=8555 EL_RPC_HOST_PORT=9545 EL_WS_HOST_PORT=9546
+    MINING_ADDRESS="kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
+    MINING_THREADS=1
+    IGRA_LOCK_SCRIPT_PUBKEY=20aeb014c0814f5c549bbea36638e08b1e8d4c1b8251780841fce1fdcbf72ee01dac
+    POST_FORK_LOCK_SCRIPT_PUBKEY="" LOCK_SCRIPT_FORK_DAA_SCORE=""
+    RPC_BIND_ADDR=127.0.0.1 RPC_READ_ONLY=true
+    IGRA_LAUNCH_DAA_SCORE=0 L1_REFERENCE_DAA_SCORE=0 L1_REFERENCE_TIMESTAMP=1735689600
+}
+
+ok "validate: good baseline"        bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; validate_devnet_env"
+no "validate: NETWORK not devnet"   bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; NETWORK=mainnet; validate_devnet_env"
+no "validate: TX_ID_PREFIX odd"     bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; TX_ID_PREFIX=97b; validate_devnet_env"
+no "validate: bad lane id"          bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LANE_ID=zz; validate_devnet_env"
+no "validate: lane missing+toccata" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LANE_ID=; validate_devnet_env"
+no "validate: port out of range"    bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; RPC_PORT=70000; validate_devnet_env"
+no "validate: port collision"       bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; EL_WS_HOST_PORT=9545; validate_devnet_env"
+no "validate: mining addr mainnet"  bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; MINING_ADDRESS=kaspa:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s; validate_devnet_env"
+no "validate: lock pair half-set"   bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; POST_FORK_LOCK_SCRIPT_PUBKEY=20ab; validate_devnet_env"
+ok "validate: lock pair both set"   bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; POST_FORK_LOCK_SCRIPT_PUBKEY=20ab; LOCK_SCRIPT_FORK_DAA_SCORE=5000; validate_devnet_env"
+no "validate: toccata <= maturity"  bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; TOCCATA_ACTIVATION_DAA_SCORE=100; validate_devnet_env"
+no "validate: negative genesis ts"  bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; L1_REFERENCE_TIMESTAMP=0; L1_REFERENCE_DAA_SCORE=100; IGRA_LAUNCH_DAA_SCORE=0; validate_devnet_env"
+no "validate: finality too low"     bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; FINALITY_PERIOD_SECONDS=10; validate_devnet_env"
+ok "validate: open RPC bind warns not errors" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; RPC_BIND_ADDR=0.0.0.0; RPC_READ_ONLY=false; validate_devnet_env"
+
+# --- resolve_devnet_env ---
+RESOLVE_TMP="$(mktemp -d)"
+mkdir -p "$RESOLVE_TMP"
+cat > "$RESOLVE_TMP/.env.devnet.example" <<'ENVEOF'
+NETWORK=devnet
+FINALITY_PERIOD_SECONDS=600
+RPC_PORT=8555
+ENVEOF
+cat > "$RESOLVE_TMP/versions.devnet.env" <<'ENVEOF'
+KASPAD_VERSION=devnet
+ENVEOF
+
+ok "resolve: loads template when no .env" bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$RPC_PORT\" = 8555 ] && [ \"\$KASPAD_VERSION\" = devnet ] && [ \"\$DEVNET_ENV_SOURCE\" = '$RESOLVE_TMP/.env.devnet.example' ]"
+ok "resolve: shell override wins"         bash -c "$(declare -f resolve_devnet_env); FINALITY_PERIOD_SECONDS=999 resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$FINALITY_PERIOD_SECONDS\" = 999 ]"
+no "resolve: missing source fails"        bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .nope.example versions.devnet.env"
+rm -rf "$RESOLVE_TMP"
+
+# --- mining_preflight ---
+MINE_TMP="$(mktemp -d)"
+mkdir -p "$MINE_TMP/repos/kaspa-miner"
+touch "$MINE_TMP/Dockerfile.kaspa-miner"
+MINE_FUNCS="$(declare -f mining_preflight is_valid_mining_address is_positive_int)"
+
+ok "mining: all present + valid" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
+no "mining: miner repo missing"  bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/nope' '$MINE_TMP/Dockerfile.kaspa-miner'"
+no "mining: dockerfile missing"  bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/nope.Dockerfile'"
+no "mining: bad address"         bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspa:bad MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
+no "mining: bad threads"         bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=0 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
+rm -rf "$MINE_TMP"
+
+# --- record_source_revisions ---
+REV_TMP="$(mktemp -d)"
+mkdir -p "$REV_TMP/repos/rusty-kaspa-private" "$REV_TMP/out"
+( cd "$REV_TMP/repos/rusty-kaspa-private" && git init -q && git config user.email t@t && git config user.name t && git commit -q --allow-empty -m init )
+REV_FUNCS="$(declare -f record_source_revisions)"
+ok "revisions: writes a manifest file" bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; ls '$REV_TMP/out'/*.txt >/dev/null 2>&1"
+ok "revisions: records clean repo"     bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; grep -q 'rusty-kaspa-private.*clean' \$(ls '$REV_TMP/out'/*.txt | head -1)"
+ok "revisions: marks missing repo"     bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; grep -q '^kaspa-miner.*missing' \$(ls '$REV_TMP/out'/*.txt | tail -1)"
+rm -rf "$REV_TMP"
+
+echo "----"
+echo "$((TESTS_RUN - TESTS_FAILED))/$TESTS_RUN passed"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/scripts/dev/test-devnet-preflight.sh
+++ b/scripts/dev/test-devnet-preflight.sh
@@ -35,10 +35,14 @@ ok  "is_uint 123"          is_uint 123
 no  "is_uint empty"        is_uint ""
 no  "is_uint -5"           is_uint -5
 no  "is_uint abc"          is_uint abc
+no  "is_uint 08 (octal)"   is_uint 08
+no  "is_uint 011 (octal)"  is_uint 011
+no  "is_uint 00"           is_uint 00
 
 ok  "is_positive_int 1"    is_positive_int 1
 no  "is_positive_int 0"    is_positive_int 0
 no  "is_positive_int x"    is_positive_int x
+no  "is_positive_int 007"  is_positive_int 007
 
 ok  "is_hex 9ab1"          is_hex 9ab1
 no  "is_hex 0xff"          is_hex 0xff
@@ -54,6 +58,7 @@ ok  "is_port 65535"        is_port 65535
 no  "is_port 0"            is_port 0
 no  "is_port 70000"        is_port 70000
 no  "is_port empty"        is_port ""
+no  "is_port 08 (octal)"   is_port 08
 
 ok  "mining addr valid"    is_valid_mining_address "kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
 no  "mining addr mainnet"  is_valid_mining_address "kaspa:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
@@ -69,7 +74,7 @@ good_env() {
     TOCCATA_ACTIVATION_DAA_SCORE=1000
     KASPAD_GRPC_PORT=16610 KASPAD_P2P_PORT=16611
     KASPAD_BORSH_PORT=17610 KASPAD_JSON_PORT=18610
-    RPC_PORT=8555 EL_RPC_HOST_PORT=9545 EL_WS_HOST_PORT=9546
+    RPC_PORT=8555 EL_RPC_HOST_PORT=9545 EL_WS_HOST_PORT=9546 KASWALLET_HOST_PORT=8082
     MINING_ADDRESS="kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s"
     MINING_THREADS=1
     IGRA_LOCK_SCRIPT_PUBKEY=20aeb014c0814f5c549bbea36638e08b1e8d4c1b8251780841fce1fdcbf72ee01dac
@@ -92,6 +97,10 @@ no "validate: toccata <= maturity"  bash -c "$(declare -f good_env validate_devn
 no "validate: negative genesis ts"  bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; L1_REFERENCE_TIMESTAMP=0; L1_REFERENCE_DAA_SCORE=100; IGRA_LAUNCH_DAA_SCORE=0; validate_devnet_env"
 no "validate: finality too low"     bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; FINALITY_PERIOD_SECONDS=10; validate_devnet_env"
 ok "validate: open RPC bind warns not errors" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; RPC_BIND_ADDR=0.0.0.0; RPC_READ_ONLY=false; validate_devnet_env"
+no "validate: lane uppercase"       bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LANE_ID=97B10000; validate_devnet_env"
+no "validate: lane all-zero"        bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LANE_ID=00000000; validate_devnet_env"
+no "validate: kaswallet port clash" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; KASWALLET_HOST_PORT=8555; validate_devnet_env"
+no "validate: zero-padded launch"   bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LAUNCH_DAA_SCORE=08; validate_devnet_env"
 
 # --- resolve_devnet_env ---
 RESOLVE_TMP="$(mktemp -d)"
@@ -100,6 +109,7 @@ cat > "$RESOLVE_TMP/.env.devnet.example" <<'ENVEOF'
 NETWORK=devnet
 FINALITY_PERIOD_SECONDS=600
 RPC_PORT=8555
+IGRA_LANE_ID=97b10000
 ENVEOF
 cat > "$RESOLVE_TMP/versions.devnet.env" <<'ENVEOF'
 KASPAD_VERSION=devnet
@@ -107,30 +117,29 @@ ENVEOF
 
 ok "resolve: loads template when no .env" bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$RPC_PORT\" = 8555 ] && [ \"\$KASPAD_VERSION\" = devnet ] && [ \"\$DEVNET_ENV_SOURCE\" = '$RESOLVE_TMP/.env.devnet.example' ]"
 ok "resolve: shell override wins"         bash -c "$(declare -f resolve_devnet_env); FINALITY_PERIOD_SECONDS=999 resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$FINALITY_PERIOD_SECONDS\" = 999 ]"
+# A set-but-empty shell override must win over the file value (opt-out contract).
+ok "resolve: empty shell override wins"   bash -c "$(declare -f resolve_devnet_env); IGRA_LANE_ID= resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ -z \"\$IGRA_LANE_ID\" ]"
+ok "resolve: unset falls to file value"   bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$IGRA_LANE_ID\" = 97b10000 ]"
 no "resolve: missing source fails"        bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .nope.example versions.devnet.env"
 rm -rf "$RESOLVE_TMP"
 
-# --- mining_preflight ---
-MINE_TMP="$(mktemp -d)"
-mkdir -p "$MINE_TMP/repos/kaspa-miner"
-touch "$MINE_TMP/Dockerfile.kaspa-miner"
+# --- mining_preflight (validates mining config only; the miner is external) ---
 MINE_FUNCS="$(declare -f mining_preflight is_valid_mining_address is_positive_int)"
 
-ok "mining: all present + valid" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
-no "mining: miner repo missing"  bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/nope' '$MINE_TMP/Dockerfile.kaspa-miner'"
-no "mining: dockerfile missing"  bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/nope.Dockerfile'"
-no "mining: bad address"         bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspa:bad MINING_THREADS=1 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
-no "mining: bad threads"         bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=0 mining_preflight '$MINE_TMP/repos' '$MINE_TMP/Dockerfile.kaspa-miner'"
-rm -rf "$MINE_TMP"
+ok "mining: valid addr + threads" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight 2>/dev/null"
+no "mining: bad address"          bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspa:bad MINING_THREADS=1 mining_preflight 2>/dev/null"
+no "mining: bad threads"          bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=0 mining_preflight 2>/dev/null"
 
 # --- record_source_revisions ---
 REV_TMP="$(mktemp -d)"
 mkdir -p "$REV_TMP/repos/rusty-kaspa-private" "$REV_TMP/out"
 ( cd "$REV_TMP/repos/rusty-kaspa-private" && git init -q && git config user.email t@t && git config user.name t && git commit -q --allow-empty -m init )
-REV_FUNCS="$(declare -f record_source_revisions)"
+REV_FUNCS="$(declare -f record_source_revisions is_positive_int)"
 ok "revisions: writes a manifest file" bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; ls '$REV_TMP/out'/*.txt >/dev/null 2>&1"
 ok "revisions: records clean repo"     bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; grep -q 'rusty-kaspa-private.*clean' \$(ls '$REV_TMP/out'/*.txt | head -1)"
-ok "revisions: marks missing repo"     bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; grep -q '^kaspa-miner.*missing' \$(ls '$REV_TMP/out'/*.txt | tail -1)"
+ok "revisions: marks missing repo"     bash -c "$REV_FUNCS; NETWORK=devnet record_source_revisions '$REV_TMP/repos' '$REV_TMP/out' >/dev/null; grep -q '^reth-private.*missing' \$(ls '$REV_TMP/out'/*.txt | tail -1)"
+# Retention cap: with REHEARSAL_KEEP=2, three runs leave only the 2 newest manifests.
+ok "revisions: caps retention to REHEARSAL_KEEP" bash -c "$REV_FUNCS; export NETWORK=devnet REHEARSAL_KEEP=2; for i in 1 2 3; do record_source_revisions '$REV_TMP/repos' '$REV_TMP/keep' >/dev/null; done; [ \"\$(ls '$REV_TMP/keep'/*.txt | wc -l)\" -eq 2 ]"
 rm -rf "$REV_TMP"
 
 echo "----"

--- a/scripts/lib/devnet-preflight.sh
+++ b/scripts/lib/devnet-preflight.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# devnet-preflight.sh - Validation, mining preflight, and source-revision
+# recording for the IGRA devnet setup flow. Sourced by scripts/setup-devnet.sh.
+# Functions are pure (inputs via args/env, output via message + return code) so
+# they can be unit-tested without Docker (see scripts/dev/test-devnet-preflight.sh).
+
+# --- predicate helpers (return 0 = true, 1 = false; no output) ---
+
+is_uint()          { [[ "${1:-}" =~ ^[0-9]+$ ]]; }
+is_positive_int()  { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( ${1:-0} > 0 )); }
+is_hex()           { [[ "${1:-}" =~ ^[0-9a-fA-F]+$ ]]; }
+is_hex_even()      { [[ "${1:-}" =~ ^([0-9a-fA-F]{2})+$ ]]; }
+is_port()          { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( ${1:-0} >= 1 && ${1:-0} <= 65535 )); }
+# Devnet kaspa address: kaspadev: prefix + bech32 charset payload (>= 59 chars).
+is_valid_mining_address() {
+    [[ "${1:-}" =~ ^kaspadev:[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{59,}$ ]]
+}
+
+# validate_devnet_env - check the resolved devnet configuration in the
+# environment. Aggregates ALL problems, prints them to stderr, returns 1 if any.
+validate_devnet_env() {
+    local errors=()
+    local toccata="${TOCCATA_ACTIVATION_DAA_SCORE:-}"
+    local launch="${IGRA_LAUNCH_DAA_SCORE:-}"
+    local l1daa="${L1_REFERENCE_DAA_SCORE:-}"
+    local l1ts="${L1_REFERENCE_TIMESTAMP:-}"
+    local name p
+
+    # NETWORK
+    [ "${NETWORK:-}" = "devnet" ] || \
+        errors+=("NETWORK must be 'devnet' (got: '${NETWORK:-<unset>}')")
+
+    # TX_ID_PREFIX
+    is_hex_even "${TX_ID_PREFIX:-}" || \
+        errors+=("TX_ID_PREFIX must be hex with an even number of chars (got: '${TX_ID_PREFIX:-<unset>}')")
+
+    # IGRA_LANE_ID: 8 or 40 hex; mandatory when Toccata is scheduled
+    if [ -n "${IGRA_LANE_ID:-}" ]; then
+        [[ "${IGRA_LANE_ID}" =~ ^([0-9a-fA-F]{8}|[0-9a-fA-F]{40})$ ]] || \
+            errors+=("IGRA_LANE_ID must be 8 or 40 hex chars (got: '${IGRA_LANE_ID}')")
+    elif [ -n "$toccata" ]; then
+        errors+=("IGRA_LANE_ID is required when TOCCATA_ACTIVATION_DAA_SCORE is set")
+    fi
+
+    # FINALITY_PERIOD_SECONDS
+    local fin="${FINALITY_PERIOD_SECONDS:-}"
+    if ! is_uint "$fin"; then
+        errors+=("FINALITY_PERIOD_SECONDS must be an integer (got: '${fin:-<unset>}')")
+    elif (( fin < 60 || fin > 92000 )); then
+        errors+=("FINALITY_PERIOD_SECONDS must be in [60, 92000] (got: $fin)")
+    fi
+
+    # Ports: range, then collision among the valid ones
+    local ports=()
+    for name in KASPAD_GRPC_PORT KASPAD_P2P_PORT KASPAD_BORSH_PORT KASPAD_JSON_PORT \
+                RPC_PORT EL_RPC_HOST_PORT EL_WS_HOST_PORT; do
+        p="${!name:-}"
+        if is_port "$p"; then
+            ports+=("$p:$name")
+        else
+            errors+=("$name must be an integer in 1-65535 (got: '${p:-<unset>}')")
+        fi
+    done
+    if (( ${#ports[@]} > 0 )); then
+        local dup
+        dup="$(printf '%s\n' "${ports[@]}" | cut -d: -f1 | sort | uniq -d)"
+        if [ -n "$dup" ]; then
+            local val who
+            while IFS= read -r val; do
+                [ -n "$val" ] || continue
+                who="$(printf '%s\n' "${ports[@]}" | awk -F: -v v="$val" '$1==v{printf "%s ",$2}')"
+                errors+=("port collision on $val: ${who% }")
+            done <<< "$dup"
+        fi
+    fi
+
+    # Mining
+    is_valid_mining_address "${MINING_ADDRESS:-}" || \
+        errors+=("MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}')")
+    is_positive_int "${MINING_THREADS:-}" || \
+        errors+=("MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')")
+
+    # Lock script pubkey (entry) hex when present
+    if [ -n "${IGRA_LOCK_SCRIPT_PUBKEY:-}" ]; then
+        is_hex "${IGRA_LOCK_SCRIPT_PUBKEY}" || \
+            errors+=("IGRA_LOCK_SCRIPT_PUBKEY must be hex (got: '${IGRA_LOCK_SCRIPT_PUBKEY}')")
+    fi
+
+    # Lock-script fork pair: both set or both empty
+    local pf="${POST_FORK_LOCK_SCRIPT_PUBKEY:-}" fd="${LOCK_SCRIPT_FORK_DAA_SCORE:-}"
+    if [ -n "$pf" ] && [ -z "$fd" ]; then
+        errors+=("LOCK_SCRIPT_FORK_DAA_SCORE must be set when POST_FORK_LOCK_SCRIPT_PUBKEY is set")
+    fi
+    if [ -z "$pf" ] && [ -n "$fd" ]; then
+        errors+=("POST_FORK_LOCK_SCRIPT_PUBKEY must be set when LOCK_SCRIPT_FORK_DAA_SCORE is set")
+    fi
+    [ -z "$pf" ] || is_hex "$pf" || errors+=("POST_FORK_LOCK_SCRIPT_PUBKEY must be hex")
+    if [ -n "$fd" ] && ! is_uint "$fd"; then
+        errors+=("LOCK_SCRIPT_FORK_DAA_SCORE must be a non-negative integer (got: '$fd')")
+    fi
+
+    # RPC bind address: valid host/IP when set; warn on unsafe exposure
+    if [ -n "${RPC_BIND_ADDR:-}" ]; then
+        [[ "${RPC_BIND_ADDR}" =~ ^[0-9A-Za-z.:_-]+$ ]] || \
+            errors+=("RPC_BIND_ADDR must be a valid host/IP (got: '${RPC_BIND_ADDR}')")
+        if [ "${RPC_BIND_ADDR}" = "0.0.0.0" ] && [ "${RPC_READ_ONLY:-true}" = "false" ]; then
+            echo "WARNING: RPC_BIND_ADDR=0.0.0.0 with RPC_READ_ONLY=false exposes the" >&2
+            echo "         wallet-backed RPC off-box with no TLS/auth." >&2
+        fi
+    fi
+
+    # DAA ordering
+    for name in IGRA_LAUNCH_DAA_SCORE L1_REFERENCE_DAA_SCORE L1_REFERENCE_TIMESTAMP; do
+        is_uint "${!name:-}" || \
+            errors+=("$name must be a non-negative integer (got: '${!name:-<unset>}')")
+    done
+    if is_uint "$launch" && is_uint "$l1daa" && is_uint "$l1ts"; then
+        local genesis_ts=$(( launch / 10 - l1daa / 10 + l1ts - 1 ))
+        (( genesis_ts > 0 )) || \
+            errors+=("derived EL genesis timestamp must be positive: (IGRA_LAUNCH_DAA_SCORE/10 - L1_REFERENCE_DAA_SCORE/10 + L1_REFERENCE_TIMESTAMP - 1) = $genesis_ts")
+    fi
+    if [ -n "$toccata" ]; then
+        if is_uint "$toccata"; then
+            if is_uint "$launch" && ! (( toccata > launch )); then
+                errors+=("TOCCATA_ACTIVATION_DAA_SCORE ($toccata) must be > IGRA_LAUNCH_DAA_SCORE ($launch)")
+            fi
+            (( toccata > 200 )) || \
+                errors+=("TOCCATA_ACTIVATION_DAA_SCORE ($toccata) must be > coinbase_maturity (200) to leave a pre-fork window")
+        else
+            errors+=("TOCCATA_ACTIVATION_DAA_SCORE must be a non-negative integer (got: '$toccata')")
+        fi
+    fi
+    if [ -n "$fd" ] && is_uint "$fd" && is_uint "$launch" && ! (( fd >= launch )); then
+        errors+=("LOCK_SCRIPT_FORK_DAA_SCORE ($fd) must be >= IGRA_LAUNCH_DAA_SCORE ($launch)")
+    fi
+
+    if (( ${#errors[@]} > 0 )); then
+        echo "Devnet configuration is invalid:" >&2
+        printf '  ERROR: %s\n' "${errors[@]}" >&2
+        return 1
+    fi
+    return 0
+}
+
+# resolve_devnet_env - load the single effective env source (.env if present,
+# else the committed template) plus the versions file, exporting everything so
+# validation AND the build read identical inputs. Shell/CLI values for the
+# documented tunables take precedence over the file (README runs the script with
+# e.g. FINALITY_PERIOD_SECONDS=600 ./scripts/setup-devnet.sh).
+resolve_devnet_env() {
+    local project_dir="$1" env_file="$2" versions_file="$3"
+    local source_path
+
+    if [ -f "$project_dir/.env" ]; then
+        source_path="$project_dir/.env"
+    else
+        source_path="$project_dir/$env_file"
+        echo "[setup-devnet] No .env yet; using template $env_file for build-time inputs" >&2
+        echo "               (run_setup will create .env from the same template)." >&2
+    fi
+    if [ ! -f "$source_path" ]; then
+        echo "ERROR: env source not found: $source_path" >&2
+        return 1
+    fi
+    export DEVNET_ENV_SOURCE="$source_path"
+
+    # Capture shell-provided tunables (set, even if empty) so the file cannot
+    # clobber a command-line override.
+    local k saved=()
+    for k in FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID; do
+        [ -n "${!k+x}" ] && saved+=("$k=${!k}")
+    done
+
+    set -a
+    # shellcheck source=/dev/null
+    source "$source_path"
+    if [ -f "$project_dir/$versions_file" ]; then
+        # shellcheck source=/dev/null
+        source "$project_dir/$versions_file"
+    fi
+    set +a
+
+    # Re-apply captured shell overrides (precedence: shell > file).
+    if (( ${#saved[@]} > 0 )); then
+        local kv
+        for kv in "${saved[@]}"; do export "${kv?}"; done
+    fi
+}
+
+# mining_preflight - verify mining can actually run. Called when Toccata is
+# scheduled, because the KIP-21 rehearsal cannot reach the activation DAA score
+# without mined blocks. Returns 1 (with actionable errors) if mining is impossible.
+mining_preflight() {
+    local repos_dir="$1" dockerfile="$2"
+    local errors=()
+
+    [ -d "$repos_dir/kaspa-miner" ] || \
+        errors+=("kaspa-miner source repo not found at $repos_dir/kaspa-miner (clone via scripts/dev/setup-repos.sh)")
+    [ -f "$dockerfile" ] || \
+        errors+=("kaspa-miner Dockerfile not found at $dockerfile")
+    is_valid_mining_address "${MINING_ADDRESS:-}" || \
+        errors+=("MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}')")
+    is_positive_int "${MINING_THREADS:-}" || \
+        errors+=("MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')")
+
+    if (( ${#errors[@]} > 0 )); then
+        echo "Mining preflight failed (required for the Toccata/KIP-21 rehearsal):" >&2
+        printf '  ERROR: %s\n' "${errors[@]}" >&2
+        return 1
+    fi
+    return 0
+}
+
+# record_source_revisions - write a timestamped manifest of the exact source
+# revisions (branch/SHA/dirty) of every built repo, so each rehearsal is
+# reproducible. Files accumulate (one per run) under <out_dir>.
+record_source_revisions() {
+    local repos_dir="$1" out_dir="$2"
+    local ts manifest repo path branch sha dirty
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    mkdir -p "$out_dir"
+    manifest="$out_dir/$ts.txt"
+
+    {
+        echo "# Devnet rehearsal manifest"
+        echo "timestamp_utc: $ts"
+        echo "NETWORK: ${NETWORK:-}"
+        echo "FINALITY_PERIOD_SECONDS: ${FINALITY_PERIOD_SECONDS:-}"
+        echo "TOCCATA_ACTIVATION_DAA_SCORE: ${TOCCATA_ACTIVATION_DAA_SCORE:-}"
+        echo "IGRA_LANE_ID: ${IGRA_LANE_ID:-}"
+        echo "env_source: ${DEVNET_ENV_SOURCE:-unknown}"
+        echo
+        printf '%-22s %-22s %-42s %s\n' "repo" "branch" "sha" "state"
+        for repo in rusty-kaspa-private reth-private kaswallet igra-rpc-provider kaspa-miner; do
+            path="$repos_dir/$repo"
+            if git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+                branch="$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+                sha="$(git -C "$path" rev-parse HEAD 2>/dev/null || echo '?')"
+                if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
+                    dirty="dirty"
+                else
+                    dirty="clean"
+                fi
+            else
+                branch="-"; sha="-"; dirty="missing"
+            fi
+            printf '%-22s %-22s %-42s %s\n' "$repo" "$branch" "$sha" "$dirty"
+        done
+    } > "$manifest"
+
+    echo "[setup-devnet] Recorded source revisions -> $manifest"
+    cat "$manifest"
+    return 0
+}

--- a/scripts/lib/devnet-preflight.sh
+++ b/scripts/lib/devnet-preflight.sh
@@ -6,11 +6,12 @@
 
 # --- predicate helpers (return 0 = true, 1 = false; no output) ---
 
-is_uint()          { [[ "${1:-}" =~ ^[0-9]+$ ]]; }
-is_positive_int()  { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( ${1:-0} > 0 )); }
+# Reject leading zeros so bash never reads a value as octal in (( ... )).
+is_uint()          { [[ "${1:-}" =~ ^(0|[1-9][0-9]*)$ ]]; }
+is_positive_int()  { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
 is_hex()           { [[ "${1:-}" =~ ^[0-9a-fA-F]+$ ]]; }
 is_hex_even()      { [[ "${1:-}" =~ ^([0-9a-fA-F]{2})+$ ]]; }
-is_port()          { [[ "${1:-}" =~ ^[0-9]+$ ]] && (( ${1:-0} >= 1 && ${1:-0} <= 65535 )); }
+is_port()          { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]] && (( ${1} >= 1 && ${1} <= 65535 )); }
 # Devnet kaspa address: kaspadev: prefix + bech32 charset payload (>= 59 chars).
 is_valid_mining_address() {
     [[ "${1:-}" =~ ^kaspadev:[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{59,}$ ]]
@@ -34,10 +35,15 @@ validate_devnet_env() {
     is_hex_even "${TX_ID_PREFIX:-}" || \
         errors+=("TX_ID_PREFIX must be hex with an even number of chars (got: '${TX_ID_PREFIX:-<unset>}')")
 
-    # IGRA_LANE_ID: 8 or 40 hex; mandatory when Toccata is scheduled
+    # IGRA_LANE_ID: 8 or 40 lowercase hex (kaspad validates the exact lane shape at
+    # startup); not all-zero (reserved SUBNETWORK_ID_NATIVE); mandatory when Toccata
+    # is scheduled.
     if [ -n "${IGRA_LANE_ID:-}" ]; then
-        [[ "${IGRA_LANE_ID}" =~ ^([0-9a-fA-F]{8}|[0-9a-fA-F]{40})$ ]] || \
-            errors+=("IGRA_LANE_ID must be 8 or 40 hex chars (got: '${IGRA_LANE_ID}')")
+        if ! [[ "${IGRA_LANE_ID}" =~ ^([0-9a-f]{8}|[0-9a-f]{40})$ ]]; then
+            errors+=("IGRA_LANE_ID must be 8 or 40 lowercase hex chars (got: '${IGRA_LANE_ID}')")
+        elif [[ "${IGRA_LANE_ID}" =~ ^0+$ ]]; then
+            errors+=("IGRA_LANE_ID must not be all-zero (reserved SUBNETWORK_ID_NATIVE shape)")
+        fi
     elif [ -n "$toccata" ]; then
         errors+=("IGRA_LANE_ID is required when TOCCATA_ACTIVATION_DAA_SCORE is set")
     fi
@@ -53,7 +59,7 @@ validate_devnet_env() {
     # Ports: range, then collision among the valid ones
     local ports=()
     for name in KASPAD_GRPC_PORT KASPAD_P2P_PORT KASPAD_BORSH_PORT KASPAD_JSON_PORT \
-                RPC_PORT EL_RPC_HOST_PORT EL_WS_HOST_PORT; do
+                RPC_PORT EL_RPC_HOST_PORT EL_WS_HOST_PORT KASWALLET_HOST_PORT; do
         p="${!name:-}"
         if is_port "$p"; then
             ports+=("$p:$name")
@@ -115,7 +121,8 @@ validate_devnet_env() {
             errors+=("$name must be a non-negative integer (got: '${!name:-<unset>}')")
     done
     if is_uint "$launch" && is_uint "$l1daa" && is_uint "$l1ts"; then
-        local genesis_ts=$(( launch / 10 - l1daa / 10 + l1ts - 1 ))
+        # Per-term division mirrors run-igra-el.sh's calculate_genesis_timestamp.
+        local genesis_ts=$(( 10#$launch / 10 - 10#$l1daa / 10 + 10#$l1ts - 1 ))
         (( genesis_ts > 0 )) || \
             errors+=("derived EL genesis timestamp must be positive: (IGRA_LAUNCH_DAA_SCORE/10 - L1_REFERENCE_DAA_SCORE/10 + L1_REFERENCE_TIMESTAMP - 1) = $genesis_ts")
     fi
@@ -187,17 +194,12 @@ resolve_devnet_env() {
     fi
 }
 
-# mining_preflight - verify mining can actually run. Called when Toccata is
-# scheduled, because the KIP-21 rehearsal cannot reach the activation DAA score
-# without mined blocks. Returns 1 (with actionable errors) if mining is impossible.
+# mining_preflight - validate MINING_ADDRESS/MINING_THREADS and remind the operator
+# to start an external miner. Called when Toccata is scheduled, because the KIP-21
+# rehearsal cannot reach the activation DAA score without mined blocks.
 mining_preflight() {
-    local repos_dir="$1" dockerfile="$2"
     local errors=()
 
-    [ -d "$repos_dir/kaspa-miner" ] || \
-        errors+=("kaspa-miner source repo not found at $repos_dir/kaspa-miner (clone via scripts/dev/setup-repos.sh)")
-    [ -f "$dockerfile" ] || \
-        errors+=("kaspa-miner Dockerfile not found at $dockerfile")
     is_valid_mining_address "${MINING_ADDRESS:-}" || \
         errors+=("MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}')")
     is_positive_int "${MINING_THREADS:-}" || \
@@ -208,6 +210,11 @@ mining_preflight() {
         printf '  ERROR: %s\n' "${errors[@]}" >&2
         return 1
     fi
+
+    echo "[setup-devnet] Toccata is scheduled at DAA ${TOCCATA_ACTIVATION_DAA_SCORE:-}." >&2
+    echo "               kaspad mines nothing on its own; point a miner at the devnet" >&2
+    echo "               kaspad gRPC port (127.0.0.1:\${KASPAD_GRPC_PORT}) with" >&2
+    echo "               --mining-address ${MINING_ADDRESS:-} to reach the activation score." >&2
     return 0
 }
 
@@ -216,10 +223,16 @@ mining_preflight() {
 # reproducible. Files accumulate (one per run) under <out_dir>.
 record_source_revisions() {
     local repos_dir="$1" out_dir="$2"
-    local ts manifest repo path branch sha dirty
+    local ts manifest repo path branch sha dirty n
     ts="$(date -u +%Y%m%dT%H%M%SZ)"
     mkdir -p "$out_dir"
+    # Suffix on collision so same-second runs don't clobber each other.
     manifest="$out_dir/$ts.txt"
+    n=1
+    while [ -e "$manifest" ]; do
+        manifest="$out_dir/$ts-$n.txt"
+        n=$((n + 1))
+    done
 
     {
         echo "# Devnet rehearsal manifest"
@@ -231,7 +244,7 @@ record_source_revisions() {
         echo "env_source: ${DEVNET_ENV_SOURCE:-unknown}"
         echo
         printf '%-22s %-22s %-42s %s\n' "repo" "branch" "sha" "state"
-        for repo in rusty-kaspa-private reth-private kaswallet igra-rpc-provider kaspa-miner; do
+        for repo in rusty-kaspa-private reth-private kaswallet igra-rpc-provider; do
             path="$repos_dir/$repo"
             if git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
                 branch="$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
@@ -247,6 +260,17 @@ record_source_revisions() {
             printf '%-22s %-22s %-42s %s\n' "$repo" "$branch" "$sha" "$dirty"
         done
     } > "$manifest"
+
+    # Keep the newest REHEARSAL_KEEP (default 20) manifests.
+    local keep="${REHEARSAL_KEEP:-20}"
+    if is_positive_int "$keep"; then
+        local old
+        # Manifest names are controlled timestamps, so ls -t is safe here.
+        # shellcheck disable=SC2012
+        while IFS= read -r old; do
+            [ -n "$old" ] && rm -f "$old"
+        done < <(ls -1t "$out_dir"/*.txt 2>/dev/null | tail -n "+$((keep + 1))")
+    fi
 
     echo "[setup-devnet] Recorded source revisions -> $manifest"
     cat "$manifest"

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -119,9 +119,10 @@ validate_devnet_env || exit 1
 # Record exactly what will be built (one manifest per rehearsal).
 record_source_revisions "$PROJECT_DIR/build/repos" "$PROJECT_DIR/rehearsals"
 
-# Mining is mandatory for the KIP-21 rehearsal whenever Toccata is scheduled.
+# When Toccata is scheduled, validate the mining config and remind the operator to
+# start an external miner (required to reach the activation DAA score).
 if [ -n "${TOCCATA_ACTIVATION_DAA_SCORE:-}" ]; then
-    mining_preflight "$PROJECT_DIR/build/repos" "$PROJECT_DIR/build/Dockerfile.kaspa-miner" || exit 1
+    mining_preflight || exit 1
 fi
 
 generate_devnet_overrides "$FINALITY_PERIOD_SECONDS" "$TOCCATA_ACTIVATION_DAA_SCORE"
@@ -136,9 +137,9 @@ build_devnet_stack() {
     local repos_dir="$SCRIPT_DIR/../build/repos"
     local missing=()
     local r
-    # kaspa-miner is included so a missing miner repo surfaces here, not later at
-    # the manual `--profile mining up` step.
-    for r in rusty-kaspa-private reth-private kaswallet igra-rpc-provider kaspa-miner; do
+    # The miner is not built from this repo (operators run their own); only the
+    # four core services are required here.
+    for r in rusty-kaspa-private reth-private kaswallet igra-rpc-provider; do
         [ -d "$repos_dir/$r" ] || missing+=("$r")
     done
     if (( ${#missing[@]} > 0 )); then
@@ -165,7 +166,6 @@ build_devnet_stack() {
     fi
 
     echo "[setup-devnet] Building devnet images from source (first build is slow)..."
-    # kaspa-miner is excluded; it builds on demand under the "mining" profile.
     docker compose build kaspad execution-layer kaswallet-0 rpc-provider-0
 }
 
@@ -219,7 +219,8 @@ print_summary() {
     echo "Services started:"
     docker compose ps --format "table {{.Name}}\t{{.Status}}"
     echo
-    echo "NOTE: kaspad mines no blocks until you start the miner (see below)."
+    echo "NOTE: kaspad mines no blocks on its own. Point an external miner at the"
+    echo "      devnet kaspad gRPC port to produce blocks (see below)."
     echo
     echo "Useful commands:"
     echo "  docker compose -f $COMPOSE_FILE logs -f kaspad           # kaspad"
@@ -235,15 +236,19 @@ print_summary() {
 
 run_setup "$@"
 
-# kaspa-miner is gated behind the "mining" profile and built on demand.
+# The miner is not part of this stack; operators run their own against the
+# published devnet kaspad gRPC port.
 cat <<EOF
 
 === Devnet: Mining ===
 
-Start the in-stack kaspa-miner once kaspad is healthy:
+kaspad mines no blocks on its own. The miner is not part of this stack; a helper
+clones, builds and runs tmrlvi/kaspa-miner on the host against the devnet kaspad
+gRPC port. Run it once kaspad is healthy:
 
-  docker compose -f docker-compose.devnet.yml --profile mining up -d --build kaspa-miner
-  docker compose -f docker-compose.devnet.yml logs -f kaspa-miner
+  ./scripts/dev/run-devnet-miner.sh
 
-Stop with: docker compose -f docker-compose.devnet.yml --profile mining down
+It reads MINING_ADDRESS / MINING_THREADS / KASPAD_GRPC_PORT from your .env; see
+'./scripts/dev/run-devnet-miner.sh --help' for options.
+Mining is required to reach TOCCATA_ACTIVATION_DAA_SCORE for the KIP-21 rehearsal.
 EOF

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -33,98 +33,27 @@ export COMPOSE_FILE="docker-compose.devnet.yml"
 # Single worker by default (devnet runs only kaswallet-0 / rpc-provider-0).
 export NUM_WORKERS="${NUM_WORKERS:-1}"
 
-# Resolve devnet knobs from .env (else the committed example) before generating the
-# override JSON, so a value set in .env reaches it. Inline `VAR=...` still wins.
-DEVNET_ENV_FILE="$SCRIPT_DIR/../.env"
-[ -f "$DEVNET_ENV_FILE" ] || DEVNET_ENV_FILE="$SCRIPT_DIR/../$ENV_FILE"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/lib/devnet-preflight.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/devnet-preflight.sh"
 
-read_devnet_env() {
-    local key="$1" file="$2" line val found=1
-    [ -f "$file" ] || return 1
-    while IFS= read -r line || [ -n "$line" ]; do
-        line="${line%$'\r'}"
-        case "$line" in
-            "$key"=*)
-                val="${line#*=}"
-                val="${val#"${val%%[![:space:]]*}"}"
-                val="${val%"${val##*[![:space:]]}"}"
-                case "$val" in
-                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
-                esac
-                found=0
-                ;;
-        esac
-    done < "$file"
-    [ "$found" -eq 0 ] && printf '%s' "$val"
-    return "$found"
-}
+# Load the single effective env source (.env or template) + versions so
+# validation and the build read identical inputs. Shell overrides win.
+resolve_devnet_env "$PROJECT_DIR" "$ENV_FILE" "$VERSIONS_FILE" || exit 1
 
-# Precedence: inline env (set, even if empty) > env file > default.
-resolve_devnet_var() {
-    local name="$1" default="$2" val
-    [ -n "${!name+set}" ] && return 0
-    if val="$(read_devnet_env "$name" "$DEVNET_ENV_FILE")"; then
-        printf -v "$name" '%s' "$val"
-    else
-        printf -v "$name" '%s' "$default"
-    fi
-}
-
-# Generate kaspad override-params JSON. Default: 600s finality (= 6000-block depth at BPS=10).
-resolve_devnet_var FINALITY_PERIOD_SECONDS 600
+# Tunable defaults applied on top of the resolved env so:
+#   shell override > .env file > default.
+# Use ${VAR-default} (not :-) for TOCCATA/LANE so an explicit empty opts out.
 FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-600}"
-# Empty TOCCATA_ACTIVATION_DAA_SCORE opts out of Toccata; defaults match .env.devnet.example.
-resolve_devnet_var TOCCATA_ACTIVATION_DAA_SCORE 1000
-resolve_devnet_var IGRA_LANE_ID 97b10000
-resolve_devnet_var IGRA_LAUNCH_DAA_SCORE 0
-
-# Fail before build/up if the KIP-21 transition config is invalid or incomplete.
-# Toccata is optional: an empty TOCCATA_ACTIVATION_DAA_SCORE opts out (no fork). But
-# when Toccata IS scheduled, a lane id is mandatory (kaspad requires it post-Toccata).
-validate_toccata_and_lane() {
-    local toccata="$1" lane="$2" launch="$3"
-    if [ -n "$toccata" ]; then
-        if ! [[ "$toccata" =~ ^[1-9][0-9]*$ ]]; then
-            echo "ERROR: TOCCATA_ACTIVATION_DAA_SCORE must be a positive integer with no leading zeros, or empty to disable Toccata (got: $toccata)" >&2
-            exit 1
-        fi
-        if (( toccata > 920000 )); then
-            echo "ERROR: TOCCATA_ACTIVATION_DAA_SCORE=$toccata is implausibly large (> 920000); likely a typo. Lower it or set it empty to disable Toccata." >&2
-            exit 1
-        fi
-        if [ -z "$lane" ]; then
-            echo "ERROR: IGRA_LANE_ID is required when TOCCATA_ACTIVATION_DAA_SCORE is set (Toccata scheduled)" >&2
-            exit 1
-        fi
-        if [[ "$launch" =~ ^[0-9]+$ ]] && (( launch >= toccata )); then
-            echo "ERROR: IGRA_LAUNCH_DAA_SCORE ($launch) must be < TOCCATA_ACTIVATION_DAA_SCORE ($toccata) so the pre-fork entry window opens before the fork" >&2
-            exit 1
-        fi
-    fi
-    if [ -n "$lane" ]; then
-        if ! [[ "$lane" =~ ^([0-9a-f]{8}|[0-9a-f]{40})$ ]]; then
-            echo "ERROR: IGRA_LANE_ID must be 8 or 40 lowercase hex chars (got: $lane); kaspad validates the exact lane shape at startup" >&2
-            exit 1
-        fi
-        if [[ "$lane" =~ ^0+$ ]]; then
-            echo "ERROR: IGRA_LANE_ID must not be all-zero (reserved SUBNETWORK_ID_NATIVE shape)" >&2
-            exit 1
-        fi
-    fi
-}
+TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE-1000}"
+IGRA_LANE_ID="${IGRA_LANE_ID-97b10000}"
+export FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID
 
 generate_devnet_overrides() {
     local seconds="$1"
     local toccata="$2"
-    # Upper bound is below pruning_depth/BPS (= 108000s): kaspad's effective
-    # finalization window is finality_depth + merge_depth + anticone overhead
-    # (~159k blocks with these params). Capping at 92000s keeps finality_depth
-    # (920000) plus that overhead safely under pruning_depth (1080000); higher
-    # values silently cap because devnet uses min(pruning_depth, anticone depth).
-    if ! [[ "$seconds" =~ ^[0-9]+$ ]] || (( seconds < 60 )) || (( seconds > 92000 )); then
-        echo "ERROR: FINALITY_PERIOD_SECONDS must be an integer in [60, 92000] (got: $seconds)" >&2
-        exit 1
-    fi
+    # FINALITY_PERIOD_SECONDS range is validated upstream in validate_devnet_env.
     local depth=$(( seconds * 10 ))   # BPS=10 on devnet
     local out_dir="$SCRIPT_DIR/../overrides"
     mkdir -p "$out_dir"
@@ -184,7 +113,17 @@ EOF
     fi
 }
 
-validate_toccata_and_lane "$TOCCATA_ACTIVATION_DAA_SCORE" "$IGRA_LANE_ID" "$IGRA_LAUNCH_DAA_SCORE"
+# Fail fast on bad config BEFORE any expensive build/up.
+validate_devnet_env || exit 1
+
+# Record exactly what will be built (one manifest per rehearsal).
+record_source_revisions "$PROJECT_DIR/build/repos" "$PROJECT_DIR/rehearsals"
+
+# Mining is mandatory for the KIP-21 rehearsal whenever Toccata is scheduled.
+if [ -n "${TOCCATA_ACTIVATION_DAA_SCORE:-}" ]; then
+    mining_preflight "$PROJECT_DIR/build/repos" "$PROJECT_DIR/build/Dockerfile.kaspa-miner" || exit 1
+fi
+
 generate_devnet_overrides "$FINALITY_PERIOD_SECONDS" "$TOCCATA_ACTIVATION_DAA_SCORE"
 warn_if_finality_baked
 
@@ -226,20 +165,6 @@ build_devnet_stack() {
     fi
 
     echo "[setup-devnet] Building devnet images from source (first build is slow)..."
-    # Export the inputs the compose file references so `docker compose build` can
-    # interpolate it and tag images as igranetwork/<svc>:devnet. Prefer the live
-    # .env (operator overrides) when it exists so build-time and run-time inputs
-    # match; fall back to the committed example only on first run.
-    local env_source="$SCRIPT_DIR/../.env"
-    if [[ ! -f "$env_source" ]]; then
-        env_source="$SCRIPT_DIR/../$ENV_FILE"
-    fi
-    set -a
-    # shellcheck source=/dev/null
-    source "$env_source"
-    # shellcheck source=/dev/null
-    source "$SCRIPT_DIR/../$VERSIONS_FILE"
-    set +a
     # kaspa-miner is excluded; it builds on demand under the "mining" profile.
     docker compose build kaspad execution-layer kaswallet-0 rpc-provider-0
 }
@@ -254,6 +179,8 @@ mkdir -p "$SCRIPT_DIR/../data/reth" \
          "$SCRIPT_DIR/../logs/kaspad"
 
 # Source common library and run setup
+# shellcheck source=scripts/lib/setup-common.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/setup-common.sh"
 
 # The devnet stack uses distinct container names (*-devnet) to stay isolated from

--- a/versions.devnet.env
+++ b/versions.devnet.env
@@ -6,3 +6,7 @@ KASPAD_VERSION=devnet
 RETH_VERSION=devnet
 KASWALLET_VERSION=devnet
 RPC_PROVIDER_VERSION=devnet
+
+# Unused by the devnet compose, but validate_required_image_versions requires them.
+NODE_HEALTH_CHECK_VERSION=devnet
+ATAN_UPLOADER_VERSION=devnet


### PR DESCRIPTION
## Summary

Harden the devnet setup flow (ENG-1152) so an invalid transition config fails
fast — before any expensive image build or the long-running Toccata/KIP-21
rehearsal.

**Preflight library.** New `scripts/lib/devnet-preflight.sh`, sourced by
`setup-devnet.sh` and run before `docker compose build`/`up`. Functions are pure
(inputs via args/env) so they unit-test without Docker:

- `resolve_devnet_env` — load a single effective env source (`.env` if present,
  otherwise the committed `.env.devnet.example`) plus `versions.devnet.env`, so
  build-time and runtime inputs match. Shell/CLI values win over the file for
  `FINALITY_PERIOD_SECONDS`, `TOCCATA_ACTIVATION_DAA_SCORE` and `IGRA_LANE_ID`
  (an explicitly empty value opts out).
- `validate_devnet_env` — aggregate every config problem into one actionable
  report: NETWORK, TX_ID_PREFIX, IGRA_LANE_ID (format + required when Toccata is
  scheduled), host ports incl. `KASWALLET_HOST_PORT` (+ collisions), mining
  address/threads, lock-script pair, finality range, DAA ordering and
  genesis-timestamp positivity.
- `mining_preflight` — when Toccata is scheduled, validate the mining config
  (address/threads) and remind the operator to point a miner at the kaspad gRPC
  port.
- `record_source_revisions` — write a timestamped branch/SHA/dirty manifest for
  the four built repos (rusty-kaspa-private, reth-private, kaswallet,
  igra-rpc-provider) to a gitignored `rehearsals/`, pruned to the newest
  `REHEARSAL_KEEP` (default 20) so each rehearsal is reproducible.

**Standalone miner.** kaspa-miner is not part of the compose stack;
`scripts/dev/run-devnet-miner.sh` clones, builds and runs `tmrlvi/kaspa-miner`
on the host against the devnet kaspad gRPC port. Mining is required to reach
`TOCCATA_ACTIVATION_DAA_SCORE` for the KIP-21 rehearsal.

**Compose hardening.** Operator-controlled values are passed to kaspad as
runtime env (referenced as `$VAR`) rather than spliced in at compose-render
time, with in-entrypoint `IGRA_LANE_ID` hex/length validation as a backstop for
a direct `docker compose up`. RPC is loopback + read-only by default
(`RPC_BIND_ADDR=127.0.0.1`, `RPC_READ_ONLY=true`) with an unsafe-exposure
warning; `READ_ONLY`, `RPC_PORT` and the kaswallet host port have safe compose
defaults. Build-time and runtime env come from one resolved source.

## Testing

- `./scripts/dev/test-devnet-preflight.sh` — 58/58 passing
- `shellcheck` clean on `setup-devnet.sh`, `devnet-preflight.sh`,
  `test-devnet-preflight.sh`, `run-devnet-miner.sh`
- Integration smoke: an invalid config exits non-zero with aggregated errors
  before any docker call.
