### PR TITLE
[ENG-1161] feat(kaspad): optional KASPAD_RETENTION_PERIOD_DAYS passthrough

### DIFF
--- a/.env.atan.example
+++ b/.env.atan.example
@@ -33,6 +33,8 @@ CDN_BASE_URL=https://dyehoijgeqfp8.cloudfront.net
 # ATAN_IMPORT_URL=
 # Optional: connect to a specific peer
 # KASPAD_ADD_PEER=
+# Optional: prune block data older than N days (omit to keep kaspad's default retention).
+# KASPAD_RETENTION_PERIOD_DAYS=
 
 # --- Image Versions ---
 KASPAD_VERSION=2.3

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -82,6 +82,8 @@ KASPAD_P2P_PORT=16211
 KASPAD_BORSH_PORT=17210
 KASPAD_JSON_PORT=18210
 KASPAD_ADD_PEER=<ip-address> # optional argument
+# Optional: prune block data older than N days (omit to keep kaspad's default retention).
+# KASPAD_RETENTION_PERIOD_DAYS=
 
 IGRA_LOCK_SCRIPT_PUBKEY=20aeb014c0814f5c549bbea36638e08b1e8d4c1b8251780841fce1fdcbf72ee01dac
 IGRA_ENTRY_MIN_AMOUNT=100000000

--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -41,6 +41,9 @@ IGRA_ENABLE=true
 # Skip lock script pubkey verification for Entry transactions (TESTING ONLY, default: false)
 IGRA_SKIP_LOCK_SCRIPT_CHECK=false
 
+# Optional: prune block data older than N days (omit to keep kaspad's default retention).
+# KASPAD_RETENTION_PERIOD_DAYS=
+
 # --- General and Shared Configuration ---
 RUST_LOG=info
 IGRA_CHAIN_ID=19416

--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -88,6 +88,9 @@ KASPAD_ADD_PEER=65.109.78.124
 # Leave empty to skip; set to another rule string to override.
 KASPAD_UA_RULE=reject;ver:kaspad<1.2.1
 
+# Optional: prune block data older than N days (omit to keep kaspad's default retention).
+# KASPAD_RETENTION_PERIOD_DAYS=
+
 # --- RPC Configuration ---
 # Set to true for read-only RPC (no transaction submission)
 # Set to false if you want to accept and submit user transactions (requires funded wallets)

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -69,6 +69,9 @@ KASPAD_P2P_PORT=16111
 KASPAD_BORSH_PORT=17110
 KASPAD_JSON_PORT=18110
 
+# Optional: prune block data older than N days (omit to keep kaspad's default retention).
+# KASPAD_RETENTION_PERIOD_DAYS=
+
 
 # --- RPC Configuration ---
 # Set to true for read-only RPC (no transaction submission)

--- a/doc/node-operations/atan-only.md
+++ b/doc/node-operations/atan-only.md
@@ -55,6 +55,7 @@ See `.env.atan.example` at the repository root for all available variables. Key 
 | `CDN_BASE_URL` | CloudFront URL | CDN for ATAN data import |
 | `ATAN_IMPORT_URL` | (empty) | Optional full import URL override; leave unset to use the auto-constructed `{CDN_BASE_URL}/{NETWORK}/{TX_ID_PREFIX}/index.pb` |
 | `KASPAD_ADD_PEER` | (empty) | Optional peer to connect to |
+| `KASPAD_RETENTION_PERIOD_DAYS` | (empty) | Optional block-data retention window in days (passed as `--retention-period-days`); omit to use kaspad's default |
 
 ## Monitoring
 

--- a/doc/node-operations/environment-reference.md
+++ b/doc/node-operations/environment-reference.md
@@ -30,6 +30,7 @@ All operational variables across the stack.
 | `CDN_BASE_URL` | `.env` | CDN base URL for ATAN data import |
 | `ATAN_IMPORT_URL` | `.env` | Optional override for auto-constructed import URL |
 | `KASPAD_ADD_PEER` | `.env` | Optional peer address |
+| `KASPAD_RETENTION_PERIOD_DAYS` | `.env` | Optional block-data retention window in days, passed to kaspad as `--retention-period-days`; omit to use kaspad's default. Applies to all kaspad modes |
 | `AWS_ACCESS_KEY_ID` | `.env` | AWS credentials for atan-uploader |
 | `AWS_SECRET_ACCESS_KEY` | `.env` | AWS credentials for atan-uploader |
 | `DATADIR` | `.env` | Data directory path for atan-uploader |

--- a/docker-compose.atan.yml
+++ b/docker-compose.atan.yml
@@ -35,6 +35,7 @@ services:
       - KASPAD_ADD_PEER
       - KASPAD_NONINTERACTIVE
       - KASPAD_UA_RULE
+      - KASPAD_RETENTION_PERIOD_DAYS
       - ATAN_IMPORT_URL
       - CDN_BASE_URL
       - NETWORK
