### PR TITLE
[ENG-1162] fix(kaswallet): gate --subnetwork-id on KASWALLET_VERSION (v3+ only)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,14 +132,17 @@ x-kaswallet-runtime: &kaswallet-runtime
     - NETWORK
     - KASPAD_HOST
     - KASPAD_GRPC_PORT
-    # Operator-facing 4-byte lane namespace (e.g. 97b10000). REQUIRED:
-    # without it kaswallet-daemon defaults to SUBNETWORK_ID_NATIVE and emits
-    # pre-Toccata (v0) transactions that post-Toccata kaspad rejects. The
-    # entrypoint forwards it to kaswallet-daemon as --subnetwork-id,
-    # mirroring the kaspad --igra-lane-id pattern below so all lane-id
-    # wiring lives at the entrypoint layer. (The daemon also accepts
-    # KASWALLET_SUBNETWORK_ID via clap env=; we deliberately do not use
-    # that path.)
+    # Pinned kaswallet image tag (e.g. 2.3, 3.0, or devnet). The entrypoint
+    # reads its major version to decide whether to forward --subnetwork-id:
+    # only kaswallet v3+ understands that flag; v2.x rejects it and crash-loops.
+    - KASWALLET_VERSION
+    # Operator-facing 4-byte lane namespace (e.g. 97b10000). For kaswallet v3+
+    # the entrypoint forwards it to kaswallet-daemon as --subnetwork-id (and
+    # hard-fails if unset), mirroring the kaspad --igra-lane-id pattern below so
+    # all lane-id wiring lives at the entrypoint layer. On pre-Toccata v2.x the
+    # flag is skipped and the daemon defaults to SUBNETWORK_ID_NATIVE / v0
+    # transactions, which is correct pre-Toccata. (The daemon also accepts
+    # KASWALLET_SUBNETWORK_ID via clap env=; we deliberately do not use that path.)
     - IGRA_LANE_ID
   extra_hosts:
     - "host.docker.internal:host-gateway"
@@ -163,11 +166,24 @@ x-kaswallet-runtime: &kaswallet-runtime
           ARGS="$$ARGS --testnet-suffix=$$KASPA_NETSUFFIX"
         fi
       fi
-      if [ -z "$$IGRA_LANE_ID" ]; then
-        echo "Error: IGRA_LANE_ID must be set for kaswallet; without it the daemon defaults to SUBNETWORK_ID_NATIVE and emits pre-Toccata (v0) transactions that post-Toccata kaspad rejects" >&2
-        exit 1
+      # kaswallet only learned --subnetwork-id in v3 (post-Toccata). v2.x
+      # rejects it ("unexpected argument") and crash-loops, so gate the flag on
+      # the pinned KASWALLET_VERSION: pass it for v3+ (and source tags like
+      # devnet/latest), skip it for any numeric major < 3 (e.g. 2.3), where the
+      # daemon correctly defaults to SUBNETWORK_ID_NATIVE / pre-Toccata (v0)
+      # transactions.
+      KASWALLET_MAJOR="$${KASWALLET_VERSION%%.*}"
+      case "$$KASWALLET_MAJOR" in
+        ''|*[!0-9]*) PASS_SUBNETWORK=1 ;;
+        *) if [ "$$KASWALLET_MAJOR" -ge 3 ]; then PASS_SUBNETWORK=1; else PASS_SUBNETWORK=0; fi ;;
+      esac
+      if [ "$$PASS_SUBNETWORK" = "1" ]; then
+        if [ -z "$$IGRA_LANE_ID" ]; then
+          echo "Error: IGRA_LANE_ID must be set for kaswallet v3+; without it the daemon defaults to SUBNETWORK_ID_NATIVE and emits pre-Toccata (v0) transactions that post-Toccata kaspad rejects" >&2
+          exit 1
+        fi
+        ARGS="$$ARGS --subnetwork-id=$$IGRA_LANE_ID"
       fi
-      ARGS="$$ARGS --subnetwork-id=$$IGRA_LANE_ID"
       exec sh /app/watch-dependencies.sh \
         --tcp kaspad "$$KASPAD_HOST" "$$KASPAD_GRPC_PORT" \
         -- /app/kaswallet-daemon $$ARGS


### PR DESCRIPTION
Ticket: [ENG-1162](https://app.clickup.com/t/86aj6g22k)

## Problem
`kaswallet-0` crash-loops on the v3.0 stack before the Toccata switch:
```
error: unexpected argument '--subnetwork-id' found
```

## Root cause
The kaswallet entrypoint appended `--subnetwork-id=$IGRA_LANE_ID` **unconditionally**, but that flag only exists in kaswallet **v3+**. `versions.mainnet.env` pins `KASWALLET_VERSION=2.3` (kaswallet intentionally stays on 2.3 until the mainnet Toccata/KIP-21 switch), so the 2.3 binary rejects the flag and never starts. The `${IGRA_LANE_ID:?…}` render guards force the lane id to be set, which guaranteed the flag was passed to the 2.x binary.

## Fix (`docker-compose.yml`, `x-kaswallet-runtime` anchor — covers `kaswallet-0..N`)
- Pass `KASWALLET_VERSION` into the kaswallet container so the entrypoint can read it.
- Forward `--subnetwork-id` (and its `IGRA_LANE_ID` fail-fast) only when the numeric major version is **`>= 3`**. Pre-v3 binaries start flag-less and default to `SUBNETWORK_ID_NATIVE` / v0 transactions (correct pre-Toccata); `devnet`/`latest` source tags keep passing it.
- Cutover is automatic: bumping `KASWALLET_VERSION` to `3.0` after the switch enables the flag with no compose edit.

`docker-compose.devnet.yml` (already conditional, source build) and `docker-compose.atan.yml` (no kaswallet) are unaffected. Docs intentionally not updated — v3 ships imminently and the docs describe the v3 end-state.

## Verification
- `docker compose config` renders cleanly for mainnet (2.3) and galleon (3.0); `KASWALLET_VERSION` reaches the container.
- Ran the rendered entrypoint with stubbed deps: **2.3 launches with no `--subnetwork-id`**; **3.0 launches with `--subnetwork-id=97b10000`**.
- `.github/workflows/compose-config.yml` literal assertions (`--subnetwork-id=$$IGRA_LANE_ID`, `IGRA_LANE_ID must be set`, `--testnet-suffix=$$KASPA_NETSUFFIX`) all preserved.
- POSIX-sh gate unit-tested across `2.3/3.0/devnet/latest/empty` and edge values; `shellcheck -s sh` clean (no new findings).
