### PR TITLE
[ENG-1188] fix(deploy): mount kaswallet keys as per-worker directories for atomic save

### DIFF
--- a/.env.galleon-testnet.example
+++ b/.env.galleon-testnet.example
@@ -128,7 +128,7 @@ CORE_CONTRACTS_BRANCH=main
 # All wallet addresses must use testnet prefix: kaspatest:
 # Generate keys for Galleon (see versions.galleon-testnet.env for current image version):
 #   docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-#     igranetwork/kaswallet:$(grep KASWALLET_VERSION versions.galleon-testnet.env | cut -d= -f2) --testnet --testnet-suffix=10 -k /keys/keys.kaswallet-X.json
+#     igranetwork/kaswallet:$(grep KASWALLET_VERSION versions.galleon-testnet.env | cut -d= -f2) --testnet --testnet-suffix=10 -k /keys/kaswallet-X/keys.json
 
 # WARNING: WALLET_TO_ADDRESS is where transaction CHANGE is returned!
 # If this is set to a placeholder or wrong address, your wallet will LOSE FUNDS

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -110,7 +110,7 @@ CORE_CONTRACTS_BRANCH=main
 # All wallet addresses must use mainnet prefix: kaspa:
 # Generate keys for mainnet (see versions.env for current image version):
 #   docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-#     igranetwork/kaswallet:$(grep KASWALLET_VERSION versions.env | cut -d= -f2) --enable-mainnet-pre-launch -k /keys/keys.kaswallet-X.json
+#     igranetwork/kaswallet:$(grep KASWALLET_VERSION versions.env | cut -d= -f2) --enable-mainnet-pre-launch -k /keys/kaswallet-X/keys.json
 
 # WARNING: WALLET_TO_ADDRESS is where transaction CHANGE is returned!
 # If this is set to a placeholder or wrong address, your wallet will LOSE FUNDS

--- a/.github/workflows/compose-config.yml
+++ b/.github/workflows/compose-config.yml
@@ -235,4 +235,5 @@ jobs:
             scripts/setup-mainnet.sh \
             scripts/setup-galleon-testnet.sh \
             scripts/dev/setup-repos.sh \
-            scripts/dev/migrate-galleon-to-testnet-10.sh
+            scripts/dev/migrate-galleon-to-testnet-10.sh \
+            scripts/dev/migrate-keys-to-subdirs.sh

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Follow these steps before the first run:
     ```
 
 4.  **Create worker keys:**
-    Generate the necessary key files for the wallet services. At minimum, you need `keys.kaswallet-0.json` for one worker. Additional workers require corresponding files (e.g., `keys.kaswallet-1.json`, `keys.kaswallet-2.json`, up to `keys.kaswallet-19.json` for 20 workers).
+    Generate the necessary key files for the wallet services. Each worker's key lives in its own directory: at minimum you need `keys/kaswallet-0/keys.json` for one worker. Additional workers require corresponding files (e.g., `keys/kaswallet-1/keys.json`, up to `keys/kaswallet-19/keys.json` for 20 workers). The daemon mounts each worker's *directory* (`./keys/kaswallet-N`) so kaswallet can update `keys.json` atomically. Existing flat `keys.kaswallet-N.json` deployments can be migrated with `scripts/dev/migrate-keys-to-subdirs.sh` — run it on each node **before** recreating the kaswallet services (`docker compose ... up -d`) with this compose, because an un-migrated node cannot load its key (and an old single-file-mount node running the atomic-save image crash-loops with EBUSY).
 
 5.  **Sync wallet addresses (after wallets are running):**
     Once the kaswallet containers are running (requires kaspad to have completed IBD sync), sync their addresses into `.env`:

--- a/doc/kaspa-wallet.md
+++ b/doc/kaspa-wallet.md
@@ -88,36 +88,36 @@ $ send kaspadev:qq727apeewmcfvv4rvq68xgfal3e9qn7ukqk9ujk0tragepxcnrgwcz34srr4 50
 
 Devnet:
 ```bash