@@ -67,6 +68,12 @@ services:
         # Set KASPAD_UA_RULE in .env to apply; leave empty to skip.
         if [ -n "$$KASPAD_UA_RULE" ]; then
           ARGS="$$ARGS --ua-rule=$$KASPAD_UA_RULE"
+        fi
+
+        # Optional block-data retention window (days). Omit to keep kaspad's default.
+        # Set KASPAD_RETENTION_PERIOD_DAYS in .env to apply.
+        if [ -n "$$KASPAD_RETENTION_PERIOD_DAYS" ]; then
+          ARGS="$$ARGS --retention-period-days=$$KASPAD_RETENTION_PERIOD_DAYS"
         fi
 
         # Empty TX_ID_PREFIX would render as --atan-transaction-id-prefix=

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -50,6 +50,7 @@ services:
       - "127.0.0.1:${KASPAD_JSON_PORT}:${KASPAD_JSON_PORT}"
     environment:
       - KASPAD_ADD_PEER
+      - KASPAD_RETENTION_PERIOD_DAYS
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
       - WARM_START_BLOCK
@@ -78,6 +79,12 @@ services:
 
         if [ "$$NETWORK" != "mainnet" ]; then
           ARGS="--$$NETWORK --nodnsseed $$ARGS"
+        fi
+
+        # Optional block-data retention window (days). Omit to keep kaspad's default.
+        # Set KASPAD_RETENTION_PERIOD_DAYS in .env to apply.
+        if [ -n "$$KASPAD_RETENTION_PERIOD_DAYS" ]; then
+          ARGS="$$ARGS --retention-period-days=$$KASPAD_RETENTION_PERIOD_DAYS"
         fi
 
         IGRA_ENABLED="$${IGRA_ENABLE:-true}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,7 @@ services:
       - KASPAD_ADD_PEER
       - KASPAD_NONINTERACTIVE
       - KASPAD_UA_RULE
+      - KASPAD_RETENTION_PERIOD_DAYS
       - ENABLE_PERF_DIAGNOSTICS
       - ENABLE_EVENT_LOGGING
       - WARM_START_BLOCK
@@ -254,6 +255,12 @@ services:
         # Set KASPAD_UA_RULE in .env to apply; leave empty to skip.
         if [ -n "$$KASPAD_UA_RULE" ]; then
           ARGS="$$ARGS --ua-rule=$$KASPAD_UA_RULE"
+        fi
+
+        # Optional block-data retention window (days). Omit to keep kaspad's default.
+        # Set KASPAD_RETENTION_PERIOD_DAYS in .env to apply.
+        if [ -n "$$KASPAD_RETENTION_PERIOD_DAYS" ]; then
+          ARGS="$$ARGS --retention-period-days=$$KASPAD_RETENTION_PERIOD_DAYS"
         fi
 
         IGRA_ENABLED="$${IGRA_ENABLE:-true}"


### PR DESCRIPTION
## Summary

kaspad supports a `--retention-period-days` flag that bounds how long block data is retained before pruning, but the orchestra previously had no way to set it. This adds an optional `KASPAD_RETENTION_PERIOD_DAYS` environment variable: when set in `.env`, the kaspad entrypoint appends `--retention-period-days=<value>` to kaspad's args; when unset, nothing changes and kaspad keeps its built-in default.

It reuses the existing optional-flag pattern already used for `KASPAD_UA_RULE` / `KASPAD_ADD_PEER`, placed in the general kaspad-options section before the IGRA block so it applies regardless of `IGRA_ENABLE`.

## Changes

- **Entrypoints (3):** `docker-compose.yml`, `docker-compose.devnet.yml`, `docker-compose.atan.yml` — add `- KASPAD_RETENTION_PERIOD_DAYS` to the kaspad `environment:` passthrough and a conditional block that appends the flag only when the var is non-empty.
- **Env templates (5):** `.env.mainnet.example`, `.env.galleon-testnet.example`, `.env.devnet.example`, `.env.atan.example`, `.env.dev.example` — commented-out optional entry. (`.env.example` is the Traefik-only overrides file and is intentionally untouched.)
- **Docs (2):** `doc/node-operations/environment-reference.md`, `doc/node-operations/atan-only.md` — documented alongside `KASPAD_ADD_PEER`.

## Verification

- All three compose files parse cleanly as YAML.
- Independent review confirmed `$$` escaping, env passthrough in all three services, placement before the IGRA block, atan ordering vs. the `TX_ID_PREFIX` guard, and word-splitting are all correct.
- **Pre-merge check** (not runnable in this environment — docker daemon unavailable, kaspad source not vendored): confirm the flag spelling against the pinned image, then sanity-check the conditional.

  ```sh
  docker compose run --rm --no-deps --entrypoint /app/kaspad kaspad --help | grep -i retention
  # unset                          -> no --retention-period-days in args
  # KASPAD_RETENTION_PERIOD_DAYS=30 -> --retention-period-days=30 present
  ```

## Ticket

ENG-1161 — https://app.clickup.com/t/86aj6e6d9
