### PR TITLE
[ENG-1169] Gate node-health-check startup on EL health

### DIFF
--- a/doc/troubleshooting/service-restart-debugging.md
+++ b/doc/troubleshooting/service-restart-debugging.md
@@ -29,6 +29,7 @@ Two services currently pin `restart: unless-stopped` directly in Compose:
 flowchart LR
   executionLayer["execution-layer"] --> kaspad["kaspad"]
   executionLayer --> rpcProvider["rpc-provider-*"]
+  executionLayer --> nodeHealthCheck["node-health-check-client"]
   kaspad --> kaswallet["kaswallet-*"]
   kaswallet -->|"RPC_READ_ONLY=false"| rpcProvider
   rpcProvider --> traefik["traefik"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -432,6 +432,13 @@ services:
     container_name: node-health-check-client
     networks:
       - igra-network
+    # Gate startup on execution-layer: this client polls execution-layer:8545 and,
+    # if started in parallel on `compose up`, races reth's boot and goes stale.
+    # required:false keeps the standalone node-health-check-client profile working.
+    depends_on:
+      execution-layer:
+        condition: service_healthy
+        required: false
     environment:
       - NODE_RPC_URL=http://execution-layer:8545
       - MONITOR_URL=http://${NODE_HEALTH_CHECK_URL}:8081


### PR DESCRIPTION
## Summary
After `docker compose --profile backend down && up`, `node-health-check-client`
stayed Up but stopped pushing — its logs froze and the monitoring dashboard went
stale. It was the only `execution-layer:8545` consumer with no startup gating, so
on `up` it raced reth's boot, failed its first RPC connection, and never recovered.
This gates its startup on execution-layer health so it only starts once the RPC
port is serving.

### Changes
- `docker-compose.yml`: add `depends_on: execution-layer { condition: service_healthy, required: false }` to `node-health-check-client` (mirrors `rpc-provider`); `required: false` preserves the standalone `--profile node-health-check-client` path.
- `doc/troubleshooting/service-restart-debugging.md`: add `node-health-check-client` to the dependency-map diagram.

### Bug Fixes
- Eliminates the post-restart "Up but stale" state where the client process stayed alive (healthcheck stayed green) while it silently stopped pushing data.

## Test Plan
- [ ] `docker compose --profile backend config` renders without error
- [ ] After `docker compose --profile backend down && up -d`, `node-health-check-client` stays `Created`/waiting until `execution-layer` is `healthy`, then becomes `Up`
- [ ] `docker compose logs -f node-health-check-client` shows fresh poll/push activity (not frozen)
- [ ] Monitoring dashboard reports the node as fresh (not stale)
- [ ] Standalone `docker compose --profile node-health-check-client up -d` still starts (required:false)
