### PR TITLE
[ENG-1153] feat(devnet): Run ATAN without L2 on devnet + CPU miner and import-validation tooling

### DIFF
--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -38,6 +38,17 @@ SERVICE_RESTART_POLICY=unless-stopped
 
 # --- Kaspad Configuration ---
 IGRA_ENABLE=true
+# --- ATAN without L2 (test harness) ---
+# ATAN_ENABLE controls ATAN independently of IGRA. Defaults to IGRA_ENABLE, so
+# normal runs are unchanged. To run ATAN with L2 OFF (e.g. the Toccata
+# import-validation test), set IGRA_ENABLE=false and ATAN_ENABLE=true. In that
+# mode kaspad emits --atan-listen/--igra-lane-id but no viaduct/igra flags, and
+# does not wait for the execution layer. See scripts/dev/run-devnet-atan-no-l2.sh.
+# ATAN_ENABLE=true
+# ATAN_IMPORT_DIR imports ATAN finality-period archives from a LOCAL directory on
+# startup (mutually exclusive with ATAN_IMPORT_URL). Used by the second import
+# node; leave empty on a mining node. See scripts/dev/validate-devnet-atan.sh.
+# ATAN_IMPORT_DIR=
 # Skip lock script pubkey verification for Entry transactions (TESTING ONLY, default: false)
 IGRA_SKIP_LOCK_SCRIPT_CHECK=false
 

--- a/docker-compose.devnet-atan-import.yml
+++ b/docker-compose.devnet-atan-import.yml
@@ -1,0 +1,135 @@
+name: igra-devnet-atan-import
+
+# Second, fresh kaspad node whose ONLY job is to import node 1's ATAN archive
+# from a local directory and validate every finality period on the way in.
+# kaspad startup import is fail-closed: an invalid period => process::exit(1),
+# so a clean, staying-up container == all imported periods validated.
+
+x-default-logging: &default-logging
+  driver: "${LOGGING_DRIVER:-json-file}"
+  options: { max-size: "1g", max-file: "10", compress: "true" }
+
+volumes:
+  # Fresh atan_db so kaspad actually performs the import ("missing or outdated").
+  kaspad_import_data:
+  # Node 1's data volume, mounted read-only as the import SOURCE.
+  node1_archive:
+    external: true
+    name: igra-devnet_kaspad_data
+
+networks:
+  # Join node 1's compose network so node 2 can peer with it for L1 IBD.
+  # ATAN only starts (and imports) once consensus reports "nearly synced", which
+  # for an isolated node requires peering to a node with a fresh tip (node 1,
+  # which keeps mining during validation).
+  node1_net:
+    external: true
+    name: igra-devnet_default
+
+services:
+  kaspad-import:
+    image: igranetwork/kaspad:${KASPAD_VERSION}
+    container_name: kaspad-import-devnet
+    restart: "no"
+    logging: *default-logging
+    # Publish node 2's gRPC so a host cpuminer can drive it: node 2 self-mines a
+    # few blocks to give its sink a fresh timestamp -> is_nearly_synced -> ATAN
+    # starts and imports the archive. This avoids peering/IBD from node 1 (which
+    # hits L1 pruning-point/multiset edge cases with the aggressive devnet
+    # pruning_depth). Host port differs from node 1's 16610 to avoid a clash.
+    ports:
+      - "${IMPORT_GRPC_HOST_PORT:-16620}:${KASPAD_GRPC_PORT:-16610}"
+    environment:
+      - NETWORK=${NETWORK:-devnet}
+      - TX_ID_PREFIX=${TX_ID_PREFIX:-97b1}
+      - IGRA_LANE_ID=${IGRA_LANE_ID:-97b10000}
+      - KASPAD_GRPC_PORT=${KASPAD_GRPC_PORT:-16610}
+      # Empty by default: node 2 self-mines to reach is_nearly_synced instead of
+      # peering to node 1 (peering + aggressive devnet pruning hit L1 IBD edge
+      # cases). Set NODE1_PEER=<host[:port]> explicitly to opt back into peering.
+      - NODE1_PEER=${NODE1_PEER:-}
+      - ATAN_IMPORT_DIR=${ATAN_IMPORT_DIR:-/import-src/kaspa-devnet/datadir/atan/${TX_ID_PREFIX:-97b1}/chain_block_lists}
+      - RUST_LOG=${RUST_LOG:-info,kaspa_atan_core=info,kaspa_atan_server=info,kaspa_atan_storage=info,kaspa_atan_validation=info,kaspa_atan_import_core=info}
+    entrypoint:
+      - sh
+      - -ec
+      - |
+        ARGS="--disable-upnp \
+          --rpclisten-borsh=0.0.0.0 \
+          --rpclisten=0.0.0.0 \
+          --rpclisten-json=0.0.0.0 \
+          --listen=0.0.0.0 \
+          --utxoindex \
+          --enable-unsynced-mining \
+          --logdir=/app/logs \
+          --appdir=/app/data"
+
+        if [ "$$NETWORK" != "mainnet" ]; then
+          ARGS="--$$NETWORK --nodnsseed $$ARGS"
+        fi
+
+        # Peer with node 1 for L1 IBD so consensus reaches "nearly synced" and ATAN
+        # proceeds to import. No mining here (no miner attached); the peer just
+        # supplies the chain up to node 1's (pruned) tip.
+        #
+        # kaspad --addpeer requires an IP (it rejects a hostname with "invalid IP
+        # address syntax"), but on a user-defined docker network peers are reached
+        # by service name via the embedded DNS at 127.0.0.11. So resolve the host
+        # to an IP first (getent/nslookup both consult that DNS). A bare IPv4 is
+        # passed through unchanged.
+        if [ -n "$$NODE1_PEER" ]; then
+          peer_host="$${NODE1_PEER%%:*}"
+          peer_port="$${NODE1_PEER##*:}"
+          [ "$$peer_port" = "$$peer_host" ] && peer_port=16611
+          case "$$peer_host" in
+            *[!0-9.]*)  # contains a non-IPv4 char => a hostname; resolve it.
+              peer_ip=""
+              if command -v getent >/dev/null 2>&1; then
+                peer_ip="$$(getent hosts "$$peer_host" | awk '{print $$1}' | head -1)"
+              fi
+              if [ -z "$$peer_ip" ] && command -v nslookup >/dev/null 2>&1; then
+                peer_ip="$$(nslookup "$$peer_host" 2>/dev/null | awk '/^Address:/{print $$NF}' | grep -E '^[0-9.]+$$' | head -1)"
+              fi
+              ;;
+            *)          # already a bare IPv4.
+              peer_ip="$$peer_host"
+              ;;
+          esac
+          if [ -n "$$peer_ip" ]; then
+            echo "[import] peering to node 1 at $$peer_ip:$$peer_port (from $$NODE1_PEER)" >&2
+            ARGS="$$ARGS --addpeer=$$peer_ip:$$peer_port"
+          else
+            echo "Warning: could not resolve NODE1_PEER host '$$peer_host' to an IP (no getent/nslookup or DNS miss); starting WITHOUT a peer. ATAN may never reach 'synced' and the import will not run." >&2
+          fi
+        fi
+
+        # ATAN-only, importing from a local directory. No IGRA / viaduct / EL.
+        ARGS="$$ARGS \
+          --atan-listen \
+          --atan-transaction-id-prefix=$$TX_ID_PREFIX \
+          --igra-lane-id=$$IGRA_LANE_ID \
+          --atan-import-dir=$$ATAN_IMPORT_DIR"
+
+        # Same consensus params as node 1 (genesis/finality/toccata must match so
+        # the imported periods connect to this node's anchor).
+        if [ -f /app/overrides/devnet.json ]; then
+          ARGS="$$ARGS --override-params-file=/app/overrides/devnet.json"
+        else
+          echo "ERROR: /app/overrides/devnet.json missing; node 2 must use the same overrides as node 1." >&2
+          exit 1
+        fi
+
+        exec /app/kaspad $$ARGS
+    networks:
+      - node1_net
+    volumes:
+      - kaspad_import_data:/app/data/
+      - node1_archive:/import-src:ro
+      - ./overrides:/app/overrides:ro
+      - ./logs/kaspad-import/:/app/logs/
+    healthcheck:
+      interval: 10s
+      timeout: 2s
+      retries: 3
+      start_period: 5s
+      test: ["CMD-SHELL", "bash -lc ': > /dev/tcp/127.0.0.1/${KASPAD_GRPC_PORT:-16610}'"]

--- a/docker-compose.devnet-atan-import.yml
+++ b/docker-compose.devnet-atan-import.yml
@@ -18,17 +18,22 @@ volumes:
     name: igra-devnet_kaspad_data
 
 networks:
-  # Join node 1's compose network so node 2 can peer with it for L1 IBD.
-  # ATAN only starts (and imports) once consensus reports "nearly synced", which
-  # for an isolated node requires peering to a node with a fresh tip (node 1,
-  # which keeps mining during validation).
+  # Join node 1's compose network so node 2 CAN peer with it for L1 IBD when
+  # NODE1_PEER is set. ATAN only starts (and imports) once consensus reports
+  # "nearly synced". The default path reaches that by self-mining from a host
+  # cpuminer against node 2's published gRPC (peering is an opt-in that hits L1
+  # pruning-point/multiset edge cases). In the e2e flow node 1's miner is stopped
+  # before node 2 IBDs, so no post-IBD block is relayed into node 2.
   node1_net:
     external: true
     name: igra-devnet_default
 
 services:
   kaspad-import:
-    image: igranetwork/kaspad:${KASPAD_VERSION}
+    # Default the tag so `docker compose` on a clone that never ran
+    # setup-devnet.sh (which merges KASPAD_VERSION from versions.devnet.env into
+    # .env) does not interpolate to the invalid ref "igranetwork/kaspad:".
+    image: igranetwork/kaspad:${KASPAD_VERSION:-devnet}
     container_name: kaspad-import-devnet
     restart: "no"
     logging: *default-logging
@@ -38,7 +43,10 @@ services:
     # hits L1 pruning-point/multiset edge cases with the aggressive devnet
     # pruning_depth). Host port differs from node 1's 16610 to avoid a clash.
     ports:
-      - "${IMPORT_GRPC_HOST_PORT:-16620}:${KASPAD_GRPC_PORT:-16610}"
+      # Loopback-only, like every published port in docker-compose.devnet.yml:
+      # devnet runs kaspad gRPC without TLS/auth, and Docker-published ports
+      # bypass host firewall rules. Only a host cpuminer on loopback dials this.
+      - "127.0.0.1:${IMPORT_GRPC_HOST_PORT:-16620}:${KASPAD_GRPC_PORT:-16610}"
     environment:
       - NETWORK=${NETWORK:-devnet}
       - TX_ID_PREFIX=${TX_ID_PREFIX:-97b1}

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -61,6 +61,8 @@ services:
       - TX_ID_PREFIX
       - IGRA_LANE_ID
       - IGRA_ENABLE
+      - ATAN_ENABLE
+      - ATAN_IMPORT_DIR
       - POST_FORK_LOCK_SCRIPT_PUBKEY
       - LOCK_SCRIPT_FORK_DAA_SCORE
       # Passed as runtime env (referenced as $$VAR below) rather than spliced
@@ -83,6 +85,7 @@ services:
           --rpclisten-json=0.0.0.0 \
           --listen=0.0.0.0 \
           --utxoindex \
+          --enable-unsynced-mining \
           --logdir=/app/logs \
           --appdir=/app/data"
 
@@ -97,11 +100,13 @@ services:
         fi
 
         IGRA_ENABLED="$${IGRA_ENABLE:-true}"
+        # ATAN defaults to IGRA's setting so existing deployments are unchanged,
+        # but can be enabled independently (L2 off, ATAN on).
+        ATAN_ENABLED="$${ATAN_ENABLE:-$$IGRA_ENABLED}"
+
         if [ "$$IGRA_ENABLED" = "true" ]; then
           ARGS="$$ARGS \
             --igra-enable \
-            --atan-listen \
-            --atan-transaction-id-prefix=$$TX_ID_PREFIX \
             --viaduct-start-daa-score=$$IGRA_LAUNCH_DAA_SCORE \
             --igra-l1-reference-timestamp=$$L1_REFERENCE_TIMESTAMP \
             --igra-l1-reference-daa-score=$$L1_REFERENCE_DAA_SCORE \
@@ -124,6 +129,11 @@ services:
           fi
           [ -n "$$POST_FORK_LOCK_SCRIPT_PUBKEY" ] && ARGS="$$ARGS --igra-post-fork-lock-script-pubkey=$$POST_FORK_LOCK_SCRIPT_PUBKEY"
           [ -n "$$LOCK_SCRIPT_FORK_DAA_SCORE" ] && ARGS="$$ARGS --igra-lock-script-fork-daa-score=$$LOCK_SCRIPT_FORK_DAA_SCORE"
+        fi
+
+        if [ "$$ATAN_ENABLED" = "true" ]; then
+          ARGS="$$ARGS --atan-listen --atan-transaction-id-prefix=$$TX_ID_PREFIX"
+
           # Toccata/KIP-21 lane: required whenever Toccata is scheduled (the override
           # file carries toccata_activation). Fail early on a misconfig reached via a
           # direct `docker compose up` that bypassed setup-devnet.sh's validation.
@@ -141,13 +151,17 @@ services:
             ARGS="$$ARGS --igra-lane-id=$$IGRA_LANE_ID"
           fi
 
