### PR TITLE
[ENG-1166] Frame v2.3→v3.0 upgrade as Toccata Part One

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ docker run --rm -v ./logs:/app/logs --entrypoint /app/igra-tx-parser igranetwork
 - [Mainnet Deployment Guide](doc/quick-setup-mainnet.md) - Public mainnet deployment with pre-built images
 - [Galleon Testnet Deployment Guide](doc/quick-setup-galleon-testnet.md) - Public Galleon testnet (testnet-10) deployment with pre-built images
 - [Galleon → testnet-10 Migration Guide](doc/node-operations/migrate-galleon-to-testnet-10.md) - One-shot upgrade for existing Galleon operators on `NETWORK=testnet`
-- [Mainnet v2.3 → v3.0 Upgrade Guide](doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md) - One-shot upgrade for existing mainnet operators from the v2.3 line to v3.0
+- [Toccata Upgrade — Part One: Mainnet v2.3 → v3.0](doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md) - Part one of the Toccata (KIP-21) upgrade: bring the backend (kaspad/reth) to v3.0 before the fork while workers stay on 2.3
 - [Kaspa Wallet Guide](doc/kaspa-wallet.md) - Wallet setup for all networks
 - [Log Management](doc/log-management.md) - Automated log cleanup for servers
 - [Docker Volume Permissions](doc/troubleshooting/docker-volume-permissions.md) - Fix permission denied errors

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,7 +12,7 @@ Choose your deployment guide:
 ## Operations
 
 - **[Node Operations](node-operations/index.md)** - Worker config, wallet API, balance monitoring, health checks, ATAN-only mode, and external CPU mining
-- **[Mainnet v2.3 → v3.0 Upgrade](node-operations/upgrade-mainnet-v2.3-to-v3.0.md)** - Move an existing mainnet deployment to v3.0: reconcile `.env` and bump images, preserving volumes
+- **[Toccata Upgrade — Part One: Mainnet v2.3 → v3.0](node-operations/upgrade-mainnet-v2.3-to-v3.0.md)** - Part one of the Toccata (KIP-21) upgrade: bring the backend (kaspad/reth) to v3.0 before the fork while workers stay on 2.3 (reconcile `.env`, preserve volumes)
 - **[Kaspa Wallet Guide](kaspa-wallet.md)** - Wallet setup and management for all networks
 - **[Log Management](log-management.md)** - Automated log cleanup for servers
 

--- a/doc/node-operations/index.md
+++ b/doc/node-operations/index.md
@@ -9,5 +9,5 @@ Operational reference for running Igra Orchestra nodes.
 - **[ATAN Verification](atan-verification.md)** - Verify stored post-KIP-21 finality-period archives with the offline `kaspa-atan-verify` tool
 - **[Environment Reference](environment-reference.md)** - All operational environment variables
 - **[Galleon → testnet-10 Migration](migrate-galleon-to-testnet-10.md)** - One-shot upgrade for existing Galleon operators on `NETWORK=testnet` to the uniform `NETWORK=testnet-10` schema (preserves IBD state)
-- **[Mainnet v2.3 → v3.0 Upgrade](upgrade-mainnet-v2.3-to-v3.0.md)** - One-shot upgrade for existing mainnet operators from the v2.3 line to v3.0 (reconciles `.env` and bumps images to 3.0; preserves volumes)
+- **[Toccata Upgrade — Part One: Mainnet v2.3 → v3.0](upgrade-mainnet-v2.3-to-v3.0.md)** - Part one of the Toccata (KIP-21) upgrade for existing mainnet operators: bring the backend (kaspad/reth) to v3.0 before the fork while workers stay on 2.3 (reconciles `.env`; preserves volumes)
 - **[Running a CPU Miner](running-a-cpu-miner.md)** - Optionally produce Kaspa L1 blocks for an isolated local network with an external CPU miner

