### PR TITLE
[ENG-1158] feat(upgrade): mainnet v2.3 -> v3.0 runbook + .env updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser igranetwork
 - [Mainnet Deployment Guide](doc/quick-setup-mainnet.md) - Public mainnet deployment with pre-built images
 - [Galleon Testnet Deployment Guide](doc/quick-setup-galleon-testnet.md) - Public Galleon testnet (testnet-10) deployment with pre-built images
 - [Galleon → testnet-10 Migration Guide](doc/node-operations/migrate-galleon-to-testnet-10.md) - One-shot upgrade for existing Galleon operators on `NETWORK=testnet`
+- [Mainnet v2.3 → v3.0 Upgrade Guide](doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md) - One-shot upgrade for existing mainnet operators from the v2.3 line to v3.0
 - [Kaspa Wallet Guide](doc/kaspa-wallet.md) - Wallet setup for all networks
 - [Log Management](doc/log-management.md) - Automated log cleanup for servers
 - [Docker Volume Permissions](doc/troubleshooting/docker-volume-permissions.md) - Fix permission denied errors

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,6 +12,7 @@ Choose your deployment guide:
 ## Operations
 
 - **[Node Operations](node-operations/index.md)** - Worker config, wallet API, balance monitoring, health checks, ATAN-only mode, and external CPU mining
+- **[Mainnet v2.3 → v3.0 Upgrade](node-operations/upgrade-mainnet-v2.3-to-v3.0.md)** - Move an existing mainnet deployment to v3.0: reconcile `.env` and bump images, preserving volumes
 - **[Kaspa Wallet Guide](kaspa-wallet.md)** - Wallet setup and management for all networks
 - **[Log Management](log-management.md)** - Automated log cleanup for servers
 

--- a/doc/node-operations/index.md
+++ b/doc/node-operations/index.md
@@ -9,4 +9,5 @@ Operational reference for running Igra Orchestra nodes.
 - **[ATAN Verification](atan-verification.md)** - Verify stored post-KIP-21 finality-period archives with the offline `kaspa-atan-verify` tool
 - **[Environment Reference](environment-reference.md)** - All operational environment variables
 - **[Galleon → testnet-10 Migration](migrate-galleon-to-testnet-10.md)** - One-shot upgrade for existing Galleon operators on `NETWORK=testnet` to the uniform `NETWORK=testnet-10` schema (preserves IBD state)
+- **[Mainnet v2.3 → v3.0 Upgrade](upgrade-mainnet-v2.3-to-v3.0.md)** - One-shot upgrade for existing mainnet operators from the v2.3 line to v3.0 (reconciles `.env` and bumps images to 3.0; preserves volumes)
 - **[Running a CPU Miner](running-a-cpu-miner.md)** - Optionally produce Kaspa L1 blocks for an isolated local network with an external CPU miner