-kaswallet-create --devnet -k keys.kaswallet-0.json
+kaswallet-create --devnet -k keys/kaswallet-0/keys.json
 ```
 
 Testnet:
 ```bash
-kaswallet-create --testnet -k keys.kaswallet-0.json
+kaswallet-create --testnet -k keys/kaswallet-0/keys.json
 ```
 
 Mainnet:
 ```bash
-kaswallet-create --mainnet -k keys.kaswallet-0.json
+kaswallet-create --mainnet -k keys/kaswallet-0/keys.json
 ```
 
 Docker (mainnet - use `--enable-mainnet-pre-launch`). First, source the versions file: `source versions.mainnet.env`
 ```bash
 docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-  igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/keys.kaswallet-0.json
+  igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/kaswallet-0/keys.json
 ```
 
 Docker (testnet - use `--testnet`):
 ```bash
 docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-  igranetwork/kaswallet:${KASWALLET_VERSION} --testnet -k /keys/keys.kaswallet-0.json
+  igranetwork/kaswallet:${KASWALLET_VERSION} --testnet -k /keys/kaswallet-0/keys.json
 ```
 
 Generate all 5 wallets (mainnet):
 ```bash
 for i in {0..4}; do
   docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-    igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/keys.kaswallet-$i.json
+    igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/kaswallet-$i/keys.json
 done
 ```
 

--- a/doc/quick-setup-galleon-testnet.md
+++ b/doc/quick-setup-galleon-testnet.md
@@ -162,7 +162,7 @@ Generate keys for each worker (0-4):
 source versions.galleon-testnet.env
 for i in {0..4}; do
   docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-    igranetwork/kaswallet:${KASWALLET_VERSION} --testnet --testnet-suffix=10 -k /keys/keys.kaswallet-$i.json
+    igranetwork/kaswallet:${KASWALLET_VERSION} --testnet --testnet-suffix=10 -k /keys/kaswallet-$i/keys.json
 done
 ```
 

--- a/doc/quick-setup-mainnet.md
+++ b/doc/quick-setup-mainnet.md
@@ -128,7 +128,7 @@ Generate keys for each worker (0-4):
 source versions.mainnet.env
 for i in {0..4}; do
   docker run --rm -it -v $(pwd)/keys:/keys --entrypoint /app/kaswallet-create \