-          # Devnet has no ATAN data source: missing config is a warning, not fatal.
-          if [ -n "$$ATAN_IMPORT_URL" ]; then
+          # ATAN import source (mutually exclusive; kaspad panics if both are set).
+          # --atan-import-dir imports from a local directory (used by the second,
+          # import-validation node). --atan-import-url imports from an HTTPS index.
+          if [ -n "$$ATAN_IMPORT_DIR" ]; then
+            ARGS="$$ARGS --atan-import-dir=$$ATAN_IMPORT_DIR"
+          elif [ -n "$$ATAN_IMPORT_URL" ]; then
             ARGS="$$ARGS --atan-import-url=$$ATAN_IMPORT_URL"
           elif [ -n "$$CDN_BASE_URL" ] && [ -n "$$NETWORK" ] && [ -n "$$TX_ID_PREFIX" ]; then
             ARGS="$$ARGS --atan-import-url=$$CDN_BASE_URL/$$NETWORK/$$TX_ID_PREFIX/index.pb"
           else
-            echo "Warning: No ATAN import URL configured (devnet has no ATAN data source). Continuing without import." >&2
+            echo "Warning: No ATAN import source configured (devnet mining node has none). Continuing without import." >&2
           fi
         fi
 
@@ -164,9 +178,14 @@ services:
           echo "WARN: /app/overrides/devnet.json not found; using kaspad devnet defaults (finality = 12h). Re-run scripts/setup-devnet.sh to regenerate." >&2
         fi
 
-        exec sh /app/watch-dependencies.sh \
-          --tcp execution-layer execution-layer 8545 \
-          -- /app/kaspad $$ARGS
+        if [ "$$IGRA_ENABLED" = "true" ]; then
+          exec sh /app/watch-dependencies.sh \
+            --tcp execution-layer execution-layer 8545 \
+            -- /app/kaspad $$ARGS
+        else
+          # ATAN-only / L2-off: no execution layer to wait for.
+          exec /app/kaspad $$ARGS
+        fi
     volumes:
       - kaspad_data:/app/data/
       - ./logs/kaspad/:/app/logs/  # Event logs when ENABLE_EVENT_LOGGING=true
@@ -181,7 +200,8 @@ services:
         - CMD-SHELL
         - >
           bash -lc ': > /dev/tcp/127.0.0.1/${KASPAD_GRPC_PORT}' &&
-          bash -lc ': > /dev/tcp/execution-layer/8545'
+          { [ "$${IGRA_ENABLE:-true}" != "true" ] ||
+            bash -lc ': > /dev/tcp/execution-layer/8545'; }
 
   execution-layer:
     build:

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -79,6 +79,11 @@ services:
       - sh
       - -ec
       - |
+        # --enable-unsynced-mining is always on: this cold-start, single-node
+        # (--nodnsseed, typically no --addpeer) devnet never reaches "synced" on
+        # its own, so without it kaspad refuses to serve block templates and the
+        # chain can never start. On a peered setup (KASPAD_ADD_PEER) it also lets
+        # a restarting node serve templates mid-IBD; that is acceptable on devnet.
         ARGS="--disable-upnp \
           --rpclisten-borsh=0.0.0.0 \
           --rpclisten=0.0.0.0 \
@@ -133,10 +138,18 @@ services:
 
         if [ "$$ATAN_ENABLED" = "true" ]; then
           ARGS="$$ARGS --atan-listen --atan-transaction-id-prefix=$$TX_ID_PREFIX"
+        fi
 
-          # Toccata/KIP-21 lane: required whenever Toccata is scheduled (the override
-          # file carries toccata_activation). Fail early on a misconfig reached via a
-          # direct `docker compose up` that bypassed setup-devnet.sh's validation.
+        # Toccata/KIP-21 lane selection is NOT ATAN-specific: post-Toccata,
+        # kaswallet tags transactions with the lane and consensus selects lane-v1
+        # transactions regardless of ATAN. So emit --igra-lane-id and enforce the
+        # "lane required when Toccata is scheduled" guard whenever IGRA or ATAN is
+        # on. Keeping this outside the ATAN block covers the IGRA-on/ATAN-off
+        # combination, which would otherwise silently drop the lane id and skip
+        # the guard, surfacing the misconfig only deep in kaspad at runtime.
+        # Fail early here on a misconfig reached via a direct `docker compose up`
+        # that bypassed setup-devnet.sh's validation.
+        if [ "$$IGRA_ENABLED" = "true" ] || [ "$$ATAN_ENABLED" = "true" ]; then
           if [ -f /app/overrides/devnet.json ] && grep -q '"toccata_activation"' /app/overrides/devnet.json && [ -z "$$IGRA_LANE_ID" ]; then
             echo "Error: IGRA_LANE_ID must be set when toccata_activation is scheduled in overrides/devnet.json" >&2; exit 1
           fi
@@ -150,10 +163,15 @@ services:
             esac
             ARGS="$$ARGS --igra-lane-id=$$IGRA_LANE_ID"
           fi
+        fi
 
+        if [ "$$ATAN_ENABLED" = "true" ]; then
           # ATAN import source (mutually exclusive; kaspad panics if both are set).
           # --atan-import-dir imports from a local directory (used by the second,
           # import-validation node). --atan-import-url imports from an HTTPS index.
+          if [ -n "$$ATAN_IMPORT_DIR" ] && [ -n "$$ATAN_IMPORT_URL" ]; then
+            echo "Error: ATAN_IMPORT_DIR and ATAN_IMPORT_URL are mutually exclusive (kaspad panics if both are passed); set only one." >&2; exit 1
+          fi
           if [ -n "$$ATAN_IMPORT_DIR" ]; then
             ARGS="$$ARGS --atan-import-dir=$$ATAN_IMPORT_DIR"
           elif [ -n "$$ATAN_IMPORT_URL" ]; then

--- a/scripts/dev/run-devnet-atan-import-e2e.sh
+++ b/scripts/dev/run-devnet-atan-import-e2e.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# run-devnet-atan-import-e2e.sh - one-shot CLEAN end-to-end for the ATAN
+# import-validation path (node 1 archives -> node 2 imports + four-group-validates
+# across the Toccata boundary), driven entirely in one process so the tight
+# consensus-sync window is hit reliably.
+#
+# Why the choreography:
+#   * On this fast-pruning devnet (pruning_depth=3000) node 2 must sync via
+#     headers-proof IBD, and ATAN only starts once consensus is is_nearly_synced
+#     (sink block timestamp younger than ~33s for these params).
+#   * To be nearly-synced, node 2's sink (== node 1's tip after IBD) must be
+#     < ~33s old -> node 1 must have a FRESH tip.
+#   * But node 1 mining is incompatible with node 2's IBD:
+#       - mining DURING node 2 IBD  -> "got unexpected pruning point"
+#       - mining AFTER  node 2 IBD  -> GhostdagCompact panic on block relay
+#       - bursty stop/restart mining-> node 1 UTXO-commitment corruption
+#                                       -> node 2 "multiset hash mismatch"
+#   So: node 1 is mined in ONE clean continuous session, then STOPPED, and node 2
+#   must finish IBD within ~33s of node 1's last block, with NO node-1 mining
+#   after. Steps 4-5 below therefore run kill-miner then up-node2 back-to-back in
+#   this single process (zero inter-step latency) to fit inside the window.
+#
+# Leaves both nodes up on PASS for inspection; prints PASS/FAIL.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_NODE1="$PROJECT_DIR/docker-compose.devnet.yml"
+COMPOSE_NODE2="$PROJECT_DIR/docker-compose.devnet-atan-import.yml"
+
+TX_ID_PREFIX="${TX_ID_PREFIX:-97b1}"
+FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-60}"
+TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-3300}"
+MINING_THREADS="${MINING_THREADS:-2}"          # 4 threads caused gRPC broken-pipe deaths
+TARGET_PERIOD="${TARGET_PERIOD:-7}"            # archive at least this many periods (past boundary 5)
+MINE_TIMEOUT_SECS="${MINE_TIMEOUT_SECS:-1500}" # ~25 min cap for the mining phase
+ARCHIVE_DIR="/app/data/kaspa-devnet/datadir/atan/${TX_ID_PREFIX}/chain_block_lists"
+BOUNDARY_PERIOD=$(( TOCCATA_ACTIVATION_DAA_SCORE / (FINALITY_PERIOD_SECONDS * 10) ))
+NODE1_PEER_ADDR="${NODE1_PEER_ADDR:-kaspad-devnet:16611}"
+
+log()  { echo "[e2e] $(date +%T) $*"; }
+fail() { echo "[e2e] VALIDATION FAILED: $*" >&2; exit 1; }
+
+# pgrep pattern for the miner binary. Safe from self-match: this script's own
+# process cmdline is the script PATH, which does not contain "kaspa-miner".
+MINER_PAT='kaspa-miner'
+miner_alive() { pgrep -f "$MINER_PAT" >/dev/null 2>&1; }
+stop_miner()  { pkill -9 -f "$MINER_PAT" >/dev/null 2>&1 || true; }
+
+node1_last_period() {
+    docker exec kaspad-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n | tail -1"
+}
+
+# ---------------------------------------------------------------------------
+log "STEP 1: clean slate (destroys any local devnet chain + archives)"
+docker compose -f "$COMPOSE_NODE2" down -v >/dev/null 2>&1 || true
+docker compose -f "$COMPOSE_NODE1" down -v >/dev/null 2>&1 || true
+docker rm -f kaspad-devnet >/dev/null 2>&1 || true
+docker volume rm igra-devnet_kaspad_data >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+log "STEP 2: bring up a fresh ATAN-only node 1 (L2 off)"
+"$SCRIPT_DIR/run-devnet-atan-no-l2.sh" >/tmp/e2e-node1-up.log 2>&1 \
+    || { tail -20 /tmp/e2e-node1-up.log; fail "node 1 failed to come up"; }
+docker ps --format '{{.Names}}' | grep -qx kaspad-devnet || fail "kaspad-devnet not running after startup"
+log "node 1 up; boundary period = $BOUNDARY_PERIOD (Toccata DAA $TOCCATA_ACTIVATION_DAA_SCORE)"
+
+# ---------------------------------------------------------------------------
+log "STEP 3: mine ONE clean continuous session until archived period >= $TARGET_PERIOD"
+SKIP_BUILD=1 MINING_THREADS="$MINING_THREADS" "$SCRIPT_DIR/run-devnet-cpuminer.sh" >/tmp/e2e-miner.log 2>&1 &
+sleep 6
+miner_alive || { tail -8 /tmp/e2e-miner.log; fail "miner did not start"; }
+
+deadline=$(( SECONDS + MINE_TIMEOUT_SECS ))
+last=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+    if ! miner_alive; then
+        log "miner died mid-session (gRPC?); restarting once (clean-continuous best-effort)"
+        tail -3 /tmp/e2e-miner.log
+        SKIP_BUILD=1 MINING_THREADS="$MINING_THREADS" "$SCRIPT_DIR/run-devnet-cpuminer.sh" >>/tmp/e2e-miner.log 2>&1 &
+        sleep 6
+        miner_alive || fail "miner will not stay alive; check node 1 health / .env MINING_ADDRESS"
+    fi
+    last="$(node1_last_period)"
+    log "  archived last period = ${last:-none}"
+    if [ -n "$last" ] && [ "$last" -ge "$TARGET_PERIOD" ] 2>/dev/null; then break; fi
+    sleep 20
+done
+[ -n "$last" ] && [ "$last" -ge "$TARGET_PERIOD" ] 2>/dev/null \
+    || fail "did not reach period $TARGET_PERIOD within ${MINE_TIMEOUT_SECS}s (got '${last:-none}')"
+log "node 1 archived through period $last (single clean session)"
+
+# ---------------------------------------------------------------------------
+# STEP 4+5 RUN BACK-TO-BACK: stop mining then immediately peer node 2, so node
+# 2's IBD completes inside the ~33s is_nearly_synced window and NO node-1 block
+# is relayed to the headers-proof-synced node 2 afterwards.
+log "STEP 4: stop node 1 mining (freeze pruning point; tip now maximally fresh)"
+stop_miner
+
+log "STEP 5: immediately peer a fresh node 2 (headers-proof IBD -> ATAN import)"
+NODE1_PEER="$NODE1_PEER_ADDR" docker compose -f "$COMPOSE_NODE2" up -d >/dev/null 2>&1 \
+    || fail "could not start kaspad-import (node 2)"
+kill_ts=$SECONDS
+docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet || fail "node 2 did not start"
+
+# ---------------------------------------------------------------------------
+log "STEP 6: watch node 2 for sync -> import -> four-group validation"
+synced=""; imported=""; outcome=""
+for _ in $(seq 1 60); do
+    if ! docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet; then
+        echo "---- node 2 last logs ----"; docker logs --tail 30 kaspad-import-devnet 2>&1 || true
+        fail "node 2 EXITED during sync/import (fail-closed validation panic OR L1 IBD error)."
+    fi
+    logs="$(docker logs kaspad-import-devnet 2>&1)"
+
+    # Hard failures (L1 IBD or ATAN validation)
+    if echo "$logs" | grep -Eiq 'multiset hash|got unexpected pruning point|panic|AtanError|Validation\('; then
+        echo "---- node 2 error context ----"
+        echo "$logs" | grep -Ei 'multiset hash|unexpected pruning|panic|AtanError|Validation\(' | tail -6
+        fail "node 2 hit an L1/validation error during import."
+    fi
+
+    [ -z "$synced" ] && echo "$logs" | grep -q 'Consensus is synced, starting ATAN' && {
+        synced=1; log "  node 2: consensus synced, ATAN starting (window hit: ~$((SECONDS-kill_ts))s after mining stop)"
+    }
+    # Peered node 2 anchors at node 1's (advanced) pruning point, so node 1's
+    # archived periods are HISTORICAL for it (imported + four-group validated,
+    # not skipped as "recent/redundant"). Accept either completion line.
+    echo "$logs" | grep -qE 'Import of (recent|historical) finality period chain block lists complete' && {
+        imported=1; log "  node 2: import phase complete (four-group validation ran fail-closed)"; break
+    }
+    sleep 2
+done
+
+[ -n "$synced" ] || {
+    echo "---- node 2 tail ----"; docker logs --tail 15 kaspad-import-devnet 2>&1 | grep -Ei 'waiting|synced|IBD' || true
+    fail "node 2 never reached is_nearly_synced within the window (node 1 tip aged past ~33s before IBD finished). Re-run: this is the timing window, not an ATAN error."
+}
+[ -n "$imported" ] || fail "node 2 synced but did not report import completion within timeout."
+
+# ---------------------------------------------------------------------------
+log "STEP 7: assert node 2 stored validated periods across the Toccata boundary"
+sleep 8
+docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet \
+    || fail "node 2 exited shortly after import (late validation failure)."
+n2="$(docker exec kaspad-import-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n")"
+n2_first="$(echo "$n2" | head -1)"; n2_last="$(echo "$n2" | tail -1)"
+log "node 2 stored periods: first=${n2_first:-none} last=${n2_last:-none}"
+[ -n "$n2_last" ] || fail "node 2 stored no periods after import."
+[ "$n2_last" -gt "$BOUNDARY_PERIOD" ] 2>/dev/null \
+    || fail "node 2 top period ($n2_last) not past the Toccata boundary ($BOUNDARY_PERIOD)."
+
+# Check the importing node's log for the four-group / historical import evidence.
+hist="$(docker logs kaspad-import-devnet 2>&1 | grep -Ei 'historical finality period|Import ranges' | tail -2)"
+echo "$hist" | sed 's/^/[e2e]   /'
+
+echo
+echo "[e2e] VALIDATION PASSED: node 2 imported finality periods ${n2_first}..${n2_last} across the Toccata boundary ${BOUNDARY_PERIOD} with no L1/validation error (four-group validator ran fail-closed on import)."