--- a/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
+++ b/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
@@ -1,0 +1,210 @@
+# Mainnet v2.3 → v3.0 Upgrade
+
+## Who this is for
+
+If you run an existing IGRA Orchestra **mainnet** deployment (`NETWORK=mainnet`)
+on the v2.3 line and want to move it to v3.0 **without losing your synced
+kaspad/reth data**, run this once.
+
+If you're starting fresh and don't have a synced node, skip this guide and use
+`./scripts/setup-mainnet.sh` directly — the template already ships the v3.0
+values.
+
+## What the upgrade does
+
+The "version" here is the orchestra **release line** (v3.0, which lands on
+`main`). Pulling `main` brings the new `docker-compose.yml`, the new
+`config/traefik/dynamic.yml` file-provider middleware, and updated entrypoints —
+but it does **not** touch your `.env`, which is gitignored and carries your
+image-version pins. The real upgrade work is reconciling `.env`:
+
+- **Adds `IGRA_LANE_ID=97b10000`** — the post-KIP21 dedicated IGRA lane
+  namespace (4 bytes / 8 lowercase hex chars, no `0x`), shared across all
+  networks. The v3.0 compose **refuses to render** without it
+  (`${IGRA_LANE_ID:?...}`), and kaspad receives it as `--igra-lane-id`.
+  (kaswallet also receives it as `--subnetwork-id`, but only once you bring the
+  workers up after the Toccata switch — see below.)
+- **Ensures `TX_ID_PREFIX=97b1`** — now also required (`${TX_ID_PREFIX:?...}`).
+  A mainnet v2.3 `.env` normally already has it; it is added only if missing.
+- **Ensures `SERVICE_RESTART_POLICY=unless-stopped`** — added if missing so
+  Traefik and friends self-heal after a boot-time race.
+- **Bumps kaspad and reth to 3.0** — `KASPAD_VERSION` and `RETH_VERSION` go
+  `2.3 → 3.0`. **`RPC_PROVIDER_VERSION` and `KASWALLET_VERSION` stay at `2.3`**
+  for now (`NODE_HEALTH_CHECK_VERSION` / `ATAN_UPLOADER_VERSION` stay `2.1`).
+  kaspad 3.0 is Toccata-aware but the fork is **not yet active** on mainnet, so
+  the network still uses native (v0) transactions. The rpc-provider/kaswallet
+  bump is deferred to [After the Toccata switch](#after-the-toccata-switch) — the
+  v3.0 frontend emits lane/subnetwork (v1) transactions that mainnet rejects
+  before the fork.
+
+The upgrade keeps `NETWORK=mainnet` and the `igra-orchestra-mainnet` compose
+project, so your existing volumes are reused as-is — **no volume rename, no
+re-sync**.
+
+The ATAN import URL now auto-constructs as
+`{CDN_BASE_URL}/mainnet/97b1/index.pb`. If your `.env` pins `ATAN_IMPORT_URL`
+explicitly, the script leaves it untouched but flags it so you can verify or
+remove it.
+
+## Prerequisites
+
+- The deployment directory is on the latest `main` checkout (after v3.0 is merged
+  into `main`) so it has the new `docker-compose.yml`,
+  `config/traefik/dynamic.yml`, and `scripts/upgrade-mainnet-v2.3-to-v3.0.sh`.
+- `docker compose` v2 plugin available (`docker compose version`).
+- Your `.env` is a real mainnet config (`NETWORK=mainnet`,
+  `IGRA_CHAIN_ID=38833`). The script refuses to run otherwise — that's a safety
+  feature.
+- The reconcile is `.env`-only and reversible (a timestamped backup is written),
+  so it needs no extra disk and finishes in seconds.
+
+## Run the upgrade
+
+### 1. Pull the latest code
+
+The v3.0 changes ship on `main`. From your deployment directory:
+
+```bash
+cd /path/to/your/igra-orchestra
+git fetch origin
+git checkout main        # or whatever ref your deployment tracks
+git pull --ff-only
+```
+
+### 2. Reconcile `.env`
+
+```bash
+./scripts/upgrade-mainnet-v2.3-to-v3.0.sh
+```
+
+The script prints a pre-flight summary of every change (old → new) and asks for
+confirmation before writing. It backs up `.env` to
+`.env.backup.pre-v3.0.YYYYMMDD_HHMMSS` (mode 600), upserts the variables above,
+syncs the image pins from `versions.mainnet.env`, and finally runs
+`docker compose config -q` to prove the required variables are present. Pass
+`-y` to skip the prompt for unattended runs.
+
+<details>
+<summary>Prefer to edit <code>.env</code> by hand?</summary>
+
+Set these in `.env` (the values are mainnet canonical):
+
+| Variable | Set to |
+|---|---|
+| `IGRA_LANE_ID` | `97b10000` |
+| `TX_ID_PREFIX` | `97b1` (if not already set) |
+| `SERVICE_RESTART_POLICY` | `unless-stopped` (if not already set) |
+| `KASPAD_VERSION` | `3.0` |
+| `RETH_VERSION` | `3.0` |
+| `KASWALLET_VERSION` | `2.3` (unchanged until after Toccata) |
+| `RPC_PROVIDER_VERSION` | `2.3` (unchanged until after Toccata) |
+| `NODE_HEALTH_CHECK_VERSION` | `2.1` |
+| `ATAN_UPLOADER_VERSION` | `2.1` |
+
+</details>
+
+### 3. Validate and bring the stack up
+
+```bash
+docker compose config -q     # must exit cleanly (no "IGRA_LANE_ID must be set" error)
+```
+
+**The first backend start needs `KASPAD_NONINTERACTIVE=true`.** The kaspad image
+bump always triggers a one-time DB metadata upgrade that prompts `Do you confirm?
+(y/n)`; inside Docker there is no TTY to answer it, so kaspad rejects it and
+crash-loops (`Operation was rejected (), exiting..`). Approve it noninteractively
+on the first start:
+
+```bash
+KASPAD_NONINTERACTIVE=true docker compose --profile backend up -d --no-build
+docker compose logs -f kaspad        # wait until it logs past the upgrade and starts syncing
+```
+
+Once kaspad is past the upgrade, recreate it without the override so the flag is
+not left set:
+
+```bash
+docker compose --profile backend up -d --no-build --force-recreate kaspad
+```
+
+**Do not recreate the frontend workers in this phase.** `rpc-provider` and
+`kaswallet` stay on 2.3 and keep emitting native (v0) transactions, which is what
+pre-Toccata mainnet expects. Leave your existing worker containers running — only
+the `backend` profile is recreated now. You'll upgrade the workers in
+[After the Toccata switch](#after-the-toccata-switch).
+
+### About `KASPAD_NONINTERACTIVE`
+
+`KASPAD_NONINTERACTIVE=true` maps to kaspad `--yes`, which answers the
+`Do you confirm? (y/n)` DB-upgrade prompt shown on the first start. It is safe for
+this known older-version metadata upgrade; pass it only on that first start (as in
+step 3) and **do not** leave it in `.env`. Without it, kaspad logs
+`Operation was rejected (), exiting..` and crash-loops until you re-run the first
+start with the flag. See
+[troubleshooting/kaspad-db-upgrade.md](../troubleshooting/kaspad-db-upgrade.md)
+for detail.
+
+## Verify
+
+```bash
+grep '^IGRA_LANE_ID=' .env                        # IGRA_LANE_ID=97b10000
+grep -E '^(KASPAD|RETH)_VERSION=' .env            # both 3.0
+grep -E '^(RPC_PROVIDER|KASWALLET)_VERSION=' .env  # both 2.3 (until Toccata)
+docker compose config -q && echo "compose OK"     # required vars present
+```
+
+In the running stack, confirm:
+
+- **kaspad** logs its startup banner and **IBD resumes from your previous
+  height** (not a fresh sync from 0).
+- `docker compose ps` shows `kaspad` and `execution-layer` **running / healthy**
+  on the new 3.0 images; your existing `rpc-provider-*` / `kaswallet-*` /
+  `traefik` workers keep running on 2.3 (they are not recreated in this phase).
+- The **health-check client** reports `KASPAD_VERSION=3.0` to the monitoring
+  server.
+
+## After the Toccata switch
+
+Once Toccata (KIP-21) has activated on mainnet, upgrade the workers so they emit
+lane/subnetwork (v1) transactions:
+
+1. Set the worker pins to `3.0` in `.env` (a follow-up repo change will also bump
+   them in `versions.mainnet.env`):
+
+   | Variable | Set to |
+   |---|---|
+   | `RPC_PROVIDER_VERSION` | `3.0` |
+   | `KASWALLET_VERSION` | `3.0` |
+
+2. Recreate the worker profile (same `N` as before):
+
+   ```bash
+   docker compose config -q
+   docker compose --profile frontend-w<N> up -d --no-build
+   ```
+
+The v3.0 kaswallet then runs with `--subnetwork-id=$IGRA_LANE_ID` and emits
+post-Toccata (v1) transactions on the IGRA lane.
+
+## Rollback
+
+The reconcile is `.env`-only and your volumes are never touched, so rollback is
+clean:
+
+- **`.env`**: restore from `.env.backup.pre-v3.0.*` written before the rewrite.
+- **Compose / entrypoints**: `git checkout <your-previous-ref>` to put back the
+  old `docker-compose.yml`.
+- **Images**: with the old `.env` restored, the 2.3 pins come back and
+  `docker compose up -d --no-build` runs the old images against your unchanged
+  volumes.
+
+## Troubleshooting
+
+| Error | Meaning | Fix |
+|---|---|---|
+| `IGRA_LANE_ID must be set ...` at `docker compose` | `.env` is still on the v2.3 schema (missing the lane) | Run `./scripts/upgrade-mainnet-v2.3-to-v3.0.sh` (or set `IGRA_LANE_ID=97b10000` by hand) |
+| `TX_ID_PREFIX must be set ...` at `docker compose` | `TX_ID_PREFIX` missing/empty | Set `TX_ID_PREFIX=97b1` in `.env` |
+| `.env NETWORK is '...', not 'mainnet'` | Wrong network for this script | This guide is mainnet-only; for Galleon use [migrate-galleon-to-testnet-10.md](migrate-galleon-to-testnet-10.md) |
+| `.env IGRA_CHAIN_ID is '...', not the mainnet value '38833'` | Custom or stale chain identity | Restore the mainnet `IGRA_CHAIN_ID=38833` (keep your node-specific overrides) |
+| `Node database is from an older version` then `Operation was rejected (), exiting..` | kaspad needs the one-time DB metadata upgrade but can't prompt inside Docker | Run the `KASPAD_NONINTERACTIVE=true` bring-up above |
+| `docker compose not found; skipped compose validation` | `docker compose` v2 plugin missing on the host | Install the Docker Compose v2 plugin, then run `docker compose config -q` |

--- a/scripts/upgrade-mainnet-v2.3-to-v3.0.sh
+++ b/scripts/upgrade-mainnet-v2.3-to-v3.0.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# upgrade-mainnet-v2.3-to-v3.0.sh
+#
+# Reconcile an existing IGRA Orchestra MAINNET .env from the v2.3 line to v3.0.
+#
+# The v3.0 docker-compose.yml refuses to render without IGRA_LANE_ID and
+# TX_ID_PREFIX (both guarded by ${VAR:?...}), and its kaspad/kaswallet
+# entrypoints pass the post-Toccata flags --igra-lane-id / --subnetwork-id
+# unconditionally, so mainnet must run 3.0 images. This script edits .env only;
+# it does NOT touch Docker volumes — mainnet keeps NETWORK=mainnet and reuses
+# its existing kaspad/reth data. It is idempotent: safe to re-run.
+#
+# What it changes in .env:
+#   - adds IGRA_LANE_ID=97b10000                     (new required lane namespace)
+#   - ensures TX_ID_PREFIX=97b1                      (now required; set only if unset)
+#   - ensures SERVICE_RESTART_POLICY=unless-stopped  (set only if unset)
+#   - syncs image-version pins from versions.mainnet.env (kaspad/reth -> 3.0;
+#     rpc-provider/kaswallet stay 2.3 until the mainnet Toccata switch)
+# A timestamped mode-600 backup (.env.backup.pre-v3.0.*) is written first.
+#
+# Usage: scripts/upgrade-mainnet-v2.3-to-v3.0.sh [-y|--yes]
+set -euo pipefail
+
+# Resolve repo root and reuse the shared setup helpers (update_env_var,
+# read_env_value, log, error, die). Sourcing setup-common.sh also loads the
+# pins from versions.mainnet.env via VERSIONS_FILE below; it does not run setup.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Consumed by setup-common.sh (it validates/loads image versions at source time).
+# shellcheck disable=SC2034
+ENV_NAME="IGRA Mainnet"
+# shellcheck disable=SC2034
+ENV_FILE=".env.mainnet.example"
+# shellcheck disable=SC2034
+NODE_ID_PREFIX="MN-"
+# shellcheck disable=SC2034
+KASWALLET_FLAG="--enable-mainnet-pre-launch"
+VERSIONS_FILE="versions.mainnet.env"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/setup-common.sh"
+
+cd "$PROJECT_DIR"
+
+# --- canonical mainnet values ---
+EXPECTED_NETWORK="mainnet"
+EXPECTED_IGRA_CHAIN_ID="38833"
+EXPECTED_TX_ID_PREFIX="97b1"
+# Post-KIP21 dedicated IGRA lane namespace (4 bytes / 8 lowercase hex chars,
+# no 0x prefix). Shared across all networks; required by the v3.0 compose.
+IGRA_LANE_ID_VALUE="97b10000"
+DEFAULT_RESTART_POLICY="unless-stopped"
+IMAGE_VERSION_VARS=(
+    KASPAD_VERSION
+    RETH_VERSION
+    RPC_PROVIDER_VERSION
+    KASWALLET_VERSION
+    NODE_HEALTH_CHECK_VERSION
+    ATAN_UPLOADER_VERSION
+)
+
+ASSUME_YES=false
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) ASSUME_YES=true ;;
+        -h|--help)
+            echo "Usage: scripts/upgrade-mainnet-v2.3-to-v3.0.sh [-y|--yes]"
+            echo "Reconcile an existing mainnet .env from the v2.3 line to v3.0 (edits .env only)."
+            exit 0 ;;
+        *) die "Unknown argument: $arg (use -y/--yes to skip the confirmation prompt)" ;;
+    esac
+done
+
+# Single-instance lock. Best-effort: flock may be absent on macOS, and unlike a
+# volume migration the .env edit is atomic (update_env_var) and idempotent, so a
+# missing lock is not fatal here.
+if command -v flock >/dev/null 2>&1; then
+    LOCKFILE="${TMPDIR:-/tmp}/upgrade-mainnet-v2.3-to-v3.0.$(id -u).lock"
+    exec 9>"$LOCKFILE"
+    flock -n 9 || die "another upgrade run is in progress (lock: $LOCKFILE)"
+fi
+
+# --- preflight ---
+[[ -f docker-compose.yml ]] || die "docker-compose.yml not found in $PROJECT_DIR; run this from the igra-orchestra repo root."
+[[ -f .env ]] || die ".env not found in $PROJECT_DIR. Nothing to upgrade — use scripts/setup-mainnet.sh for a fresh deployment."
+[[ -f "$VERSIONS_FILE" ]] || die "$VERSIONS_FILE not found in $PROJECT_DIR; cannot sync image-version pins."
+
+network_value="$(read_env_value .env NETWORK)"
+[[ "$network_value" == "$EXPECTED_NETWORK" ]] \
+    || die ".env NETWORK is '${network_value:-<unset>}', not '$EXPECTED_NETWORK'. This script is mainnet-only; for Galleon see doc/node-operations/migrate-galleon-to-testnet-10.md."
+chain_value="$(read_env_value .env IGRA_CHAIN_ID)"
+[[ "$chain_value" == "$EXPECTED_IGRA_CHAIN_ID" ]] \
+    || die ".env IGRA_CHAIN_ID is '${chain_value:-<unset>}', not the mainnet value '$EXPECTED_IGRA_CHAIN_ID'. Refusing to edit a non-mainnet or stale .env; correct it or edit .env by hand."
+
+# The pins we are about to sync must be real values (not empty / TODO_*).
+for v in "${IMAGE_VERSION_VARS[@]}"; do
+    pin="$(read_env_value "$VERSIONS_FILE" "$v")"
+    [[ -n "$pin" && "$pin" != TODO_* ]] \
+        || die "$VERSIONS_FILE has no usable value for $v ('${pin:-<empty>}'); fix the versions file before upgrading."
+done
+
+# --- show planned changes ---
+cur_lane="$(read_env_value .env IGRA_LANE_ID)"
+cur_prefix="$(read_env_value .env TX_ID_PREFIX)"
+cur_restart="$(read_env_value .env SERVICE_RESTART_POLICY)"
+cur_atan="$(read_env_value .env ATAN_IMPORT_URL)"
+
+echo "Planned .env changes (mainnet v2.3 -> v3.0):"
+printf '  %-28s %s -> %s\n' "IGRA_LANE_ID" "${cur_lane:-<unset>}" "$IGRA_LANE_ID_VALUE"
+if [[ -z "$cur_prefix" ]]; then
+    printf '  %-28s %s -> %s\n' "TX_ID_PREFIX" "<unset>" "$EXPECTED_TX_ID_PREFIX"
+elif [[ "$cur_prefix" != "$EXPECTED_TX_ID_PREFIX" ]]; then
+    printf '  %-28s %s (kept; mainnet canonical is %s) !!\n' "TX_ID_PREFIX" "$cur_prefix" "$EXPECTED_TX_ID_PREFIX"
+else
+    printf '  %-28s %s (unchanged)\n' "TX_ID_PREFIX" "$cur_prefix"
+fi
+if [[ -z "$cur_restart" ]]; then
+    printf '  %-28s %s -> %s\n' "SERVICE_RESTART_POLICY" "<unset>" "$DEFAULT_RESTART_POLICY"
+else
+    printf '  %-28s %s (unchanged)\n' "SERVICE_RESTART_POLICY" "$cur_restart"
+fi
+echo "  image-version pins (from $VERSIONS_FILE):"
+for v in "${IMAGE_VERSION_VARS[@]}"; do
+    cur="$(read_env_value .env "$v")"
+    new="$(read_env_value "$VERSIONS_FILE" "$v")"
+    printf '       %-26s %s -> %s\n' "$v" "${cur:-<unset>}" "$new"
+done
+if [[ -n "$cur_atan" ]]; then
+    echo "  note: ATAN_IMPORT_URL is set ('$cur_atan'). v3.0 auto-builds it as"
+    echo "        {CDN_BASE_URL}/mainnet/97b1/index.pb; left unchanged — verify or unset"
+    echo "        it unless you are deliberately overriding the default."
+fi
+echo "A timestamped backup of .env is written first; Docker volumes are NOT touched."
+
+if [[ "$ASSUME_YES" != true ]]; then
+    yn=""
+    read -r -p "Proceed? [y/N]: " yn || true
+    [[ "$yn" =~ ^[Yy] ]] || { echo "Aborted; .env unchanged."; exit 1; }
+fi
+
+# --- backup (.env may hold credentials: keep it mode 600) ---
+backup_file=".env.backup.pre-v3.0.$(date +%Y%m%d_%H%M%S)"
+(umask 077 && cp .env "$backup_file")
+chmod 600 "$backup_file"
+log "Backed up .env -> $backup_file"
+
+# --- apply (update_env_var upserts: replace if present, append if absent) ---
+update_env_var .env IGRA_LANE_ID "$IGRA_LANE_ID_VALUE"
+if [[ -z "$cur_prefix" ]]; then
+    update_env_var .env TX_ID_PREFIX "$EXPECTED_TX_ID_PREFIX"
+elif [[ "$cur_prefix" != "$EXPECTED_TX_ID_PREFIX" ]]; then
+    error "TX_ID_PREFIX kept at '$cur_prefix' (mainnet canonical is '$EXPECTED_TX_ID_PREFIX'); not overwriting a custom value."
+fi
+[[ -n "$cur_restart" ]] || update_env_var .env SERVICE_RESTART_POLICY "$DEFAULT_RESTART_POLICY"
+for v in "${IMAGE_VERSION_VARS[@]}"; do
+    update_env_var .env "$v" "$(read_env_value "$VERSIONS_FILE" "$v")"
+done
+
+# --- post-write validation ---
+[[ "$(read_env_value .env IGRA_LANE_ID)" == "$IGRA_LANE_ID_VALUE" ]] \
+    || die "post-write check failed: IGRA_LANE_ID is not $IGRA_LANE_ID_VALUE"
+for v in "${IMAGE_VERSION_VARS[@]}"; do
+    want="$(read_env_value "$VERSIONS_FILE" "$v")"
+    [[ "$(read_env_value .env "$v")" == "$want" ]] \
+        || die "post-write check failed: $v is not $want"
+done
+env_mode="$(stat -c %a .env 2>/dev/null || stat -f %A .env)"
+[[ "$env_mode" == "600" ]] || error ".env mode is $env_mode (expected 600); review permissions."
+log ".env reconciled to v3.0."
+
+# Prove the compose file renders with the new .env (i.e. the ${VAR:?...} guards
+# are satisfied). `docker compose config` needs only the CLI/plugin, not the daemon.
+if docker compose version >/dev/null 2>&1; then
+    if docker compose config -q; then
+        log "docker compose config: OK (required variables present)."
+    else
+        die "docker compose config failed after the .env update; inspect the error above."
+    fi
+else
+    error "docker compose not found; skipped compose validation. Run 'docker compose config -q' once it is available."
+fi
+
+cat <<EOF
+
+Done. .env reconciled to v3.0 (backup: $backup_file). Docker volumes untouched.
+
+Next steps:
+  1. First backend start: the kaspad image bump always triggers a one-time DB
+     metadata upgrade that prompts for confirmation and crash-loops inside Docker
+     without a TTY, so approve it noninteractively on this first start:
+
+       KASPAD_NONINTERACTIVE=true docker compose --profile backend up -d --no-build
+       docker compose logs -f kaspad     # wait until it logs past the upgrade
+
+  2. Once kaspad is past the upgrade, recreate it without the override:
+
+       docker compose --profile backend up -d --no-build --force-recreate kaspad
+
+  rpc-provider and kaswallet stay on 2.3 for now: do NOT recreate the frontend
+  profile until after the mainnet Toccata switch. Leave the existing worker
+  containers running (they keep emitting native v0 transactions). See the
+  runbook's "After the Toccata switch" section for the worker bump.
+
+Full procedure & troubleshooting:
+  doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
+EOF