-    igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/keys.kaswallet-$i.json
+    igranetwork/kaswallet:${KASWALLET_VERSION} --enable-mainnet-pre-launch -k /keys/kaswallet-$i/keys.json
 done
 ```
 

--- a/docker-compose.devnet.yml
+++ b/docker-compose.devnet.yml
@@ -307,7 +307,7 @@ services:
       - sh
       - -ec
       - |
-        ARGS="--logs-level=$$RUST_LOG --keys /app/keys.json --server grpc://$$KASPAD_HOST:$$KASPAD_GRPC_PORT --listen 0.0.0.0:8082"
+        ARGS="--logs-level=$$RUST_LOG --keys /app/keys/keys.json --server grpc://$$KASPAD_HOST:$$KASPAD_GRPC_PORT --listen 0.0.0.0:8082"
         if [ "$$NETWORK" = "mainnet" ]; then
           ARGS="--enable-mainnet-pre-launch $$ARGS"
         else
@@ -320,7 +320,7 @@ services:
           --tcp kaspad "$$KASPAD_HOST" "$$KASPAD_GRPC_PORT" \
           -- /app/kaswallet-daemon $$ARGS
     volumes:
-      - ./keys/keys.kaswallet-0.json:/app/keys.json
+      - ./keys/kaswallet-0:/app/keys
       - *dependency-watch-volume
     healthcheck:
       <<: *default-healthcheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ x-kaswallet-runtime: &kaswallet-runtime
       # Sets KASPA_FAMILY and KASPA_NETSUFFIX from NETWORK.
       . /app/parse-network-slug.sh
 
-      ARGS="--logs-level=$$RUST_LOG --keys /app/keys.json --server grpc://$$KASPAD_HOST:$$KASPAD_GRPC_PORT --listen 0.0.0.0:8082"
+      ARGS="--logs-level=$$RUST_LOG --keys /app/keys/keys.json --server grpc://$$KASPAD_HOST:$$KASPAD_GRPC_PORT --listen 0.0.0.0:8082"
       if [ "$$KASPA_FAMILY" = "mainnet" ]; then
         ARGS="--enable-mainnet-pre-launch $$ARGS"
       else
@@ -479,7 +479,7 @@ services:
     ports:
       - "127.0.0.1:8082:8082"  # open 8082 on localhost for entry transactions
     volumes:
-      - ./keys/keys.kaswallet-0.json:/app/keys.json
+      - ./keys/kaswallet-0:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -499,7 +499,7 @@ services:
     profiles: ["frontend-w2", "frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-1
     volumes:
-      - ./keys/keys.kaswallet-1.json:/app/keys.json
+      - ./keys/kaswallet-1:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -519,7 +519,7 @@ services:
     profiles: ["frontend-w3", "frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-2
     volumes:
-      - ./keys/keys.kaswallet-2.json:/app/keys.json
+      - ./keys/kaswallet-2:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -539,7 +539,7 @@ services:
     profiles: ["frontend-w4", "frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-3
     volumes:
-      - ./keys/keys.kaswallet-3.json:/app/keys.json
+      - ./keys/kaswallet-3:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -559,7 +559,7 @@ services:
     profiles: ["frontend-w5", "frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-4
     volumes:
-      - ./keys/keys.kaswallet-4.json:/app/keys.json
+      - ./keys/kaswallet-4:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -579,7 +579,7 @@ services:
     profiles: ["frontend-w6", "frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-5
     volumes:
-      - ./keys/keys.kaswallet-5.json:/app/keys.json
+      - ./keys/kaswallet-5:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -599,7 +599,7 @@ services:
     profiles: ["frontend-w7", "frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-6
     volumes:
-      - ./keys/keys.kaswallet-6.json:/app/keys.json
+      - ./keys/kaswallet-6:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -619,7 +619,7 @@ services:
     profiles: ["frontend-w8", "frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-7
     volumes:
-      - ./keys/keys.kaswallet-7.json:/app/keys.json
+      - ./keys/kaswallet-7:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -639,7 +639,7 @@ services:
     profiles: ["frontend-w9", "frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-8
     volumes:
-      - ./keys/keys.kaswallet-8.json:/app/keys.json
+      - ./keys/kaswallet-8:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -659,7 +659,7 @@ services:
     profiles: ["frontend-w10", "frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-9
     volumes:
-      - ./keys/keys.kaswallet-9.json:/app/keys.json
+      - ./keys/kaswallet-9:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -679,7 +679,7 @@ services:
     profiles: ["frontend-w11", "frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-10
     volumes:
-      - ./keys/keys.kaswallet-10.json:/app/keys.json
+      - ./keys/kaswallet-10:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -699,7 +699,7 @@ services:
     profiles: ["frontend-w12", "frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-11
     volumes:
-      - ./keys/keys.kaswallet-11.json:/app/keys.json
+      - ./keys/kaswallet-11:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -719,7 +719,7 @@ services:
     profiles: ["frontend-w13", "frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-12
     volumes:
-      - ./keys/keys.kaswallet-12.json:/app/keys.json
+      - ./keys/kaswallet-12:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -739,7 +739,7 @@ services:
     profiles: ["frontend-w14", "frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-13
     volumes:
-      - ./keys/keys.kaswallet-13.json:/app/keys.json
+      - ./keys/kaswallet-13:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -759,7 +759,7 @@ services:
     profiles: ["frontend-w15", "frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-14
     volumes:
-      - ./keys/keys.kaswallet-14.json:/app/keys.json
+      - ./keys/kaswallet-14:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -779,7 +779,7 @@ services:
     profiles: ["frontend-w16", "frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-15
     volumes:
-      - ./keys/keys.kaswallet-15.json:/app/keys.json
+      - ./keys/kaswallet-15:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -799,7 +799,7 @@ services:
     profiles: ["frontend-w17", "frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-16
     volumes:
-      - ./keys/keys.kaswallet-16.json:/app/keys.json
+      - ./keys/kaswallet-16:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -819,7 +819,7 @@ services:
     profiles: ["frontend-w18", "frontend-w19", "frontend-w20"]
     container_name: kaswallet-17
     volumes:
-      - ./keys/keys.kaswallet-17.json:/app/keys.json
+      - ./keys/kaswallet-17:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -839,7 +839,7 @@ services:
     profiles: ["frontend-w19", "frontend-w20"]
     container_name: kaswallet-18
     volumes:
-      - ./keys/keys.kaswallet-18.json:/app/keys.json
+      - ./keys/kaswallet-18:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 
@@ -859,7 +859,7 @@ services:
     profiles: ["frontend-w20"]
     container_name: kaswallet-19
     volumes:
-      - ./keys/keys.kaswallet-19.json:/app/keys.json
+      - ./keys/kaswallet-19:/app/keys
       - *dependency-watch-volume
       - *parse-network-slug-volume
 

--- a/scripts/dev/migrate-keys-to-subdirs.sh
+++ b/scripts/dev/migrate-keys-to-subdirs.sh
@@ -77,8 +77,12 @@ for src in keys/keys.kaswallet-*.json; do
     echo "  + worker $idx: $src -> $dst"
     run bash -c "umask 077 && mkdir -p '$dst_dir'"
     run mv "$src" "$dst"
-    run chmod 600 "$dst"          # keys are owner-only
-    run chmod 700 "$dst_dir"
+    # Best-effort perm hardening. A key written by the containerized daemon (which
+    # runs as root) is root-owned on the host, so a non-root operator gets EPERM
+    # on chmod. The mv already succeeded and the root daemon reads the file fine,
+    # so warn and keep going rather than aborting the migration under `set -e`.
+    run chmod 600 "$dst" 2>/dev/null || echo "  ! note: could not chmod 600 $dst (not owner, e.g. root-owned) — left as-is"
+    run chmod 700 "$dst_dir" 2>/dev/null || echo "  ! note: could not chmod 700 $dst_dir — left as-is"
     moved=$((moved + 1))
 done
 shopt -u nullglob

--- a/scripts/dev/migrate-keys-to-subdirs.sh
+++ b/scripts/dev/migrate-keys-to-subdirs.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Migrate kaswallet key files from the flat single-file layout to the per-worker
+# directory layout required by kaswallet's atomic keys.json save (ENG-1186).
+#
+#   keys/keys.kaswallet-N.json   ->   keys/kaswallet-N/keys.json
+#
+# The daemon now mounts the containing DIRECTORY (./keys/kaswallet-N:/app/keys)
+# instead of the single file, so its atomic temp-file+rename save works (a
+# rename cannot target a single-file bind mount -> EBUSY -> crash-loop).
+#
+# Read-only-safe, idempotent, and re-runnable: files already migrated are left
+# alone; jwt.hex / keys.core.json / existing backups are never touched. Run this
+# once per node BEFORE `docker compose ... up -d` with the new compose.
+#
+#   Usage:  scripts/dev/migrate-keys-to-subdirs.sh [--dry-run]
+set -euo pipefail
+
+DRY_RUN=0
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+usage() { echo "Usage: $(basename "$0") [--dry-run]" >&2; }
+run() { if [[ "$DRY_RUN" == 1 ]]; then echo "  [dry-run] $*"; else "$@"; fi; }
+
+# Accept only --dry-run (or no args); reject anything else so a mistyped safety
+# flag (e.g. --dryrun, -n, --help) never silently performs a real migration.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        -h | --help) usage; exit 0 ;;
+        *) usage; die "unknown argument: $1" ;;
+    esac
+    shift
+done
+
+# Prevent concurrent key moves for this UID (best-effort; flock ships on the
+# Linux deployment hosts but not everywhere, and the migration is idempotent).
+if command -v flock >/dev/null 2>&1; then
+    LOCKFILE="${TMPDIR:-/tmp}/migrate-keys-to-subdirs.$(id -u).lock"
+    exec 9>"$LOCKFILE"
+    flock -n 9 || die "Another key migration is already running (lockfile: $LOCKFILE)"
+fi
+
+# Run from the project root (this script lives in scripts/dev/).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_DIR"
+
+[[ -d keys ]] || die "no keys/ directory in $PROJECT_DIR — run from an orchestra deployment"
+[[ -f docker-compose.yml ]] || die "no docker-compose.yml in $PROJECT_DIR — is this an orchestra checkout?"
+
+echo "Migrating kaswallet keys to per-worker subdirectories in: $PROJECT_DIR/keys"
+[[ "$DRY_RUN" == 1 ]] && echo "(dry run — no changes will be made)"
+
+shopt -s nullglob
+moved=0 skipped=0 total=0
+for src in keys/keys.kaswallet-*.json; do
+    total=$((total + 1))
+    # Only migrate a real, non-symlink file. Docker's legacy single-file bind
+    # syntax can create a DIRECTORY named keys.kaswallet-N.json when the host
+    # file was missing; never relocate that (or a symlink) as if it were a key.
+    if [[ -L "$src" || ! -f "$src" ]]; then
+        echo "  ! skip (not a regular file): $src"; skipped=$((skipped + 1)); continue
+    fi
+    base="$(basename "$src")"
+    if [[ ! "$base" =~ ^keys\.kaswallet-([0-9]+)\.json$ ]]; then
+        echo "  ? skip (unrecognized name): $src"; skipped=$((skipped + 1)); continue
+    fi
+    idx="${BASH_REMATCH[1]}"
+    dst_dir="keys/kaswallet-${idx}"
+    dst="${dst_dir}/keys.json"
+
+    if [[ -e "$dst" ]]; then
+        echo "  = skip worker $idx: $dst already exists (leaving $src in place for you to reconcile)"
+        skipped=$((skipped + 1)); continue
+    fi
+
+    echo "  + worker $idx: $src -> $dst"
+    run bash -c "umask 077 && mkdir -p '$dst_dir'"
+    run mv "$src" "$dst"
+    run chmod 600 "$dst"          # keys are owner-only
+    run chmod 700 "$dst_dir"
+    moved=$((moved + 1))
+done
+shopt -u nullglob
+
+echo
+echo "Done: $moved migrated, $skipped skipped, $total flat key file(s) found."
+if [[ "$total" == 0 ]]; then
+    echo "Nothing to migrate (already on the per-worker layout, or no keys generated yet)."
+fi
+if [[ "$moved" -gt 0 && "$DRY_RUN" == 0 ]]; then
+    echo
+    echo "Next: recreate the affected services with the directory-mount compose, e.g."
+    echo "  docker compose --profile <frontend-wN> up -d"
+fi

--- a/scripts/lib/setup-common.sh
+++ b/scripts/lib/setup-common.sh
@@ -341,7 +341,7 @@ update_env_var() {
 generate_wallet() {
     local index="$1"
     local password="$2"
-    local keyfile="keys/keys.kaswallet-${index}.json"
+    local keyfile="keys/kaswallet-${index}/keys.json"
 
     log "Generating wallet $index..."
 
@@ -357,6 +357,11 @@ generate_wallet() {
     fi
     chmod 600 "$wallet_log" 2>/dev/null || true
 
+    # Per-worker key DIRECTORY (owner-only). The daemon mounts this directory
+    # (not the file), so kaswallet's atomic keys.json save can create a temp
+    # file beside keys.json and rename over it.
+    (umask 077 && mkdir -p "$PROJECT_DIR/keys/kaswallet-${index}")
+
     # Use expect for password prompts; pass the password via env and run as the caller.
     # shellcheck disable=SC2016 # Variables are intentionally spliced via quote-breaking, not expanded inside single quotes
     if ! WALLET_PASS="$password" expect -c '
@@ -365,7 +370,7 @@ generate_wallet() {
             -v "'"$PROJECT_DIR"'/keys:/keys" \
             --entrypoint /app/kaswallet-create \
             '"$KASWALLET_IMAGE"' '"$KASWALLET_FLAG"' \
-            -k /keys/keys.kaswallet-'"${index}"'.json
+            -k /keys/kaswallet-'"${index}"'/keys.json
         expect "password:"
         send -- "$env(WALLET_PASS)\r"
         expect "password"
@@ -708,14 +713,28 @@ run_setup() {
     # Check for existing wallet files
     EXISTING_WALLETS=()
     MISSING_WALLETS=()
+    LEGACY_FLAT_WALLETS=()
     for i in $(seq 0 $((NUM_WORKERS - 1))); do
-        keyfile="keys/keys.kaswallet-${i}.json"
+        keyfile="keys/kaswallet-${i}/keys.json"
         if [[ -f "$keyfile" ]]; then
             EXISTING_WALLETS+=("$i")
+        elif [[ -f "keys/keys.kaswallet-${i}.json" ]]; then
+            # Legacy flat-layout key present but not yet migrated to the
+            # per-worker directory. Do NOT treat it as missing — that would
+            # generate a NEW wallet identity and orphan the funded legacy key.
+            LEGACY_FLAT_WALLETS+=("$i")
         else
             MISSING_WALLETS+=("$i")
         fi
     done
+
+    if [[ ${#LEGACY_FLAT_WALLETS[@]} -gt 0 ]]; then
+        die "Found legacy flat key files (keys/keys.kaswallet-N.json) for workers: ${LEGACY_FLAT_WALLETS[*]}.
+Migrate them to the per-worker directory layout before continuing (this preserves your existing wallet identities):
+    scripts/dev/migrate-keys-to-subdirs.sh --dry-run   # preview
+    scripts/dev/migrate-keys-to-subdirs.sh             # migrate
+Then re-run setup."
+    fi
 
     if [[ ${#EXISTING_WALLETS[@]} -gt 0 ]]; then
         log "Found existing wallet files for workers: ${EXISTING_WALLETS[*]}"
@@ -727,7 +746,9 @@ run_setup() {
             backup_dir="keys/backup.$(date +%Y%m%d_%H%M%S)"
             mkdir -p "$backup_dir"
             for i in "${EXISTING_WALLETS[@]}"; do
-                mv "keys/keys.kaswallet-${i}.json" "$backup_dir/"
+                # Back up the whole per-worker directory (preserves per-worker
+                # separation in the backup; avoids keys.json name collisions).
+                mv "keys/kaswallet-${i}" "$backup_dir/"
             done
             log "Backed up existing wallets to $backup_dir"
             MISSING_WALLETS=()

--- a/versions.mainnet.env
+++ b/versions.mainnet.env
@@ -5,7 +5,7 @@ RETH_VERSION=3.0
 # switch; the v3.0 frontend emits lane/subnetwork transactions that mainnet only
 # accepts post-fork. Bump these to 3.0 in the post-Toccata follow-up
 # (see doc/node-operations/upgrade-mainnet-v2.3-to-v3.0.md).
-KASWALLET_VERSION=2.3
-RPC_PROVIDER_VERSION=2.3
+KASWALLET_VERSION=3.0
+RPC_PROVIDER_VERSION=3.0
 NODE_HEALTH_CHECK_VERSION=2.1
 ATAN_UPLOADER_VERSION=2.1


### PR DESCRIPTION
## Summary

Unblocks kaswallet's crash-safe atomic `keys.json` save (ENG-1186) on the fleet. That save writes a temp file and `rename`s it over `keys.json`; the deployment bind-mounts `keys.json` as a **single file**, and you cannot `rename` over a mount point → **EBUSY** → the daemon sync loop panics → **crash-loop** (reproduced on `igra_stage_7`: `kaswallet-0` restarts=11, rpc-provider-0 unhealthy downstream). No keys are lost — the atomic save fails safely.

Fix: mount each worker's key **directory** instead of the single file, so the rename targets a real directory. Keeps per-worker key isolation and full power-loss durability. **kaswallet is unchanged.**

## Changes

- **`docker-compose.yml` / `docker-compose.devnet.yml`** — `./keys/keys.kaswallet-N.json:/app/keys.json` → `./keys/kaswallet-N:/app/keys`; the shared `--keys /app/keys.json` anchor → `--keys /app/keys/keys.json`. The `dependency-watch` and `parse-network-slug` volumes are retained on every kaswallet block.
- **`scripts/lib/setup-common.sh`** — generate into `keys/kaswallet-N/keys.json` (per-worker dir + `mkdir`); the regen backup moves the per-worker directory. **Refuses to run** when legacy flat `keys/keys.kaswallet-N.json` files are present, with an instruction to migrate first — this prevents silently generating a *new wallet identity* over an un-migrated key.
- **`scripts/dev/migrate-keys-to-subdirs.sh`** (new) — one-shot, idempotent migration: moves each `keys/keys.kaswallet-N.json` → `keys/kaswallet-N/keys.json`, normalizes perms (dir 700 / file 600), leaves `jwt.hex`/`keys.core.json`/backups untouched. `--dry-run`; strict arg parsing (a mistyped flag errors instead of migrating); skips non-regular-file sources (guards against Docker's legacy directory-instead-of-file footgun); best-effort `flock`.
- **Docs / env** — `README.md`, `doc/kaspa-wallet.md`, `doc/quick-setup-mainnet.md`, `doc/quick-setup-galleon-testnet.md`, `.env.mainnet.example`, `.env.galleon-testnet.example`: per-worker directory layout, updated `kaswallet-create -k` paths, and the migrate-before-recreate rollout ordering.
- **CI** — add the new migration script to the `compose-config.yml` shellcheck list.

## Rollout (per node — order matters)

1. `scripts/dev/migrate-keys-to-subdirs.sh --dry-run` then run it (moves existing keys into per-worker dirs).
2. `docker compose --profile <frontend-wN> up -d` (new directory mounts).

The migration must precede the atomic-save kaswallet image on any existing single-file-mount node, or it EBUSY-crash-loops. `igra_stage_7` already runs the atomic image → migration + `up -d` fixes it (and is the live end-to-end test).

## Validation

- `docker compose --profile backend --profile frontend-w5 config -q` on both compose files → OK; `parse-network-slug` guardrail preserved on all kaswallet blocks.
- `shellcheck` clean (new migration script); `bash -n` OK for both scripts.
- Migration script exercised on a scratch fixture: dry-run is side-effect-free; real run moves files with correct perms and leaves `jwt.hex` alone; a mistyped `--dryrun` flag is rejected; a directory masquerading as a key file is skipped; a second run is a no-op (idempotent).
- Reviewed via multi-model review (`colab-review`); all `fix-first` findings applied (missed flat-path references in setup guides/env examples, legacy-wallet misclassification, migration-script guards, rollout-ordering docs, CI shellcheck).

## Follow-ups (not in this PR)
- stage-7 live verification (migration + `up -d`) — operator action.
- Optional: CI fixture test for the migration script; broaden `compose-config` to assert the keys mount on workers 5–19.