--- a/scripts/dev/run-devnet-atan-import-e2e.sh
+++ b/scripts/dev/run-devnet-atan-import-e2e.sh
@@ -32,24 +32,84 @@ TX_ID_PREFIX="${TX_ID_PREFIX:-97b1}"
 FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-60}"
 TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-3300}"
 MINING_THREADS="${MINING_THREADS:-2}"          # 4 threads caused gRPC broken-pipe deaths
-TARGET_PERIOD="${TARGET_PERIOD:-7}"            # archive at least this many periods (past boundary 5)
 MINE_TIMEOUT_SECS="${MINE_TIMEOUT_SECS:-1500}" # ~25 min cap for the mining phase
+MAX_MINER_RESTARTS="${MAX_MINER_RESTARTS:-1}"  # bound restart cycles (bursty restarts corrupt node 1)
 ARCHIVE_DIR="/app/data/kaspa-devnet/datadir/atan/${TX_ID_PREFIX}/chain_block_lists"
 BOUNDARY_PERIOD=$(( TOCCATA_ACTIVATION_DAA_SCORE / (FINALITY_PERIOD_SECONDS * 10) ))
 NODE1_PEER_ADDR="${NODE1_PEER_ADDR:-kaspad-devnet:16611}"
+CPUMINER_BIN="$PROJECT_DIR/build/repos/kaspanet-cpuminer/target/release/kaspa-miner"
+
+# Per-run log dir via mktemp -d (not fixed /tmp paths that concurrent runs would
+# clobber and pre-existing symlinks could hijack). Printed on failure.
+RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/e2e-atan-import.XXXXXX")"
+NODE1_UP_LOG="$RUN_DIR/node1-up.log"
+MINER_LOG="$RUN_DIR/miner.log"
+NODE2_COMPOSE_LOG="$RUN_DIR/node2-compose.log"
 
 log()  { echo "[e2e] $(date +%T) $*"; }
 fail() { echo "[e2e] VALIDATION FAILED: $*" >&2; exit 1; }
 
-# pgrep pattern for the miner binary. Safe from self-match: this script's own
-# process cmdline is the script PATH, which does not contain "kaspa-miner".
-MINER_PAT='kaspa-miner'
-miner_alive() { pgrep -f "$MINER_PAT" >/dev/null 2>&1; }
-stop_miner()  { pkill -9 -f "$MINER_PAT" >/dev/null 2>&1 || true; }
+# Default the mining target to 2 periods past the boundary so the run always
+# crosses Toccata even when the boundary is moved via TOCCATA/FINALITY overrides;
+# reject an explicit target that would stop mining before the boundary.
+TARGET_PERIOD="${TARGET_PERIOD:-$((BOUNDARY_PERIOD + 2))}"
+[ "$TARGET_PERIOD" -gt "$BOUNDARY_PERIOD" ] 2>/dev/null \
+    || fail "TARGET_PERIOD ($TARGET_PERIOD) must be > the Toccata boundary period ($BOUNDARY_PERIOD); mining would stop before crossing Toccata."
+
+# Preflight helpers: is_valid_mining_address + .env resolution, so the destructive
+# STEP 1 wipe is gated on a runnable configuration (STEP 3 mines with SKIP_BUILD=1).
+# shellcheck source=scripts/lib/devnet-preflight.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-preflight.sh"
+ENV_FILE="$PROJECT_DIR/.env"; [ -f "$ENV_FILE" ] || ENV_FILE="$PROJECT_DIR/.env.devnet.example"
+# shellcheck source=scripts/lib/devnet-env.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-env.sh"
+resolve MINING_ADDRESS ""
+
+# Miner lifecycle: track the concrete PID (run-devnet-cpuminer.sh ends in `exec`,
+# so $! is the miner's stable PID) instead of a pkill -f pattern that could kill
+# an unrelated kaspa-miner (e.g. run-devnet-miner.sh) or mis-report liveness.
+MINER_PID=""
+start_miner() {
+    SKIP_BUILD=1 MINING_THREADS="$MINING_THREADS" \
+        "$SCRIPT_DIR/run-devnet-cpuminer.sh" >>"$MINER_LOG" 2>&1 &
+    MINER_PID=$!
+}
+miner_alive() { [ -n "$MINER_PID" ] && kill -0 "$MINER_PID" 2>/dev/null; }
+stop_miner()  { [ -n "$MINER_PID" ] && kill "$MINER_PID" 2>/dev/null; MINER_PID=""; }
+# A leaked background miner otherwise survives any failure path / Ctrl+C and keeps
+# mining node 1, dirtying the clean baseline for the next run. No-op on the PASS
+# path, where mining is already stopped in STEP 4.
+trap stop_miner EXIT
 
 node1_last_period() {
     docker exec kaspad-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n | tail -1"
 }
+node1_all_periods() {
+    docker exec kaspad-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n"
+}
+
+# ---------------------------------------------------------------------------
+# STEP 0: preflight BEFORE the destructive wipe. STEP 3 mines with SKIP_BUILD=1
+# (no build), so a missing binary or invalid MINING_ADDRESS must be caught here,
+# not after the local chain is already gone; and the wipe itself is gated.
+log "STEP 0: preflight (before destructive wipe)"
+[ -x "$CPUMINER_BIN" ] || \
+    fail "cpuminer binary not found at $CPUMINER_BIN. Build it once first (clones + builds): ./scripts/dev/run-devnet-cpuminer.sh"
+is_valid_mining_address "$MINING_ADDRESS" || \
+    fail "MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}'); set it in .env."
+if docker volume inspect igra-devnet_kaspad_data >/dev/null 2>&1; then
+    if [ "${E2E_FORCE:-}" = "1" ]; then
+        log "E2E_FORCE=1; destroying existing igra-devnet_kaspad_data volume."
+    elif [ -t 0 ]; then
+        printf '[e2e] Existing devnet volume igra-devnet_kaspad_data will be DESTROYED. Continue? [y/N] ' >&2
+        read -r reply
+        case "$reply" in [yY]|[yY][eE][sS]) ;; *) fail "aborted (existing volume left intact)." ;; esac
+    else
+        fail "existing igra-devnet_kaspad_data volume would be destroyed; re-run with E2E_FORCE=1 to confirm (non-interactive)."
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 log "STEP 1: clean slate (destroys any local devnet chain + archives)"
@@ -60,26 +120,35 @@ docker volume rm igra-devnet_kaspad_data >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 log "STEP 2: bring up a fresh ATAN-only node 1 (L2 off)"
-"$SCRIPT_DIR/run-devnet-atan-no-l2.sh" >/tmp/e2e-node1-up.log 2>&1 \
-    || { tail -20 /tmp/e2e-node1-up.log; fail "node 1 failed to come up"; }
+"$SCRIPT_DIR/run-devnet-atan-no-l2.sh" >"$NODE1_UP_LOG" 2>&1 \
+    || { tail -20 "$NODE1_UP_LOG"; fail "node 1 failed to come up; see $NODE1_UP_LOG"; }
 docker ps --format '{{.Names}}' | grep -qx kaspad-devnet || fail "kaspad-devnet not running after startup"
-log "node 1 up; boundary period = $BOUNDARY_PERIOD (Toccata DAA $TOCCATA_ACTIVATION_DAA_SCORE)"
+log "node 1 up; boundary period = $BOUNDARY_PERIOD (Toccata DAA $TOCCATA_ACTIVATION_DAA_SCORE); logs in $RUN_DIR"
 
 # ---------------------------------------------------------------------------
 log "STEP 3: mine ONE clean continuous session until archived period >= $TARGET_PERIOD"
-SKIP_BUILD=1 MINING_THREADS="$MINING_THREADS" "$SCRIPT_DIR/run-devnet-cpuminer.sh" >/tmp/e2e-miner.log 2>&1 &
+start_miner
 sleep 6
-miner_alive || { tail -8 /tmp/e2e-miner.log; fail "miner did not start"; }
+miner_alive || { tail -8 "$MINER_LOG"; fail "miner did not start"; }
 
 deadline=$(( SECONDS + MINE_TIMEOUT_SECS ))
 last=""
+restarts=0
 while [ "$SECONDS" -lt "$deadline" ]; do
     if ! miner_alive; then
-        log "miner died mid-session (gRPC?); restarting once (clean-continuous best-effort)"
-        tail -3 /tmp/e2e-miner.log
-        SKIP_BUILD=1 MINING_THREADS="$MINING_THREADS" "$SCRIPT_DIR/run-devnet-cpuminer.sh" >>/tmp/e2e-miner.log 2>&1 &
+        # Enforce the restart bound: unlimited stop/restart cycles can recreate the
+        # node-1 UTXO-commitment corruption -> node-2 multiset mismatch this
+        # choreography exists to avoid (see header). Fail once the budget is spent.
+        if [ "$restarts" -ge "$MAX_MINER_RESTARTS" ]; then
+            tail -3 "$MINER_LOG"
+            fail "miner died again after $restarts restart(s) (limit $MAX_MINER_RESTARTS); aborting to avoid bursty stop/restart mining. Check node 1 health / .env MINING_ADDRESS."
+        fi
+        restarts=$(( restarts + 1 ))
+        log "miner died mid-session (gRPC?); restart #$restarts of $MAX_MINER_RESTARTS (clean-continuous best-effort)"
+        tail -3 "$MINER_LOG"
+        start_miner
         sleep 6
-        miner_alive || fail "miner will not stay alive; check node 1 health / .env MINING_ADDRESS"
+        miner_alive || fail "miner will not stay alive after restart #$restarts; check node 1 health / .env MINING_ADDRESS"
     fi
     last="$(node1_last_period)"
     log "  archived last period = ${last:-none}"
@@ -88,7 +157,7 @@ while [ "$SECONDS" -lt "$deadline" ]; do
 done
 [ -n "$last" ] && [ "$last" -ge "$TARGET_PERIOD" ] 2>/dev/null \
     || fail "did not reach period $TARGET_PERIOD within ${MINE_TIMEOUT_SECS}s (got '${last:-none}')"
-log "node 1 archived through period $last (single clean session)"
+log "node 1 archived through period $last (single clean session, $restarts miner restart(s))"
 
 # ---------------------------------------------------------------------------
 # STEP 4+5 RUN BACK-TO-BACK: stop mining then immediately peer node 2, so node
@@ -98,8 +167,8 @@ log "STEP 4: stop node 1 mining (freeze pruning point; tip now maximally fresh)"
 stop_miner
 
 log "STEP 5: immediately peer a fresh node 2 (headers-proof IBD -> ATAN import)"
-NODE1_PEER="$NODE1_PEER_ADDR" docker compose -f "$COMPOSE_NODE2" up -d >/dev/null 2>&1 \
-    || fail "could not start kaspad-import (node 2)"
+NODE1_PEER="$NODE1_PEER_ADDR" docker compose -f "$COMPOSE_NODE2" up -d >"$NODE2_COMPOSE_LOG" 2>&1 \
+    || { tail -20 "$NODE2_COMPOSE_LOG"; fail "could not start kaspad-import (node 2); see $NODE2_COMPOSE_LOG"; }
 kill_ts=$SECONDS
 docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet || fail "node 2 did not start"
 