--- a/versions.mainnet.env
+++ b/versions.mainnet.env
@@ -1,6 +1,10 @@
 # Docker image versions for MAINNET deployments
-KASPAD_VERSION=2.3
-RETH_VERSION=2.3
+KASPAD_VERSION=3.0
+RETH_VERSION=3.0
+# rpc-provider and kaswallet stay on 2.3 until the mainnet Toccata (KIP-21)
+# switch; the v3.0 frontend emits lane/subnetwork transactions that mainnet only
+# accepts post-fork. Bump these to 3.0 in the post-Toccata follow-up
+# (see doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md).
 KASWALLET_VERSION=2.3
 RPC_PROVIDER_VERSION=2.3
 NODE_HEALTH_CHECK_VERSION=2.1


### PR DESCRIPTION
## Summary

Adds a complete upgrade path for existing IGRA Orchestra **mainnet** deployments moving from the v2.3 line to v3.0.

The v3.0 `docker-compose.yml` refuses to render without `IGRA_LANE_ID` / `TX_ID_PREFIX` (both `${VAR:?...}`-guarded), and kaspad 3.0 is required for the scheduled Toccata (KIP-21) activation. Operators need a clear, safe way to reconcile their gitignored `.env` and move kaspad/reth off 2.3.

This also fixes a latent inconsistency: the mainnet 3.0 image bump previously lived only on the unmerged `update-mainnet-versions` branch, so `versions.mainnet.env` on v3.0 was stale at `2.3`.

