### PR TITLE
[ENG-1163] docs(upgrade): document config/traefik chown fix for v2.3->v3.0 pull

### DIFF
--- a/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
+++ b/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
@@ -71,6 +71,18 @@ git checkout main        # or whatever ref your deployment tracks
 git pull --ff-only
 ```
 
+**If the pull leaves `config/traefik/dynamic.yml` showing as `deleted`** in
+`git status` (or aborts with `unable to create file config/traefik/dynamic.yml:
+Permission denied`), the Traefik container — which runs as root and bind-mounts
+`./config/traefik` — has left that directory root-owned, so Git (running as your
+login user) can't write the newly tracked file into it. Restore ownership to your
+user and check the file back out, then re-run the pull if it had aborted:
+
+```bash
+sudo chown -R "$USER:$USER" config/traefik/
+git restore config/traefik/dynamic.yml
+```
+
 ### 2. Reconcile `.env`
 
 ```bash
@@ -202,6 +214,7 @@ clean:
 
 | Error | Meaning | Fix |
 |---|---|---|
+| `config/traefik/dynamic.yml` shows as `deleted` after the pull (or `unable to create file ... Permission denied`) | The root-running Traefik container bind-mounts `config/traefik/`, leaving the directory root-owned, so Git can't write the new tracked `dynamic.yml` into it | `sudo chown -R "$USER:$USER" config/traefik/ && git restore config/traefik/dynamic.yml` |
 | `IGRA_LANE_ID must be set ...` at `docker compose` | `.env` is still on the v2.3 schema (missing the lane) | Run `./scripts/upgrade-mainnet-v2.3-to-v3.0.sh` (or set `IGRA_LANE_ID=97b10000` by hand) |
 | `TX_ID_PREFIX must be set ...` at `docker compose` | `TX_ID_PREFIX` missing/empty | Set `TX_ID_PREFIX=97b1` in `.env` |
 | `.env NETWORK is '...', not 'mainnet'` | Wrong network for this script | This guide is mainnet-only; for Galleon use [migrate-galleon-to-testnet-10.md](migrate-galleon-to-testnet-10.md) |


### PR DESCRIPTION
## Summary

Adds a documented fix to the mainnet v2.3 → v3.0 upgrade runbook for a permission issue hit at the very first step (the `git` pull): `config/traefik/dynamic.yml` shows up as `deleted` and can't be checked out.

## Why

On a running v2.3 node, the `traefik:v3` service bind-mounts `./config/traefik:/etc/traefik` (this mount predates v3.0) and runs as **root**, so the host `config/traefik/` directory ends up root-owned. v3.0 introduces a **new tracked file**, `config/traefik/dynamic.yml`, inside that directory. During the upgrade's `git pull` / `git checkout`, Git runs as the login user and can't write the tracked file into the root-owned directory — so it appears as `deleted` in `git status` (or the checkout aborts with `Permission denied`). This has been hit on real mainnet nodes during the upgrade.

## What changed

`doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md`:

- Inline note under **1. Pull the latest code** explaining the symptom and fix.
- A **Troubleshooting** table row (placed first, since it is the earliest-occurring failure in the flow).

Both capture the fix the operator used:

```bash
sudo chown -R "$USER:$USER" config/traefik/
git restore config/traefik/dynamic.yml
```

## Verification

- Docs-only change (13 insertions, 1 file). No code / compose / script changes.
- Markdown validated: balanced code fences, well-formed 3-column troubleshooting table.
- Root cause cross-checked against git history (the `config/traefik` bind mount was introduced before v3.0; `dynamic.yml` was added on the v3.0 line) and `docker-compose.yml` (traefik runs as root with a read-write `./config/traefik` bind mount).