@@ -113,22 +182,25 @@ for _ in $(seq 1 60); do
     fi
     logs="$(docker logs kaspad-import-devnet 2>&1)"
 
-    # Hard failures (L1 IBD or ATAN validation)
-    if echo "$logs" | grep -Eiq 'multiset hash|got unexpected pruning point|panic|AtanError|Validation\('; then
+    # Hard failures (L1 IBD or ATAN validation). Herestrings, not pipes: under
+    # pipefail `echo "$logs" | grep -q` can return 141 (grep exits early -> echo
+    # gets SIGPIPE) on a large log even when the pattern matches, which would skip
+    # this fail-closed branch and let a completed-but-invalid run read as PASS.
+    if grep -Eiq 'multiset hash|got unexpected pruning point|panic|AtanError|Validation\(' <<<"$logs"; then
         echo "---- node 2 error context ----"
-        echo "$logs" | grep -Ei 'multiset hash|unexpected pruning|panic|AtanError|Validation\(' | tail -6
-        fail "node 2 hit an L1/validation error during import."
+        grep -Ei 'multiset hash|unexpected pruning|panic|AtanError|Validation\(' <<<"$logs" | tail -6
+        fail "node 2 hit an L1/validation error during import (after $restarts miner restart(s))."
     fi
 
-    [ -z "$synced" ] && echo "$logs" | grep -q 'Consensus is synced, starting ATAN' && {
+    if [ -z "$synced" ] && grep -q 'Consensus is synced, starting ATAN' <<<"$logs"; then
         synced=1; log "  node 2: consensus synced, ATAN starting (window hit: ~$((SECONDS-kill_ts))s after mining stop)"
-    }
+    fi
     # Peered node 2 anchors at node 1's (advanced) pruning point, so node 1's
     # archived periods are HISTORICAL for it (imported + four-group validated,
     # not skipped as "recent/redundant"). Accept either completion line.
-    echo "$logs" | grep -qE 'Import of (recent|historical) finality period chain block lists complete' && {
+    if grep -qE 'Import of (recent|historical) finality period chain block lists complete' <<<"$logs"; then
         imported=1; log "  node 2: import phase complete (four-group validation ran fail-closed)"; break
-    }
+    fi
     sleep 2
 done
 
@@ -149,10 +221,20 @@ log "node 2 stored periods: first=${n2_first:-none} last=${n2_last:-none}"
 [ -n "$n2_last" ] || fail "node 2 stored no periods after import."
 [ "$n2_last" -gt "$BOUNDARY_PERIOD" ] 2>/dev/null \
     || fail "node 2 top period ($n2_last) not past the Toccata boundary ($BOUNDARY_PERIOD)."
+# "Across the boundary" requires pre-Toccata coverage too, not only post-boundary
+# periods: node 2 must hold a period at/below the boundary.
+[ "$n2_first" -le "$BOUNDARY_PERIOD" ] 2>/dev/null \
+    || fail "node 2 first period ($n2_first) is past the boundary ($BOUNDARY_PERIOD); pre-Toccata periods were not imported."
+# Full-set check: every period node 1 archived must be present on node 2 (no
+# missing pre/boundary/post period, no mid-range gap). comm needs a consistent
+# sort; use lexical sort on both sides.
+n1_all="$(node1_all_periods)"
+missing="$(comm -23 <(printf '%s\n' "$n1_all" | sort) <(printf '%s\n' "$n2" | sort))"
+[ -z "$missing" ] || fail "node 2 is missing periods that node 1 archived: $(echo "$missing" | tr '\n' ' ')"
 
 # Check the importing node's log for the four-group / historical import evidence.
 hist="$(docker logs kaspad-import-devnet 2>&1 | grep -Ei 'historical finality period|Import ranges' | tail -2)"
 echo "$hist" | sed 's/^/[e2e]   /'
 
 echo
-echo "[e2e] VALIDATION PASSED: node 2 imported finality periods ${n2_first}..${n2_last} across the Toccata boundary ${BOUNDARY_PERIOD} with no L1/validation error (four-group validator ran fail-closed on import)."
+echo "[e2e] VALIDATION PASSED: node 2 imported every finality period node 1 archived (${n2_first}..${n2_last}), covering pre-Toccata, the boundary (${BOUNDARY_PERIOD}), and post-Toccata, with no L1/validation error (four-group validator ran fail-closed on import)."

--- a/scripts/dev/run-devnet-atan-no-l2.sh
+++ b/scripts/dev/run-devnet-atan-no-l2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# run-devnet-atan-no-l2.sh - Bring up a devnet kaspad with ATAN enabled but L2
+# (viaduct / execution layer) DISABLED, with Toccata scheduled early so mining
+# quickly crosses the KIP-21 boundary. Used to produce ATAN finality-period
+# archives before/after Toccata for import-validation (see
+# scripts/dev/validate-devnet-atan.sh).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.devnet.yml"
+
+# shellcheck source=scripts/lib/devnet-overrides.sh
+source "$SCRIPT_DIR/../lib/devnet-overrides.sh"
+
+log() { echo "[run-devnet-atan-no-l2] $*"; }
+
+# Test knobs (override via shell). Defaults give 5 pre + boundary + >=5 post periods.
+export NETWORK="${NETWORK:-devnet}"
+export TX_ID_PREFIX="${TX_ID_PREFIX:-97b1}"
+export IGRA_LANE_ID="${IGRA_LANE_ID:-97b10000}"
+export FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-60}"
+export TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-3300}"
+# Small pruning_depth so the pruning point advances quickly: ATAN only commits a
+# finality period once the pruning point passes it. Effective depth is
+# min(pruning_depth, ~159858), so this must be small to archive periods within a
+# short mining run. Must stay > finality_depth (600). Baked on first run.
+export PRUNING_DEPTH="${PRUNING_DEPTH:-3000}"
+export IGRA_ENABLE=false
+export ATAN_ENABLE=true
+# Mining node has no ATAN data source; leave import unset.
+export ATAN_IMPORT_DIR=""
+export ATAN_IMPORT_URL="${ATAN_IMPORT_URL:-}"
+export CDN_BASE_URL="${CDN_BASE_URL:-}"
+
+# finality_depth + toccata are baked into the consensus DB on first run. A stale
+# volume would silently keep old values, so require a clean slate.
+if docker volume inspect igra-devnet_kaspad_data >/dev/null 2>&1; then
+    log "ERROR: volume igra-devnet_kaspad_data exists; its baked finality/toccata may differ."
+    log "       Wipe it first (destroys the local chain):"
+    log "         docker compose -f $COMPOSE_FILE down -v"
+    exit 1
+fi
+
+log "Generating overrides (finality=${FINALITY_PERIOD_SECONDS}s, toccata=${TOCCATA_ACTIVATION_DAA_SCORE}, pruning_depth=${PRUNING_DEPTH})"
+OVERRIDES_OUT_DIR="$PROJECT_DIR/overrides" generate_devnet_overrides \
+    "$FINALITY_PERIOD_SECONDS" "$TOCCATA_ACTIVATION_DAA_SCORE" "$PRUNING_DEPTH"
+
+mkdir -p "$PROJECT_DIR/logs/kaspad"
+
+log "Starting kaspad ONLY (no execution layer, no L2)..."
+# --no-deps guarantees the execution-layer dependency is not started.
+docker compose -f "$COMPOSE_FILE" --profile backend up -d --build --no-deps kaspad
+
+log "Waiting for kaspad to report healthy..."
+for _ in $(seq 1 30); do
+    status="$(docker inspect -f '{{.State.Health.Status}}' kaspad-devnet 2>/dev/null || echo none)"
+    [ "$status" = "healthy" ] && break
+    sleep 2
+done
+log "kaspad health: $(docker inspect -f '{{.State.Health.Status}}' kaspad-devnet 2>/dev/null || echo unknown)"
+
+cat <<EOF
+
+Node 1 (ATAN-only, L2 off) is up. Next:
+
+  1) Mine across Toccata (needs MINING_ADDRESS=kaspadev:... in .env):
+       ./scripts/dev/run-devnet-cpuminer.sh
+     ATAN archives a period only once the pruning point (pruning_depth=${PRUNING_DEPTH}
+     behind the tip) passes it. Toccata is at DAA ${TOCCATA_ACTIVATION_DAA_SCORE}
+     (period 5). To archive 5+ periods each side, the pruning point must reach ~DAA
+     6300, i.e. mine to virtual DAA ~9500-10000. Watch the archive dir in step 2.
+
+  2) Watch archived periods appear:
+       docker exec kaspad-devnet ls /app/data/kaspa-devnet/datadir/atan/${TX_ID_PREFIX}/chain_block_lists
+
+  3) Validate via import into a second node:
+       ./scripts/dev/validate-devnet-atan.sh
+EOF

--- a/scripts/dev/run-devnet-atan-no-l2.sh
+++ b/scripts/dev/run-devnet-atan-no-l2.sh
@@ -53,12 +53,22 @@ log "Starting kaspad ONLY (no execution layer, no L2)..."
 docker compose -f "$COMPOSE_FILE" --profile backend up -d --build --no-deps kaspad
 
 log "Waiting for kaspad to report healthy..."
+status=none
 for _ in $(seq 1 30); do
     status="$(docker inspect -f '{{.State.Health.Status}}' kaspad-devnet 2>/dev/null || echo none)"
     [ "$status" = "healthy" ] && break
     sleep 2
 done
-log "kaspad health: $(docker inspect -f '{{.State.Health.Status}}' kaspad-devnet 2>/dev/null || echo unknown)"
+log "kaspad health: $status"
+# Fail closed: a still-unhealthy node (bad overrides, port clash, crash loop)
+# must not print a success banner and exit 0 — downstream callers (the e2e's
+# STEP 2) treat exit 0 + container-exists as a healthy node 1 and would burn the
+# long mining phase against a broken node before surfacing a confusing failure.
+if [ "$status" != "healthy" ]; then
+    log "ERROR: kaspad did not become healthy within 60s (status: $status). Recent logs:"
+    docker logs --tail 40 kaspad-devnet 2>&1 || true
+    exit 1
+fi
 
 cat <<EOF
 
@@ -76,4 +86,11 @@ Node 1 (ATAN-only, L2 off) is up. Next:
 
   3) Validate via import into a second node:
        ./scripts/dev/validate-devnet-atan.sh
+
+NOTE: this run overwrote overrides/devnet.json with harness params
+(finality=${FINALITY_PERIOD_SECONDS}s, toccata=${TOCCATA_ACTIVATION_DAA_SCORE},
+pruning_depth=${PRUNING_DEPTH}). The normal devnet stack loads whatever
+overrides/devnet.json is present, so re-run ./scripts/setup-devnet.sh (and wipe
+the kaspad volume) before returning to it — otherwise these params get baked into
+a fresh volume.
 EOF