The v3.0 changes ship to operators on `main` (v3.0 → main merge), so the runbook's git steps target `main`.

## Phased rollout (kaspad/reth now, workers after Toccata)

`versions.mainnet.env` bumps **kaspad and reth to 3.0** now; **`RPC_PROVIDER_VERSION` and `KASWALLET_VERSION` stay at `2.3`**. kaspad 3.0 is Toccata-aware but the fork is not yet active on mainnet, so the network still uses native (v0) transactions. The v3.0 frontend (kaswallet via `--subnetwork-id`) emits lane/subnetwork (v1) transactions that mainnet rejects before the fork — so the rpc-provider/kaswallet bump is deferred to a post-Toccata follow-up. They are frontend-profile services, so bringing up only `--profile backend` now leaves the existing 2.3 workers untouched.

## What's included

- **`scripts/upgrade-mainnet-v2.3-to-v3.0.sh`** — idempotent `.env` reconciler. Mainnet keeps `NETWORK=mainnet` and reuses its existing volumes, so there is **no volume rename / re-sync**. Sources `scripts/lib/setup-common.sh` and reuses `update_env_var` / `read_env_value` / `log` / `die`. Best-effort `flock`; preflight guards (`NETWORK=mainnet`, `IGRA_CHAIN_ID=38833`); mode-600 backup `.env.backup.pre-v3.0.*`; upserts `IGRA_LANE_ID=97b10000`, ensures `TX_ID_PREFIX=97b1` and `SERVICE_RESTART_POLICY=unless-stopped`, and syncs image pins from `versions.mainnet.env` (so kaspad/reth → 3.0 and rpc-provider/kaswallet stay 2.3). Pre-flight summary + confirmation before writing (`-y` to skip); post-write assertions + `docker compose config -q`; epilogue with the first-start `KASPAD_NONINTERACTIVE=true` bring-up.
- **`versions.mainnet.env`** — `KASPAD_VERSION` / `RETH_VERSION` `2.3 → 3.0`; `RPC_PROVIDER_VERSION` / `KASWALLET_VERSION` stay `2.3` (commented with the Toccata rationale); `NODE_HEALTH_CHECK_VERSION` / `ATAN_UPLOADER_VERSION` stay `2.1`.
- **`doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md`** — runbook (Who / What / Prerequisites / Run / Verify / **After the Toccata switch** / Rollback / Troubleshooting), matching the Galleon migration guide's house style. The first backend start uses `KASPAD_NONINTERACTIVE=true` (the kaspad image bump always triggers a one-time DB metadata upgrade that crash-loops inside Docker without it).
- Index links in `README.md`, `doc/index.md`, and `doc/node-operations/index.md`.

