### PR TITLE
[ENG-1165] docs(nav): surface CPU miner and v2.3->v3.0 upgrade pages in sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,9 @@ nav:
       - ATAN-Only Mode: node-operations/atan-only.md
       - ATAN Verification: node-operations/atan-verification.md
       - Environment Reference: node-operations/environment-reference.md
+      - Running a CPU Miner: node-operations/running-a-cpu-miner.md
       - Galleon → testnet-10 Migration: node-operations/migrate-galleon-to-testnet-10.md
+      - Mainnet v2.3 → v3.0 Upgrade: node-operations/upgrade-mainnet-v2.3-to-v3.0.md
     - Kaspa Wallet: kaspa-wallet.md
     - Log Management: log-management.md
   - Troubleshooting:


### PR DESCRIPTION
## Summary
Two `node-operations` docs pages were deployed and reachable by direct URL but missing from the site's left navigation sidebar, because they were never added to `mkdocs.yml`'s `nav:`. This adds both under Operations → Node Operations so readers can find them from the menu.

### Changes
- Add "Running a CPU Miner" (`node-operations/running-a-cpu-miner.md`) to nav, after Environment Reference
- Add "Mainnet v2.3 → v3.0 Upgrade" (`node-operations/upgrade-mainnet-v2.3-to-v3.0.md`) to nav, after the Galleon → testnet-10 migration entry
- Single-file change: `mkdocs.yml` (+2 lines)

### Notes
- Not a deploy failure: the latest `deploy-docs.yml` run already succeeded. MkDocs builds every page under `doc/`, but only entries in `nav:` appear in the sidebar — so these two were effectively undiscoverable.

## Test Plan
- [x] `mkdocs build --strict` exits 0 with no "not included in the nav" notice
- [x] Both pages' HTML build; both links now appear in the rendered sidebar
- [ ] After merge, `deploy-docs.yml` republishes GitHub Pages and both entries show in the live sidebar