--- a/scripts/dev/run-devnet-cpuminer.sh
+++ b/scripts/dev/run-devnet-cpuminer.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# run-devnet-cpuminer.sh - Set up and run the standalone kaspanet/cpuminer against
+# the local IGRA devnet, outside the docker-compose stack. Clones and builds
+# kaspanet/cpuminer once, then runs it on the host against the devnet kaspad gRPC
+# port. Reads MINING_ADDRESS / MINING_THREADS / KASPAD_GRPC_PORT from .env.
+#
+# Why this miner (vs the older tmrlvi/kaspa-miner used by run-devnet-miner.sh):
+# kaspanet/cpuminer tracks current rusty-kaspa (v3.0) proto and header
+# serialization, so the blocks it mines stay valid across the Toccata/KIP-21
+# boundary. The miner itself is fork-agnostic: it fetches a block template,
+# hashes the HEADER, and submits — it never touches transaction lane/subnetwork/
+# version/prefix. kaspad selects the transactions (native-v0 pre-Toccata,
+# lane-v1 post-Toccata) into the template, which is transparent to the miner, so
+# mining behaves identically before and after activation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Reuse predicates (is_port, is_positive_int, is_valid_mining_address).
+# shellcheck source=scripts/lib/devnet-preflight.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-preflight.sh"
+
+log()  { echo "[run-devnet-cpuminer] $*"; }
+warn() { echo "[run-devnet-cpuminer] WARNING: $*" >&2; }
+die()  { echo "[run-devnet-cpuminer] ERROR: $*" >&2; exit 1; }
+
+print_help() {
+    cat <<'EOF'
+Usage: ./scripts/dev/run-devnet-cpuminer.sh [--help]
+
+Clones and builds kaspanet/cpuminer (once) and runs it against the local devnet
+kaspad gRPC port. Runs in the foreground; press Ctrl+C to stop.
+
+Toccata-compatible: the miner tracks current rusty-kaspa proto/header hashing, so
+its blocks stay valid across the KIP-21 boundary. Mining is fork-agnostic (the
+miner hashes block headers, not transactions), so it behaves the same before and
+after Toccata activation.
+
+Configuration is read from .env (or .env.devnet.example if there is no .env);
+shell/CLI values take precedence over the file.
+
+Environment variables:
+  MINING_ADDRESS          Reward address; must be a devnet address (kaspadev:...).
+  MINING_THREADS          CPU miner threads (positive integer). Default: 1.
+  KASPAD_GRPC_PORT        Devnet kaspad gRPC port on the host. Default: 16610.
+  KASPAD_RPC_HOST         Host the miner dials. Default: 127.0.0.1 (NOT the
+                          compose-internal KASPAD_HOST, which is unreachable here).
+  MINE_WHEN_NOT_SYNCED    true|false. Default: true (a fresh single-node devnet
+                          reports "not synced"; pass the flag so it still mines).
+
+  MINER_REPO_URL          Default: https://github.com/kaspanet/cpuminer.git
+  MINER_BRANCH            Branch/tag to clone. Default: repo default branch.
+  MINER_DIR               Clone/build location.
+                          Default: build/repos/kaspanet-cpuminer
+  MINER_EXTRA_ARGS        Extra flags appended verbatim to the miner invocation.
+  SKIP_BUILD=1            Reuse an existing release binary; skip clone/build.
+
+Examples:
+  ./scripts/dev/run-devnet-cpuminer.sh
+  MINING_THREADS=4 ./scripts/dev/run-devnet-cpuminer.sh
+  SKIP_BUILD=1 ./scripts/dev/run-devnet-cpuminer.sh
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    print_help
+    exit 0
+fi
+
+# --- resolve config (shell/CLI > .env > .env.devnet.example > default) ---
+ENV_FILE="$PROJECT_DIR/.env"
+[ -f "$ENV_FILE" ] || ENV_FILE="$PROJECT_DIR/.env.devnet.example"
+
+# read_env KEY -> prints the trimmed, unquoted value from ENV_FILE; returns 1 if absent.
+read_env() {
+    local key="$1" line val found=1
+    [ -f "$ENV_FILE" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key"=*)
+                val="${line#*=}"
+                val="${val#"${val%%[![:space:]]*}"}"
+                val="${val%"${val##*[![:space:]]}"}"
+                case "$val" in
+                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
+                esac
+                found=0
+                ;;
+        esac
+    done < "$ENV_FILE"
+    [ "$found" -eq 0 ] && printf '%s' "$val"
+    return "$found"
+}
+
+# resolve NAME DEFAULT -> sets NAME from shell (if already set) else file else default.
+resolve() {
+    local name="$1" default="$2" val
+    [ -n "${!name+set}" ] && return 0
+    if val="$(read_env "$name")"; then
+        printf -v "$name" '%s' "$val"
+    else
+        printf -v "$name" '%s' "$default"
+    fi
+}
+
+[ -f "$ENV_FILE" ] && log "Reading config from $ENV_FILE (shell overrides win)"
+
+resolve MINING_ADDRESS ""
+resolve MINING_THREADS 1
+resolve KASPAD_GRPC_PORT 16610
+# Host loopback, not the compose-internal KASPAD_HOST (=kaspad).
+KASPAD_RPC_HOST="${KASPAD_RPC_HOST:-127.0.0.1}"
+MINE_WHEN_NOT_SYNCED="${MINE_WHEN_NOT_SYNCED:-true}"
+
+MINER_REPO_URL="${MINER_REPO_URL:-https://github.com/kaspanet/cpuminer.git}"
+MINER_BRANCH="${MINER_BRANCH:-}"
+MINER_DIR="${MINER_DIR:-$PROJECT_DIR/build/repos/kaspanet-cpuminer}"
+MINER_EXTRA_ARGS="${MINER_EXTRA_ARGS:-}"
+
+BIN="$MINER_DIR/target/release/kaspa-miner"
+
+# --- validate ---
+command -v git >/dev/null 2>&1 || die "git not found"
+is_valid_mining_address "$MINING_ADDRESS" || \
+    die "MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}'). Set it in .env or pass MINING_ADDRESS=..."
+is_positive_int "$MINING_THREADS" || \
+    die "MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')"
+is_port "$KASPAD_GRPC_PORT" || \
+    die "KASPAD_GRPC_PORT must be an integer in 1-65535 (got: '${KASPAD_GRPC_PORT:-<unset>}')"
+
+# --- clone + build (unless SKIP_BUILD reuses an existing binary) ---
+build_miner() {
+    command -v cargo >/dev/null 2>&1 || \
+        die "cargo (Rust toolchain) not found; needed to build the miner. Install via https://rustup.rs, or set SKIP_BUILD=1 to reuse an existing binary."
+
+    if [ ! -d "$MINER_DIR/.git" ]; then
+        log "Cloning $MINER_REPO_URL -> $MINER_DIR"
+        if [ -n "$MINER_BRANCH" ]; then
+            git clone --depth 1 --branch "$MINER_BRANCH" "$MINER_REPO_URL" "$MINER_DIR"
+        else
+            git clone --depth 1 "$MINER_REPO_URL" "$MINER_DIR"
+        fi
+    else
+        log "Reusing existing clone at $MINER_DIR"
+    fi
+
+    # kaspanet/cpuminer is a single CPU-only crate (no GPU crates), so a plain
+    # release build produces target/release/kaspa-miner.
+    log "Building kaspa-miner (release)..."
+    cargo build --release --manifest-path "$MINER_DIR/Cargo.toml"
+}
+
+if [ "${SKIP_BUILD:-}" = "1" ]; then
+    [ -x "$BIN" ] || die "SKIP_BUILD=1 but no binary at $BIN; unset SKIP_BUILD to clone and build it."
+    log "SKIP_BUILD=1; reusing existing binary $BIN"
+else
+    build_miner
+    [ -x "$BIN" ] || die "miner binary not found at $BIN after build"
+fi
+
+# --- preflight: is the devnet kaspad reachable? (non-fatal; the miner retries) ---
+if timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
+    log "devnet kaspad gRPC reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT"
+else
+    warn "devnet kaspad gRPC not reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT yet."
+    warn "Start the stack first (./scripts/setup-devnet.sh); the miner will keep retrying."
+fi
+
+# --- run (foreground; Ctrl+C stops) ---
+# No --testnet/--devnet flag: cpuminer is network-agnostic and only uses the
+# network flag to pick a default port, which we always set explicitly with -p.
+args=(-a "$MINING_ADDRESS" -s "$KASPAD_RPC_HOST" -p "$KASPAD_GRPC_PORT" -t "$MINING_THREADS")
+[ "$MINE_WHEN_NOT_SYNCED" = "true" ] && args+=(--mine-when-not-synced)
+
+log "Starting cpuminer -> $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT (address ${MINING_ADDRESS}, ${MINING_THREADS} threads)"
+log "Press Ctrl+C to stop."
+# Word-split MINER_EXTRA_ARGS so callers can pass multiple flags.
+# shellcheck disable=SC2086
+exec "$BIN" "${args[@]}" $MINER_EXTRA_ARGS

--- a/scripts/dev/run-devnet-cpuminer.sh
+++ b/scripts/dev/run-devnet-cpuminer.sh
@@ -52,7 +52,10 @@ Environment variables:
                           reports "not synced"; pass the flag so it still mines).
 
   MINER_REPO_URL          Default: https://github.com/kaspanet/cpuminer.git
-  MINER_BRANCH            Branch/tag to clone. Default: repo default branch.
+  MINER_COMMIT            Pinned commit SHA checked out when MINER_BRANCH is unset.
+                          Overriding it opts into a newer, unreviewed revision.
+  MINER_BRANCH            Branch/tag to clone instead of the pinned commit
+                          (unpinned; tracks the moving ref). Default: unset.
   MINER_DIR               Clone/build location.
                           Default: build/repos/kaspanet-cpuminer
   MINER_EXTRA_ARGS        Extra flags appended verbatim to the miner invocation.
@@ -71,41 +74,13 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 # --- resolve config (shell/CLI > .env > .env.devnet.example > default) ---
+# read_env/resolve are shared with run-devnet-miner.sh via the lib below.
 ENV_FILE="$PROJECT_DIR/.env"
 [ -f "$ENV_FILE" ] || ENV_FILE="$PROJECT_DIR/.env.devnet.example"
 
-# read_env KEY -> prints the trimmed, unquoted value from ENV_FILE; returns 1 if absent.
-read_env() {
-    local key="$1" line val found=1
-    [ -f "$ENV_FILE" ] || return 1
-    while IFS= read -r line || [ -n "$line" ]; do
-        line="${line%$'\r'}"
-        case "$line" in
-            "$key"=*)
-                val="${line#*=}"
-                val="${val#"${val%%[![:space:]]*}"}"
-                val="${val%"${val##*[![:space:]]}"}"
-                case "$val" in
-                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
-                esac
-                found=0
-                ;;
-        esac
-    done < "$ENV_FILE"
-    [ "$found" -eq 0 ] && printf '%s' "$val"
-    return "$found"
-}
-
-# resolve NAME DEFAULT -> sets NAME from shell (if already set) else file else default.
-resolve() {
-    local name="$1" default="$2" val
-    [ -n "${!name+set}" ] && return 0
-    if val="$(read_env "$name")"; then
-        printf -v "$name" '%s' "$val"
-    else
-        printf -v "$name" '%s' "$default"
-    fi
-}
+# shellcheck source=scripts/lib/devnet-env.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-env.sh"
 
 [ -f "$ENV_FILE" ] && log "Reading config from $ENV_FILE (shell overrides win)"
 
@@ -113,10 +88,15 @@ resolve MINING_ADDRESS ""
 resolve MINING_THREADS 1
 resolve KASPAD_GRPC_PORT 16610
 # Host loopback, not the compose-internal KASPAD_HOST (=kaspad).
-KASPAD_RPC_HOST="${KASPAD_RPC_HOST:-127.0.0.1}"
-MINE_WHEN_NOT_SYNCED="${MINE_WHEN_NOT_SYNCED:-true}"
+resolve KASPAD_RPC_HOST 127.0.0.1
+resolve MINE_WHEN_NOT_SYNCED true
 
 MINER_REPO_URL="${MINER_REPO_URL:-https://github.com/kaspanet/cpuminer.git}"
+# Pin a known-good commit (kaspa-miner 0.2.7 release) so an unattended clone+build
+# is reproducible and cannot silently pull a moving upstream head (cargo build
+# scripts/proc-macros run arbitrary code at build time). Override MINER_BRANCH to
+# opt into a newer ref.
+MINER_COMMIT="${MINER_COMMIT:-c4b9bec3a24823eb9c11d5dbd83c4968a6e125ea}"
 MINER_BRANCH="${MINER_BRANCH:-}"
 MINER_DIR="${MINER_DIR:-$PROJECT_DIR/build/repos/kaspanet-cpuminer}"
 MINER_EXTRA_ARGS="${MINER_EXTRA_ARGS:-}"
@@ -138,20 +118,37 @@ build_miner() {
         die "cargo (Rust toolchain) not found; needed to build the miner. Install via https://rustup.rs, or set SKIP_BUILD=1 to reuse an existing binary."
 
     if [ ! -d "$MINER_DIR/.git" ]; then
-        log "Cloning $MINER_REPO_URL -> $MINER_DIR"
         if [ -n "$MINER_BRANCH" ]; then
+            log "Cloning $MINER_REPO_URL @ $MINER_BRANCH (unpinned) -> $MINER_DIR"
             git clone --depth 1 --branch "$MINER_BRANCH" "$MINER_REPO_URL" "$MINER_DIR"
         else
-            git clone --depth 1 "$MINER_REPO_URL" "$MINER_DIR"
+            log "Cloning $MINER_REPO_URL @ pinned $MINER_COMMIT -> $MINER_DIR"
+            # Shallow-fetch the exact pinned commit (GitHub allows fetching a SHA).
+            git init -q "$MINER_DIR"
+            git -C "$MINER_DIR" remote add origin "$MINER_REPO_URL"
+            git -C "$MINER_DIR" fetch -q --depth 1 origin "$MINER_COMMIT"
+            git -C "$MINER_DIR" checkout -q --detach FETCH_HEAD
         fi
     else
         log "Reusing existing clone at $MINER_DIR"
+        # Warn if the existing checkout does not match what was requested: a
+        # changed MINER_COMMIT/MINER_BRANCH/MINER_REPO_URL is otherwise silently
+        # ignored and the stale checkout rebuilt.
+        local have_remote have_head
+        have_remote="$(git -C "$MINER_DIR" remote get-url origin 2>/dev/null || echo '?')"
+        have_head="$(git -C "$MINER_DIR" rev-parse HEAD 2>/dev/null || echo '?')"
+        [ "$have_remote" = "$MINER_REPO_URL" ] || \
+            warn "existing clone remote ($have_remote) != MINER_REPO_URL ($MINER_REPO_URL); using the existing checkout. Remove $MINER_DIR to re-clone."
+        if [ -z "$MINER_BRANCH" ] && [ "$have_head" != "$MINER_COMMIT" ]; then
+            warn "existing clone is at $have_head, not the pinned $MINER_COMMIT; using it as-is. Remove $MINER_DIR to re-clone at the pin."
+        fi
     fi
 
     # kaspanet/cpuminer is a single CPU-only crate (no GPU crates), so a plain
-    # release build produces target/release/kaspa-miner.
-    log "Building kaspa-miner (release)..."
-    cargo build --release --manifest-path "$MINER_DIR/Cargo.toml"
+    # release build produces target/release/kaspa-miner. --locked builds against
+    # the committed Cargo.lock so dependency versions cannot drift silently.
+    log "Building kaspa-miner (release) at $(git -C "$MINER_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)..."
+    cargo build --release --locked --manifest-path "$MINER_DIR/Cargo.toml"
 }
 
 if [ "${SKIP_BUILD:-}" = "1" ]; then
@@ -163,7 +160,12 @@ else
 fi
 
 # --- preflight: is the devnet kaspad reachable? (non-fatal; the miner retries) ---
-if timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
+# `timeout` is not on stock macOS (it ships with Homebrew coreutils). Without it,
+# skip the probe rather than fall into a misleading "not reachable" branch with
+# `command not found` noise; the miner retries the connection on its own anyway.
+if ! command -v timeout >/dev/null 2>&1; then
+    log "skipping gRPC reachability probe ('timeout' not found); the miner will retry $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT."
+elif timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
     log "devnet kaspad gRPC reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT"
 else
     warn "devnet kaspad gRPC not reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT yet."

--- a/scripts/dev/run-devnet-miner.sh
+++ b/scripts/dev/run-devnet-miner.sh
@@ -60,41 +60,13 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 # --- resolve config (shell/CLI > .env > .env.devnet.example > default) ---
+# read_env/resolve are shared with run-devnet-cpuminer.sh via the lib below.
 ENV_FILE="$PROJECT_DIR/.env"
 [ -f "$ENV_FILE" ] || ENV_FILE="$PROJECT_DIR/.env.devnet.example"
 
-# read_env KEY -> prints the trimmed, unquoted value from ENV_FILE; returns 1 if absent.
-read_env() {
-    local key="$1" line val found=1
-    [ -f "$ENV_FILE" ] || return 1
-    while IFS= read -r line || [ -n "$line" ]; do
-        line="${line%$'\r'}"
-        case "$line" in
-            "$key"=*)
-                val="${line#*=}"
-                val="${val#"${val%%[![:space:]]*}"}"
-                val="${val%"${val##*[![:space:]]}"}"
-                case "$val" in
-                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
-                esac
-                found=0
-                ;;
-        esac
-    done < "$ENV_FILE"
-    [ "$found" -eq 0 ] && printf '%s' "$val"
-    return "$found"
-}
-
-# resolve NAME DEFAULT -> sets NAME from shell (if already set) else file else default.
-resolve() {
-    local name="$1" default="$2" val
-    [ -n "${!name+set}" ] && return 0
-    if val="$(read_env "$name")"; then
-        printf -v "$name" '%s' "$val"
-    else
-        printf -v "$name" '%s' "$default"
-    fi
-}
+# shellcheck source=scripts/lib/devnet-env.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/devnet-env.sh"
 
 [ -f "$ENV_FILE" ] && log "Reading config from $ENV_FILE (shell overrides win)"
 
@@ -102,8 +74,8 @@ resolve MINING_ADDRESS ""
 resolve MINING_THREADS 1
 resolve KASPAD_GRPC_PORT 16610
 # Host loopback, not the compose-internal KASPAD_HOST (=kaspad).
-KASPAD_RPC_HOST="${KASPAD_RPC_HOST:-127.0.0.1}"
-MINE_WHEN_NOT_SYNCED="${MINE_WHEN_NOT_SYNCED:-true}"
+resolve KASPAD_RPC_HOST 127.0.0.1
+resolve MINE_WHEN_NOT_SYNCED true
 
 MINER_REPO_URL="${MINER_REPO_URL:-https://github.com/tmrlvi/kaspa-miner.git}"
 MINER_BRANCH="${MINER_BRANCH:-}"
@@ -177,7 +149,12 @@ else
 fi
 
 # --- preflight: is the devnet kaspad reachable? (non-fatal; the miner retries) ---
-if timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
+# `timeout` is not on stock macOS (it ships with Homebrew coreutils). Without it,
+# skip the probe rather than fall into a misleading "not reachable" branch with
+# `command not found` noise; the miner retries the connection on its own anyway.
+if ! command -v timeout >/dev/null 2>&1; then
+    log "skipping gRPC reachability probe ('timeout' not found); the miner will retry $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT."
+elif timeout 2 bash -c ": > /dev/tcp/$KASPAD_RPC_HOST/$KASPAD_GRPC_PORT" 2>/dev/null; then
     log "devnet kaspad gRPC reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT"
 else
     warn "devnet kaspad gRPC not reachable at $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT yet."

--- a/scripts/dev/test-devnet-env.sh
+++ b/scripts/dev/test-devnet-env.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# test-devnet-env.sh - plain-bash unit tests for scripts/lib/devnet-env.sh
+# Run: ./scripts/dev/test-devnet-env.sh   (exit 0 = all pass)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/devnet-env.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+check() { # check DESC ACTUAL EXPECTED
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$2" = "$3" ]; then echo "PASS: $1"; else
+        echo "FAIL: $1 (got '$2', want '$3')"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+ENV_FILE="$TMP/.env"
+
+# A representative .env: plain, whitespace-padded, double/single quoted, CRLF,
+# and a duplicated key (last assignment must win).
+printf 'PLAIN=abc\n'                    >  "$ENV_FILE"
+printf 'PADDED=   spaced   \n'          >> "$ENV_FILE"
+printf 'DQUOTED="in quotes"\n'          >> "$ENV_FILE"
+printf "SQUOTED='single'\n"             >> "$ENV_FILE"
+printf 'CRLF=windows\r\n'               >> "$ENV_FILE"
+printf 'DUP=first\n'                    >> "$ENV_FILE"
+printf 'DUP=last\n'                     >> "$ENV_FILE"
+
+# --- read_env ---
+check "plain value"       "$(read_env PLAIN)"   "abc"
+check "trims whitespace"  "$(read_env PADDED)"  "spaced"
+check "strips dquotes"    "$(read_env DQUOTED)" "in quotes"
+check "strips squotes"    "$(read_env SQUOTED)" "single"
+check "trims CR"          "$(read_env CRLF)"    "windows"
+check "last match wins"   "$(read_env DUP)"     "last"
+read_env ABSENT >/dev/null; check "absent returns 1" "$?" "1"
+
+# --- resolve precedence: shell > file > default ---
+DEF="$( unset MISSING; resolve MISSING theDefault; echo "$MISSING" )"
+check "default when absent" "$DEF" "theDefault"
+
+FROMFILE="$( unset PLAIN; resolve PLAIN theDefault; echo "$PLAIN" )"
+check "file beats default"  "$FROMFILE" "abc"
+
+SHELLWINS="$( PLAIN=shellwins; resolve PLAIN theDefault; echo "$PLAIN" )"
+check "shell beats file"    "$SHELLWINS" "shellwins"
+
+# Shell value that is explicitly empty must still win over the file.
+EMPTYWINS="$( PLAIN=""; resolve PLAIN theDefault; echo "[$PLAIN]" )"
+check "empty shell wins"    "$EMPTYWINS" "[]"
+
+echo "----"
+echo "Ran $TESTS_RUN, failed $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/scripts/dev/test-devnet-overrides.sh
+++ b/scripts/dev/test-devnet-overrides.sh
@@ -18,23 +18,32 @@ check() { # check DESC ACTUAL EXPECTED
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 export OVERRIDES_OUT_DIR="$TMP"
 
+# The JSON-validity checks need jq; without it every such check compares '' to
+# 'ok' and reports a misleading FAIL for what is really a missing tool. Detect
+# once and skip those checks (still running the content assertions) if absent.
+if command -v jq >/dev/null 2>&1; then HAVE_JQ=1; else HAVE_JQ=0; echo "SKIP: jq not installed; skipping JSON-validity checks"; fi
+check_json() { # check_json DESC FILE
+    [ "$HAVE_JQ" = "1" ] || return 0
+    check "$1" "$(jq -e . "$2" >/dev/null 2>&1 && echo ok)" "ok"
+}
+
 # Case A: Toccata scheduled -> finality_depth=600, toccata_activation=3300 present.
 # Two-arg call must keep the default pruning_depth (1080000) so setup-devnet.sh is unchanged.
 generate_devnet_overrides 60 3300 >/dev/null
 check "finality_depth 600" "$(grep -oE '"finality_depth": [0-9]+' "$TMP/devnet.json")" '"finality_depth": 600'
 check "toccata present"    "$(grep -oE '"toccata_activation": [0-9]+' "$TMP/devnet.json")" '"toccata_activation": 3300'
 check "default pruning"    "$(grep -oE '"pruning_depth": [0-9]+' "$TMP/devnet.json")" '"pruning_depth": 1080000'
-check "valid json A"       "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+check_json "valid json A"  "$TMP/devnet.json"
 
 # Case C: explicit small pruning_depth (fast-pruning ATAN harness) is honored.
 generate_devnet_overrides 60 3300 3000 >/dev/null
 check "custom pruning 3000" "$(grep -oE '"pruning_depth": [0-9]+' "$TMP/devnet.json")" '"pruning_depth": 3000'
-check "valid json C"        "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+check_json "valid json C"   "$TMP/devnet.json"
 
 # Case B: Toccata disabled (empty) -> no toccata_activation, still valid JSON (no trailing comma).
 generate_devnet_overrides 600 "" >/dev/null
 check "toccata absent"     "$(grep -c 'toccata_activation' "$TMP/devnet.json")" "0"
-check "valid json B"       "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+check_json "valid json B"  "$TMP/devnet.json"
 
 echo "----"
 echo "Ran $TESTS_RUN, failed $TESTS_FAILED"

--- a/scripts/dev/test-devnet-overrides.sh
+++ b/scripts/dev/test-devnet-overrides.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# test-devnet-overrides.sh - plain-bash unit tests for scripts/lib/devnet-overrides.sh
+# Run: ./scripts/dev/test-devnet-overrides.sh   (exit 0 = all pass)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/devnet-overrides.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+check() { # check DESC ACTUAL EXPECTED
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$2" = "$3" ]; then echo "PASS: $1"; else
+        echo "FAIL: $1 (got '$2', want '$3')"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export OVERRIDES_OUT_DIR="$TMP"
+
+# Case A: Toccata scheduled -> finality_depth=600, toccata_activation=3300 present.
+# Two-arg call must keep the default pruning_depth (1080000) so setup-devnet.sh is unchanged.
+generate_devnet_overrides 60 3300 >/dev/null
+check "finality_depth 600" "$(grep -oE '"finality_depth": [0-9]+' "$TMP/devnet.json")" '"finality_depth": 600'
+check "toccata present"    "$(grep -oE '"toccata_activation": [0-9]+' "$TMP/devnet.json")" '"toccata_activation": 3300'
+check "default pruning"    "$(grep -oE '"pruning_depth": [0-9]+' "$TMP/devnet.json")" '"pruning_depth": 1080000'
+check "valid json A"       "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+
+# Case C: explicit small pruning_depth (fast-pruning ATAN harness) is honored.
+generate_devnet_overrides 60 3300 3000 >/dev/null
+check "custom pruning 3000" "$(grep -oE '"pruning_depth": [0-9]+' "$TMP/devnet.json")" '"pruning_depth": 3000'
+check "valid json C"        "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+
+# Case B: Toccata disabled (empty) -> no toccata_activation, still valid JSON (no trailing comma).
+generate_devnet_overrides 600 "" >/dev/null
+check "toccata absent"     "$(grep -c 'toccata_activation' "$TMP/devnet.json")" "0"
+check "valid json B"       "$(jq -e . "$TMP/devnet.json" >/dev/null 2>&1 && echo ok)" "ok"
+
+echo "----"
+echo "Ran $TESTS_RUN, failed $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/scripts/dev/validate-devnet-atan.sh
+++ b/scripts/dev/validate-devnet-atan.sh
@@ -9,18 +9,44 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 IMPORT_COMPOSE="$PROJECT_DIR/docker-compose.devnet-atan-import.yml"
-TX_ID_PREFIX="${TX_ID_PREFIX:-97b1}"
-FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-60}"
-TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-3300}"
-ARCHIVE_DIR="/app/data/kaspa-devnet/datadir/atan/${TX_ID_PREFIX}/chain_block_lists"
-BOUNDARY_PERIOD=$(( TOCCATA_ACTIVATION_DAA_SCORE / (FINALITY_PERIOD_SECONDS * 10) ))
+OVERRIDES_JSON="$PROJECT_DIR/overrides/devnet.json"
+ATAN_BASE="/app/data/kaspa-devnet/datadir/atan"
+IMPORT_GRPC_HOST_PORT="${IMPORT_GRPC_HOST_PORT:-16620}"  # node 2's published gRPC
+NODE1_PEER="${NODE1_PEER:-}"                             # opt into peering instead of self-mining
 
 log()  { echo "[validate-devnet-atan] $*"; }
 fail() { echo "[validate-devnet-atan] VALIDATION FAILED: $*" >&2; exit 1; }
 