## Testing

- `shellcheck` clean; `bash -n` passes.
- Isolated end-to-end test against a throwaway v2.3-style `.env` (the repo's `.env` is never touched): kaspad/reth land on `3.0`, rpc-provider/kaswallet stay `2.3`, `IGRA_LANE_ID`/`SERVICE_RESTART_POLICY` set, mode-600 backup created, idempotent re-run (no duplicate keys), the `versions.mainnet.env` comment lines do not leak into parsed values, `docker compose config` validates, and both negative guards abort (non-mainnet `NETWORK`, wrong `IGRA_CHAIN_ID`).
- All documentation links resolve.

## How to use (now, pre-Toccata)

```bash
git fetch origin && git checkout main && git pull --ff-only   # in the deployment dir
./scripts/upgrade-mainnet-v2.3-to-v3.0.sh
docker compose config -q
# first start: the kaspad image bump triggers a one-time DB upgrade (crash-loops without this); backend only
KASPAD_NONINTERACTIVE=true docker compose --profile backend up -d --no-build
docker compose logs -f kaspad                                 # wait until it logs past the upgrade
docker compose --profile backend up -d --no-build --force-recreate kaspad   # drop the override
```

After the mainnet Toccata switch, bump `RPC_PROVIDER_VERSION`/`KASWALLET_VERSION` to `3.0` and recreate the `frontend-w<N>` profile (see the runbook).

ClickUp: ENG-1158 — https://app.clickup.com/t/86aj5n8mx