--- a/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
+++ b/doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md
@@ -1,4 +1,11 @@
-# Mainnet v2.3 → v3.0 Upgrade
+# Toccata Upgrade — Part One: Mainnet v2.3 → v3.0
+
+!!! note "A two-part upgrade"
+    The mainnet move to v3.0 is split by the **Toccata (KIP-21) hardfork**.
+    **Part One (this guide)** brings the backend (kaspad/reth) to v3.0 now, while the fork is
+    still inactive — the workers stay on 2.3 and keep emitting native (v0) transactions.
+    **Part Two** brings the `rpc-provider`/`kaswallet` workers to v3.0 once Toccata activates;
+    see [Part Two: after the Toccata switch](#part-two-after-the-toccata-switch).
 
 ## TL;DR
 
@@ -29,7 +36,7 @@ docker compose --profile backend up -d --no-build --force-recreate kaspad  # dro
 **Do not recreate the frontend workers in this phase** — they keep emitting native
 (v0) transactions, which is what pre-Toccata mainnet expects. After the fork, set
 `RPC_PROVIDER_VERSION`/`KASWALLET_VERSION` to `3.0` and recreate the worker profile;
-see [After the Toccata switch](#after-the-toccata-switch).
+see [Part Two: after the Toccata switch](#part-two-after-the-toccata-switch).
 
 Full rationale, prerequisites, verification, rollback, and troubleshooting follow below.
 
@@ -66,7 +73,7 @@ image-version pins. The real upgrade work is reconciling `.env`:
   for now (`NODE_HEALTH_CHECK_VERSION` / `ATAN_UPLOADER_VERSION` stay `2.1`).
   kaspad 3.0 is Toccata-aware but the fork is **not yet active** on mainnet, so
   the network still uses native (v0) transactions. The rpc-provider/kaswallet
-  bump is deferred to [After the Toccata switch](#after-the-toccata-switch) — the
+  bump is deferred to [Part Two: after the Toccata switch](#part-two-after-the-toccata-switch) — the
   v3.0 frontend emits lane/subnetwork (v1) transactions that mainnet rejects
   before the fork.
 
@@ -176,7 +183,7 @@ docker compose --profile backend up -d --no-build --force-recreate kaspad
 `kaswallet` stay on 2.3 and keep emitting native (v0) transactions, which is what
 pre-Toccata mainnet expects. Leave your existing worker containers running — only
 the `backend` profile is recreated now. You'll upgrade the workers in
-[After the Toccata switch](#after-the-toccata-switch).
+[Part Two: after the Toccata switch](#part-two-after-the-toccata-switch).
 
 ### About `KASPAD_NONINTERACTIVE`
 
@@ -208,7 +215,7 @@ In the running stack, confirm:
 - The **health-check client** reports `KASPAD_VERSION=3.0` to the monitoring
   server.
 
-## After the Toccata switch
+## Part Two: after the Toccata switch
 
 Once Toccata (KIP-21) has activated on mainnet, upgrade the workers so they emit
 lane/subnetwork (v1) transactions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - Environment Reference: node-operations/environment-reference.md
       - Running a CPU Miner: node-operations/running-a-cpu-miner.md
       - Galleon → testnet-10 Migration: node-operations/migrate-galleon-to-testnet-10.md
-      - Mainnet v2.3 → v3.0 Upgrade: node-operations/upgrade-mainnet-v2.3-to-v3.0.md
+      - Toccata Upgrade — Part One (v2.3 → v3.0): node-operations/upgrade-mainnet-v2.3-to-v3.0.md
     - Kaspa Wallet: kaspa-wallet.md
     - Log Management: log-management.md
   - Troubleshooting:


### PR DESCRIPTION
## Summary
Reframe the mainnet v2.3 → v3.0 upgrade runbook as "Toccata Upgrade — Part One" so its two-phase structure around the Toccata (KIP-21) hardfork is explicit: the backend moves to v3.0 before the fork (this guide), and the workers move to v3.0 after it ("Part Two"). Docs-only — no filename, version-pin, or script changes.

### Changes
- Retitle the runbook H1 to "Toccata Upgrade — Part One: Mainnet v2.3 → v3.0" and add a two-part framing admonition.
- Relabel the "After the Toccata switch" section "Part Two: after the Toccata switch" and update the three in-page anchor links to the new slug.
- Update the mkdocs nav label to "Toccata Upgrade — Part One (v2.3 → v3.0)".
- Reframe the link text and descriptions on the home and node-operations index pages.

## Test Plan
- [x] `mkdocs build --strict` passes clean (verified locally)
- [x] "Part Two" heading renders id `part-two-after-the-toccata-switch`; all in-page links resolve
- [x] No stale "Mainnet v2.3 → v3.0 Upgrade" / `#after-the-toccata-switch` references remain
- [ ] Reviewer spot-checks rendered sidebar label, H1, and page title

Ticket: ENG-1166