-# --- Preconditions: node 1 up and has enough archived periods ---
+# --- Preconditions: node 1 up ---
 docker ps --format '{{.Names}}' | grep -qx kaspad-devnet || \
     fail "node 1 (kaspad-devnet) is not running; run scripts/dev/run-devnet-atan-no-l2.sh and mine first."
+
+# --- Derive consensus params from the AUTHORITATIVE sources, not harness-default
+# env: the Toccata boundary must be computed from the same finality/toccata node 1
+# actually booted with, or the boundary pass/fail verdicts are silently wrong
+# against a differently-configured node. finality_depth + toccata_activation come
+# from the override file node 1 loaded; the tx-id prefix from node 1's archive layout.
+read_json_num() { grep -oE "\"$1\"[[:space:]]*:[[:space:]]*[0-9]+" "$2" 2>/dev/null | grep -oE '[0-9]+$' | head -1; }
+finality_depth=""; toccata=""
+if [ -f "$OVERRIDES_JSON" ]; then
+    finality_depth="$(read_json_num finality_depth "$OVERRIDES_JSON")"
+    toccata="$(read_json_num toccata_activation "$OVERRIDES_JSON")"
+fi
+# Fall back to env (harness defaults) only if the override file is unreadable.
+[ -n "$finality_depth" ] || finality_depth=$(( ${FINALITY_PERIOD_SECONDS:-60} * 10 ))
+[ -n "$toccata" ]        || toccata="${TOCCATA_ACTIVATION_DAA_SCORE:-}"
+[ "$finality_depth" -gt 0 ] 2>/dev/null || \
+    fail "could not determine finality_depth (checked $OVERRIDES_JSON and FINALITY_PERIOD_SECONDS)."
+[ -n "$toccata" ] || \
+    fail "could not determine toccata_activation; node 1 may have Toccata disabled (checked $OVERRIDES_JSON and TOCCATA_ACTIVATION_DAA_SCORE)."
+BOUNDARY_PERIOD=$(( toccata / finality_depth ))
+
+# Discover node 1's tx-id prefix from its on-disk archive layout (exactly one dir
+# expected); fall back to env/default if it cannot be read.
+prefix="$(docker exec kaspad-devnet sh -c "ls '$ATAN_BASE' 2>/dev/null" | tr -d '\r' | grep -E '^[0-9a-fA-F]+$' | head -1)"
+TX_ID_PREFIX="${prefix:-${TX_ID_PREFIX:-97b1}}"
+ARCHIVE_DIR="$ATAN_BASE/$TX_ID_PREFIX/chain_block_lists"
+log "params (from overrides/archive): finality_depth=$finality_depth toccata=$toccata boundary_period=$BOUNDARY_PERIOD tx_prefix=$TX_ID_PREFIX"
 
 periods="$(docker exec kaspad-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n")"
 [ -n "$periods" ] || fail "no archived periods in $ARCHIVE_DIR (mine longer)."
@@ -36,7 +62,25 @@ log "node 1 archived periods: first=$first last=$last count=$count (boundary per
 # --- Fresh node 2 import ---
 log "Starting node 2 (fresh atan_db) importing from node 1's archive (read-only)..."
 docker compose -f "$IMPORT_COMPOSE" down -v >/dev/null 2>&1 || true
-docker compose -f "$IMPORT_COMPOSE" up -d || fail "could not start kaspad-import (is node 1's image built?)."
+NODE1_PEER="$NODE1_PEER" docker compose -f "$IMPORT_COMPOSE" up -d \
+    || fail "could not start kaspad-import (is node 1's image built? see: docker compose -f $IMPORT_COMPOSE logs)."
+
+# ATAN only starts the import once node 2 reports is_nearly_synced. Reaching that
+# needs either peering to a fresh-tipped node 1 (opt-in via NODE1_PEER, only safe
+# with node 1 mining stopped) or self-mining node 2 a few blocks so its own sink
+# timestamp is fresh (the compose default). Unless the operator opted into peering,
+# drive self-mining from a host cpuminer against node 2's published gRPC.
+MINER_PID=""
+stop_node2_miner() { [ -n "$MINER_PID" ] && kill "$MINER_PID" 2>/dev/null; MINER_PID=""; }
+trap stop_node2_miner EXIT
+if [ -n "$NODE1_PEER" ]; then
+    log "NODE1_PEER=$NODE1_PEER set; node 2 peers to node 1 for IBD (no self-mining)."
+else
+    log "Self-mining node 2 to reach is_nearly_synced (host cpuminer -> 127.0.0.1:$IMPORT_GRPC_HOST_PORT)..."
+    KASPAD_GRPC_PORT="$IMPORT_GRPC_HOST_PORT" SKIP_BUILD=1 \
+        "$SCRIPT_DIR/run-devnet-cpuminer.sh" >/dev/null 2>&1 &
+    MINER_PID=$!
+fi
 
 # --- Wait for the import to finish or the node to die ---
 log "Waiting for import to complete (or node to hard-exit on an invalid period)..."
@@ -48,19 +92,27 @@ for _ in $(seq 1 180); do
         fail "node 2 exited during import (fail-closed validation panic = invalid period)."
     fi
     logs="$(docker logs kaspad-import-devnet 2>&1)"
-    echo "$logs" | grep -Eiq 'panic|process::exit|AtanError|Validation\(' && {
-        log "---- kaspad-import error logs ----"; echo "$logs" | tail -40
+    # Herestring (not a pipe) so grep's early exit under pipefail can't return 141
+    # and skip this fail-closed error branch on a large log.
+    if grep -Eiq 'panic|process::exit|AtanError|Validation\(' <<<"$logs"; then
+        log "---- kaspad-import error logs ----"; printf '%s\n' "$logs" | tail -40
         fail "node 2 logged a validation/panic error during import."
-    }
-    imported_line="$(echo "$logs" | grep -E 'Importing recent finality period chain block lists' | tail -1)"
+    fi
+    # Wait for the COMPLETION line, not the start line + a fixed sleep. A peered
+    # node 2 anchors at node 1's advanced pruning point and logs the HISTORICAL
+    # variant; a self-mined node 2 logs the RECENT variant. Accept either.
+    imported_line="$(grep -E 'Import of (recent|historical) finality period chain block lists complete' <<<"$logs" | tail -1)"
     [ -n "$imported_line" ] && break
     sleep 2
 done
-[ -n "$imported_line" ] || fail "node 2 did not report an import range within timeout."
-log "node 2 import: $imported_line"
+[ -n "$imported_line" ] || fail "node 2 did not reach import completion within timeout. Most likely node 2 never became is_nearly_synced, so ATAN never started. Unblock it by self-mining node 2 (SKIP_BUILD needs a prebuilt binary; run ./scripts/dev/run-devnet-cpuminer.sh once) or by peering with NODE1_PEER=kaspad-devnet:16611 (only with node 1 mining stopped)."
+log "node 2 import complete: $imported_line"
 
-# --- Give commit a moment, then confirm node 2's imported range matches node 1 ---
-sleep 10
+# Import done: stop self-mining. Node 2 stays up for the range checks below.
+stop_node2_miner
+
+# Brief settle so stored periods are flushed, then confirm the range matches node 1.
+sleep 3
 docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet || \
     fail "node 2 exited shortly after import (late validation failure)."
 n2_periods="$(docker exec kaspad-import-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n")"

--- a/scripts/dev/validate-devnet-atan.sh
+++ b/scripts/dev/validate-devnet-atan.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# validate-devnet-atan.sh - Validate node 1's ATAN archive by importing it into a
+# fresh second kaspad node (--atan-import-dir). kaspad's startup import runs the
+# post-KIP-21 four-group validator against the devnet Toccata boundary and
+# process::exit(1)s on any invalid period, so: node 2 imports the full range and
+# stays up  ==  PASS.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMPORT_COMPOSE="$PROJECT_DIR/docker-compose.devnet-atan-import.yml"
+TX_ID_PREFIX="${TX_ID_PREFIX:-97b1}"
+FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-60}"
+TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-3300}"
+ARCHIVE_DIR="/app/data/kaspa-devnet/datadir/atan/${TX_ID_PREFIX}/chain_block_lists"
+BOUNDARY_PERIOD=$(( TOCCATA_ACTIVATION_DAA_SCORE / (FINALITY_PERIOD_SECONDS * 10) ))
+
+log()  { echo "[validate-devnet-atan] $*"; }
+fail() { echo "[validate-devnet-atan] VALIDATION FAILED: $*" >&2; exit 1; }
+
+# --- Preconditions: node 1 up and has enough archived periods ---
+docker ps --format '{{.Names}}' | grep -qx kaspad-devnet || \
+    fail "node 1 (kaspad-devnet) is not running; run scripts/dev/run-devnet-atan-no-l2.sh and mine first."
+
+periods="$(docker exec kaspad-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n")"
+[ -n "$periods" ] || fail "no archived periods in $ARCHIVE_DIR (mine longer)."
+first="$(echo "$periods" | head -1)"
+last="$(echo "$periods" | tail -1)"
+count="$(echo "$periods" | wc -l | tr -d ' ')"
+log "node 1 archived periods: first=$first last=$last count=$count (boundary period=$BOUNDARY_PERIOD)"
+[ "$last" -gt "$BOUNDARY_PERIOD" ] || \
+    fail "last archived period ($last) is not past the Toccata boundary period ($BOUNDARY_PERIOD); mine longer."
+[ "$first" -le "$BOUNDARY_PERIOD" ] || \
+    log "WARNING: first archived period ($first) is already past the boundary ($BOUNDARY_PERIOD); pre-Toccata coverage is thin."
+
+# --- Fresh node 2 import ---
+log "Starting node 2 (fresh atan_db) importing from node 1's archive (read-only)..."
+docker compose -f "$IMPORT_COMPOSE" down -v >/dev/null 2>&1 || true
+docker compose -f "$IMPORT_COMPOSE" up -d || fail "could not start kaspad-import (is node 1's image built?)."
+
+# --- Wait for the import to finish or the node to die ---
+log "Waiting for import to complete (or node to hard-exit on an invalid period)..."
+imported_line=""
+for _ in $(seq 1 180); do
+    if ! docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet; then
+        log "---- kaspad-import last logs ----"
+        docker logs --tail 40 kaspad-import-devnet 2>&1 || true
+        fail "node 2 exited during import (fail-closed validation panic = invalid period)."
+    fi
+    logs="$(docker logs kaspad-import-devnet 2>&1)"
+    echo "$logs" | grep -Eiq 'panic|process::exit|AtanError|Validation\(' && {
+        log "---- kaspad-import error logs ----"; echo "$logs" | tail -40
+        fail "node 2 logged a validation/panic error during import."
+    }
+    imported_line="$(echo "$logs" | grep -E 'Importing recent finality period chain block lists' | tail -1)"
+    [ -n "$imported_line" ] && break
+    sleep 2
+done
+[ -n "$imported_line" ] || fail "node 2 did not report an import range within timeout."
+log "node 2 import: $imported_line"
+
+# --- Give commit a moment, then confirm node 2's imported range matches node 1 ---
+sleep 10
+docker ps --format '{{.Names}}' | grep -qx kaspad-import-devnet || \
+    fail "node 2 exited shortly after import (late validation failure)."
+n2_periods="$(docker exec kaspad-import-devnet sh -c "ls '$ARCHIVE_DIR' 2>/dev/null | sed 's/\.pb\$//' | sort -n")"
+[ -n "$n2_periods" ] || fail "node 2 has no stored periods after import."
+n2_first="$(echo "$n2_periods" | head -1)"
+n2_last="$(echo "$n2_periods" | tail -1)"
+n2_count="$(echo "$n2_periods" | wc -l | tr -d ' ')"
+log "node 2 stored periods: first=$n2_first last=$n2_last count=$n2_count"
+[ "$n2_last" -ge "$last" ] || fail "node 2 last period ($n2_last) < node 1 ($last); import incomplete."
+[ "$n2_last" -gt "$BOUNDARY_PERIOD" ] || fail "node 2 did not import past the Toccata boundary."
+# Pre-Toccata coverage: node 2 must hold periods at/below the boundary, not only post-Toccata ones.
+[ "$n2_first" -le "$BOUNDARY_PERIOD" ] || fail "node 2 first period ($n2_first) is past the boundary ($BOUNDARY_PERIOD); pre-Toccata periods were not imported."
+# Full-set check: every period node 1 archived must be present on node 2 (no missing pre/boundary/post, no mid-range gaps).
+# comm needs a consistent sort; use lexical sort on both sides.
+missing="$(comm -23 <(printf '%s\n' "$periods" | sort) <(printf '%s\n' "$n2_periods" | sort))"
+[ -z "$missing" ] || fail "node 2 is missing periods that node 1 archived: $(echo "$missing" | tr '\n' ' ')"
+
+echo "[validate-devnet-atan] VALIDATION PASSED: node 2 imported all $count periods node 1 archived ($n2_first..$n2_last), covering pre-Toccata, boundary ($BOUNDARY_PERIOD), and post-Toccata, with no validation error."

--- a/scripts/lib/devnet-env.sh
+++ b/scripts/lib/devnet-env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# devnet-env.sh - shared .env reader for the host miner scripts
+# (run-devnet-miner.sh, run-devnet-cpuminer.sh). Both need the same precedence
+# rule (shell/CLI > .env > default) and the same tolerant parser, so it lives
+# here once instead of being copied per script. Covered by
+# scripts/dev/test-devnet-env.sh.
+#
+# Contract: the caller sets $ENV_FILE to the file to read before calling
+# resolve/read_env (typically .env, falling back to .env.devnet.example).
+
+# read_env KEY -> prints the trimmed, unquoted value from $ENV_FILE; returns 1 if absent.
+# Tolerates CRLF line endings, surrounding whitespace, and single/double quotes;
+# last matching assignment wins.
+read_env() {
+    local key="$1" line val found=1
+    [ -f "$ENV_FILE" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key"=*)
+                val="${line#*=}"
+                val="${val#"${val%%[![:space:]]*}"}"
+                val="${val%"${val##*[![:space:]]}"}"
+                case "$val" in
+                    \"*\"|\'*\') val="${val:1:${#val}-2}" ;;
+                esac
+                found=0
+                ;;
+        esac
+    done < "$ENV_FILE"
+    [ "$found" -eq 0 ] && printf '%s' "$val"
+    return "$found"
+}
+
+# resolve NAME DEFAULT -> sets NAME from shell (if already set) else $ENV_FILE else default.
+resolve() {
+    local name="$1" default="$2" val
+    [ -n "${!name+set}" ] && return 0
+    if val="$(read_env "$name")"; then
+        printf -v "$name" '%s' "$val"
+    else
+        printf -v "$name" '%s' "$default"
+    fi
+}

--- a/scripts/lib/devnet-overrides.sh
+++ b/scripts/lib/devnet-overrides.sh
@@ -15,7 +15,31 @@ generate_devnet_overrides() {
     local seconds="$1"
     local toccata="$2"
     local pruning_depth="${3:-1080000}"
+
+    # Validate here so every caller is covered: run-devnet-atan-no-l2.sh passes
+    # raw env values through without any upstream validation. A bad value would
+    # otherwise break the arithmetic below, splice invalid JSON / injected fields
+    # into devnet.json, or bake a broken consensus config into the volume on first
+    # run (only fixable by wiping it). (Leading zeros rejected so no octal parse.)
+    if ! [[ "$seconds" =~ ^[1-9][0-9]*$ ]]; then
+        echo "[devnet-overrides] ERROR: FINALITY_PERIOD_SECONDS must be a positive integer (got: '$seconds')" >&2
+        return 1
+    fi
+    if ! [[ "$pruning_depth" =~ ^[1-9][0-9]*$ ]]; then
+        echo "[devnet-overrides] ERROR: PRUNING_DEPTH must be a positive integer (got: '$pruning_depth')" >&2
+        return 1
+    fi
+    if [ -n "$toccata" ] && ! [[ "$toccata" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        echo "[devnet-overrides] ERROR: TOCCATA_ACTIVATION_DAA_SCORE must be a non-negative integer or empty (got: '$toccata')" >&2
+        return 1
+    fi
+
     local depth=$(( seconds * 10 ))   # BPS=10 on devnet
+    # pruning_depth must stay > finality_depth (the invariant this file documents).
+    if (( pruning_depth <= depth )); then
+        echo "[devnet-overrides] ERROR: pruning_depth ($pruning_depth) must be > finality_depth ($depth = ${seconds}s*10)" >&2
+        return 1
+    fi
     local lib_dir out_dir
     lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     out_dir="${OVERRIDES_OUT_DIR:-$lib_dir/../../overrides}"

--- a/scripts/lib/devnet-overrides.sh
+++ b/scripts/lib/devnet-overrides.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# devnet-overrides.sh - generate overrides/devnet.json (consensus override params).
+# Sourced by scripts/setup-devnet.sh and scripts/dev/run-devnet-atan-no-l2.sh.
+
+# generate_devnet_overrides SECONDS TOCCATA [PRUNING_DEPTH]
+#   Writes $OVERRIDES_OUT_DIR/devnet.json (default: <this-lib>/../../overrides).
+#   finality_depth = SECONDS*10 (BPS=10). toccata_activation appended only when
+#   TOCCATA is non-empty (keeps JSON comma-correct when Toccata is disabled).
+#   PRUNING_DEPTH defaults to 1080000 (kaspad devnet default; keeps setup-devnet.sh
+#   unchanged). ATAN commits a finality period only when the pruning point advances
+#   past it, and the effective pruning depth is min(pruning_depth, ~159858 for these
+#   blockrate params) — so a SMALL pruning_depth (e.g. 3000) is required for ATAN to
+#   archive periods within a short devnet mining run (see run-devnet-atan-no-l2.sh).
+generate_devnet_overrides() {
+    local seconds="$1"
+    local toccata="$2"
+    local pruning_depth="${3:-1080000}"
+    local depth=$(( seconds * 10 ))   # BPS=10 on devnet
+    local lib_dir out_dir
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    out_dir="${OVERRIDES_OUT_DIR:-$lib_dir/../../overrides}"
+    mkdir -p "$out_dir"
+    local toccata_line=""
+    if [ -n "$toccata" ]; then
+        toccata_line=",
+  \"toccata_activation\": $toccata"
+    fi
+    cat > "$out_dir/devnet.json" <<EOF
+{
+  "blockrate": {
+    "target_time_per_block": 100,
+    "ghostdag_k": 124,
+    "past_median_time_sample_rate": 10,
+    "difficulty_sample_rate": 2,
+    "max_block_parents": 16,
+    "mergeset_size_limit": 248,
+    "merge_depth": 36000,
+    "finality_depth": $depth,
+    "pruning_depth": $pruning_depth,
+    "coinbase_maturity": 200
+  },
+  "crescendo_activation": 0$toccata_line
+}
+EOF
+    if [ -n "$toccata" ]; then
+        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), pruning_depth=$pruning_depth, toccata_activation=$toccata"
+    else
+        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), pruning_depth=$pruning_depth, toccata_activation disabled (never)"
+    fi
+}

--- a/scripts/lib/devnet-preflight.sh
+++ b/scripts/lib/devnet-preflight.sh
@@ -212,9 +212,13 @@ mining_preflight() {
     fi
 
     echo "[setup-devnet] Toccata is scheduled at DAA ${TOCCATA_ACTIVATION_DAA_SCORE:-}." >&2
-    echo "               kaspad mines nothing on its own; point a miner at the devnet" >&2
-    echo "               kaspad gRPC port (127.0.0.1:\${KASPAD_GRPC_PORT}) with" >&2
-    echo "               --mining-address ${MINING_ADDRESS:-} to reach the activation score." >&2
+    echo "               kaspad mines nothing on its own. Use the Toccata-compatible" >&2
+    echo "               cpuminer, whose blocks stay valid across the KIP-21 boundary:" >&2
+    echo "                 ./scripts/dev/run-devnet-cpuminer.sh" >&2
+    echo "               (The older ./scripts/dev/run-devnet-miner.sh does not track the" >&2
+    echo "               v3.0 proto/header serialization and can mine blocks that go" >&2
+    echo "               invalid post-Toccata.) It reads MINING_ADDRESS=${MINING_ADDRESS:-}" >&2
+    echo "               and dials the devnet kaspad gRPC port to reach the activation score." >&2
     return 0
 }
 

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/lib/devnet-overrides.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/devnet-overrides.sh"
+
 # Environment-specific configuration (used by sourced setup-common.sh)
 # shellcheck disable=SC2034
 ENV_NAME="Devnet"
@@ -49,46 +53,6 @@ FINALITY_PERIOD_SECONDS="${FINALITY_PERIOD_SECONDS:-600}"
 TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE-1000}"
 IGRA_LANE_ID="${IGRA_LANE_ID-97b10000}"
 export FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID
-
-generate_devnet_overrides() {
-    local seconds="$1"
-    local toccata="$2"
-    # FINALITY_PERIOD_SECONDS range is validated upstream in validate_devnet_env.
-    local depth=$(( seconds * 10 ))   # BPS=10 on devnet
-    local out_dir="$SCRIPT_DIR/../overrides"
-    mkdir -p "$out_dir"
-    # blockrate mirrors the kaspad devnet defaults; only finality_depth is tuned.
-    # crescendo_activation=0 keeps post-Crescendo consensus active from genesis.
-    # toccata_activation is appended as the last field only when scheduled, so the
-    # JSON has no trailing comma when Toccata is disabled (empty score).
-    local toccata_line=""
-    if [ -n "$toccata" ]; then
-        toccata_line=",
-  \"toccata_activation\": $toccata"
-    fi
-    cat > "$out_dir/devnet.json" <<EOF
-{
-  "blockrate": {
-    "target_time_per_block": 100,
-    "ghostdag_k": 124,
-    "past_median_time_sample_rate": 10,
-    "difficulty_sample_rate": 2,
-    "max_block_parents": 16,
-    "mergeset_size_limit": 248,
-    "merge_depth": 36000,
-    "finality_depth": $depth,
-    "pruning_depth": 1080000,
-    "coinbase_maturity": 200
-  },
-  "crescendo_activation": 0$toccata_line
-}
-EOF
-    if [ -n "$toccata" ]; then
-        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), toccata_activation=$toccata"
-    else
-        echo "[setup-devnet] Generated overrides/devnet.json: finality_depth=$depth (= ${seconds}s at 10 BPS), toccata_activation disabled (never)"
-    fi
-}
 
 # finality_depth is baked into kaspad's consensus DB on first run and lives in the
 # kaspad_data named volume; --override-params-file only applies to a fresh DB. Warn

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -201,7 +201,29 @@ print_summary() {
 run_setup "$@"
 
 # The miner is not part of this stack; operators run their own against the
-# published devnet kaspad gRPC port.
+# published devnet kaspad gRPC port. When Toccata is scheduled, recommend the
+# cpuminer: the older tmrlvi miner does not track v3.0 proto/header serialization
+# and can mine blocks that go invalid across the Toccata/KIP-21 boundary.
+if [ -n "${TOCCATA_ACTIVATION_DAA_SCORE:-}" ]; then
+cat <<EOF
+
+=== Devnet: Mining (Toccata scheduled at DAA ${TOCCATA_ACTIVATION_DAA_SCORE}) ===
+
+kaspad mines no blocks on its own. Because Toccata/KIP-21 is scheduled, use the
+cpuminer helper, whose blocks stay valid across the boundary (it tracks current
+rusty-kaspa v3.0 proto/header serialization). Run it once kaspad is healthy:
+
+  ./scripts/dev/run-devnet-cpuminer.sh
+
+The older ./scripts/dev/run-devnet-miner.sh (tmrlvi/kaspa-miner) does NOT track
+v3.0 serialization and can produce blocks that go invalid post-Toccata; prefer
+the cpuminer whenever Toccata is scheduled.
+
+It reads MINING_ADDRESS / MINING_THREADS / KASPAD_GRPC_PORT from your .env; see
+'./scripts/dev/run-devnet-cpuminer.sh --help' for options.
+Mining is required to reach TOCCATA_ACTIVATION_DAA_SCORE for the KIP-21 rehearsal.
+EOF
+else
 cat <<EOF
 
 === Devnet: Mining ===
@@ -214,5 +236,5 @@ gRPC port. Run it once kaspad is healthy:
 
 It reads MINING_ADDRESS / MINING_THREADS / KASPAD_GRPC_PORT from your .env; see
 './scripts/dev/run-devnet-miner.sh --help' for options.
-Mining is required to reach TOCCATA_ACTIVATION_DAA_SCORE for the KIP-21 rehearsal.
 EOF
+fi


### PR DESCRIPTION
Summary

Enables the devnet kaspad to run with ATAN enabled while the L2 (viaduct / execution layer) is disabled, and adds the tooling needed to mine across the Toccata (KIP-21) boundary and validate archived finality periods. This makes it possible to exercise ATAN's finality-period archiving and its post-KIP-21 four-group validator on devnet without standing up the full L2 stack.

Existing behavior is preserved: with IGRA_ENABLE=true (the default), the kaspad entrypoint, flags, and dependency wiring are unchanged.

What's included

ATAN / L2 decoupling
- docker-compose.devnet.yml: new ATAN_ENABLE / ATAN_IMPORT_DIR toggles. ATAN flags (--atan-listen, --atan-transaction-id-prefix, --igra-lane-id, import source) are now emitted independently of IGRA_ENABLE. When IGRA is disabled, kaspad no longer waits for the execution layer and the healthcheck skips the EL probe. ATAN_ENABLE defaults to IGRA_ENABLE, so normal runs are unaffected.
- .env.devnet.example: documents ATAN_ENABLE and ATAN_IMPORT_DIR.

Shared overrides generator
- scripts/lib/devnet-overrides.sh: extracts generate_devnet_overrides (previously inline in setup-devnet.sh) into a shared library with a parameterizable pruning_depth, so the setup and the new run scripts share one generator.
- scripts/setup-devnet.sh: sources the shared library instead of the inline copy (no behavior change).
- scripts/dev/test-devnet-overrides.sh: unit tests for the overrides generator (default vs. custom pruning depth, JSON validity, Toccata on/off).

Mining and validation tooling
- scripts/dev/run-devnet-cpuminer.sh: standalone kaspanet/cpuminer runner against the local devnet kaspad gRPC endpoint.
- scripts/dev/run-devnet-atan-no-l2.sh: brings up an ATAN-only node (L2 off) with Toccata scheduled early so mining quickly crosses the KIP-21 boundary.
- docker-compose.devnet-atan-import.yml, scripts/dev/validate-devnet-atan.sh, scripts/dev/run-devnet-atan-import-e2e.sh: import a node's ATAN archive into a fresh second node and validate every finality period on the way in. Import is fail-closed, so a clean, staying-up node means all periods validated.

Testing

- Unit tests: ./scripts/dev/test-devnet-overrides.sh — all pass.
- Compose renders in both modes (IGRA_ENABLE=true and IGRA_ENABLE=false ATAN_ENABLE=true).
- End-to-end: a fresh ATAN-only node mined and archived finality periods spanning the Toccata boundary (periods 0–4 pre-Toccata, 5 = boundary, 6+ post-Toccata). A second node imported the archive across the boundary — the four-group validator ran fail-closed on each historical period with no validation error, no viaduct/window errors, and the importing node stayed healthy.