### PR TITLE
[ENG-1191] feat(devnet): L2 load + lane-id validation harness

### DIFF
--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -72,18 +72,20 @@ IGRA_LAUNCH_DAA_SCORE=0
 L1_REFERENCE_DAA_SCORE=0
 L1_REFERENCE_TIMESTAMP=1735689600  # 2025-01-01T00:00:00Z
 MIN_PROTOCOL_FEE_PER_GAS_GWEI=2000
-# Hash of the EL genesis block. kaspad takes it as --igra-genesis-hash
-# (docker-compose.devnet.yml:118) and halts with "Genesis hash mismatch" if the
-# execution layer reports anything else, so it must match the genesis that
-# run-igra-el.sh derives from the variables above (CHAIN_ID, ONE_TIME_ADDRESS,
-# the DAA/timestamp references, TX_ID_PREFIX, MIN_PROTOCOL_FEE_PER_GAS_GWEI,
-# IGRA_LOCK_SCRIPT_PUBKEY, IGRA_ENTRY_MIN_AMOUNT, the three *_BLOCK_HASH values,
-# and the SHA256 of the rendered network-params.md that becomes extraData).
-# Change any of those and this value must be recomputed:
-#   curl -s http://127.0.0.1:9545 -H 'content-type: application/json' \
+# Hash of the EL genesis block. kaspad takes it as --igra-genesis-hash and halts
+# with "Genesis hash mismatch" if the execution layer reports anything else, so it
+# must match the genesis that run-igra-el.sh derives from the variables above
+# (IGRA_CHAIN_ID, EL_ONE_TIME_ADDRESS, IGRA_LAUNCH_DAA_SCORE and the DAA/timestamp
+# references, TX_ID_PREFIX, MIN_PROTOCOL_FEE_PER_GAS_GWEI, IGRA_LOCK_SCRIPT_PUBKEY,
+# IGRA_ENTRY_MIN_AMOUNT, the three *_BLOCK_HASH values, and the SHA256 of the
+# rendered network-params.md that becomes extraData). This value was probed under
+# this template's own IGRA_LAUNCH_DAA_SCORE=0. Change any of those inputs and it
+# must be recomputed AND the EL data dir wiped, or kaspad halts on the mismatch:
+#   docker compose -f docker-compose.devnet.yml down -v && rm -rf data/reth
+#   curl -s "http://127.0.0.1:${EL_RPC_HOST_PORT:-9545}" -H 'content-type: application/json' \
 #     --data '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x0",false]}' \
 #     | jq -r .result.hash
-GENESIS_BLOCK_HASH=0x174a4dac41d61c27ca946f92154e663d65e4581003c8c6cde86ae29d3b9b00de
+GENESIS_BLOCK_HASH=0xd9f22bfc80bc3dd812044abc940c72239c3c66addfb917c47a5af3768ead0d4e
 
 # --- Kaspad Ports ---
 # Distinct ports to avoid clashing with mainnet/testnet on the same host.

--- a/.env.devnet.example
+++ b/.env.devnet.example
@@ -72,7 +72,18 @@ IGRA_LAUNCH_DAA_SCORE=0
 L1_REFERENCE_DAA_SCORE=0
 L1_REFERENCE_TIMESTAMP=1735689600  # 2025-01-01T00:00:00Z
 MIN_PROTOCOL_FEE_PER_GAS_GWEI=2000
-GENESIS_BLOCK_HASH=0xd9f22bfc80bc3dd812044abc940c72239c3c66addfb917c47a5af3768ead0d4e
+# Hash of the EL genesis block. kaspad takes it as --igra-genesis-hash
+# (docker-compose.devnet.yml:118) and halts with "Genesis hash mismatch" if the
+# execution layer reports anything else, so it must match the genesis that
+# run-igra-el.sh derives from the variables above (CHAIN_ID, ONE_TIME_ADDRESS,
+# the DAA/timestamp references, TX_ID_PREFIX, MIN_PROTOCOL_FEE_PER_GAS_GWEI,
+# IGRA_LOCK_SCRIPT_PUBKEY, IGRA_ENTRY_MIN_AMOUNT, the three *_BLOCK_HASH values,
+# and the SHA256 of the rendered network-params.md that becomes extraData).
+# Change any of those and this value must be recomputed:
+#   curl -s http://127.0.0.1:9545 -H 'content-type: application/json' \
+#     --data '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x0",false]}' \
+#     | jq -r .result.hash
+GENESIS_BLOCK_HASH=0x174a4dac41d61c27ca946f92154e663d65e4581003c8c6cde86ae29d3b9b00de
 
 # --- Kaspad Ports ---
 # Distinct ports to avoid clashing with mainnet/testnet on the same host.
@@ -92,6 +103,12 @@ IGRA_ENTRY_MIN_AMOUNT=100000000
 # --- Mining Configuration ---
 MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s
 MINING_THREADS=1
+# Hard cap on the local miner's block-submission rate: minimum milliseconds
+# between submitted blocks, enforced globally across miner threads. Keeps the
+# number of blocks per DAA-score window under viaduct's limit of 10, so the L2
+# (viaduct) does not hit VerifierError::TooManyBlocks and panic on fast local
+# mining. 150 => <= ~6.6 blocks/s (safe margin under 10). Set 0 to disable.
+MINING_MIN_BLOCK_INTERVAL_MS=150
 
 # --- Execution Layer Configuration ---
 EL_ONE_TIME_ADDRESS=0x2B7dABDF193677725C6Ecd25dc7CfAf6054193d8
@@ -109,6 +126,8 @@ KASPA_BLOCK_HASH=0x0000000000000000000000000000000000000000000000000000000000000
 # --- RPC Configuration ---
 # Read-only by default on the local devnet; operators opt into wallet-backed
 # write methods by setting this to false (and funding the wallets).
+# RPC_READ_ONLY=true rejects eth_sendRawTransaction. For L2 load tests
+# (scripts/dev/run-devnet-l2-load.sh) set RPC_READ_ONLY=false.
 RPC_READ_ONLY=true
 # Host port for RPC provider (eth_* JSON-RPC).
 RPC_PORT=8555

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 repos/
+build/
 jwt.hex
 keys.json
 logs/

--- a/scripts/dev/patches/cpuminer-min-block-interval.patch
+++ b/scripts/dev/patches/cpuminer-min-block-interval.patch
@@ -57,25 +57,26 @@ index 09e0176..070c9cf 100644
          Arc,
      },
 -    time::Duration,
-+    time::{Duration, SystemTime, UNIX_EPOCH},
++    time::{Duration, Instant},
  };
  use tokio::{
      sync::mpsc::Sender,
-@@ -47,14 +47,38 @@ pub fn get_num_cpus(n_cpus: Option<u16>) -> u16 {
+@@ -47,14 +47,40 @@ pub fn get_num_cpus(n_cpus: Option<u16>) -> u16 {
  
  const LOG_RATE: Duration = Duration::from_secs(10);
  
 +/// Global, cross-thread submission gate. Returns `true` and atomically claims
-+/// the slot (storing `now_ms`) iff at least `interval_ms` has elapsed since the
-+/// last claimed submission; otherwise returns `false` without mutating. A CAS
-+/// loop guarantees at most one thread wins the slot per interval.
++/// the monotonic `now_ms` slot iff at least `interval_ms` elapsed since the last
++/// claim; else `false` without mutating. Seed 0 = never-submitted (always wins);
++/// a claim never stores 0 so the seed cannot recur. CAS keeps one winner per slot.
 +fn try_claim_submit_slot(last_submit_ms: &AtomicU64, now_ms: u64, interval_ms: u64) -> bool {
 +    loop {
 +        let prev = last_submit_ms.load(Ordering::Relaxed);
-+        if now_ms.saturating_sub(prev) < interval_ms {
++        if prev != 0 && now_ms.saturating_sub(prev) < interval_ms {
 +            return false;
 +        }
-+        match last_submit_ms.compare_exchange_weak(prev, now_ms, Ordering::SeqCst, Ordering::Relaxed) {
++        let claim = now_ms.max(1);
++        match last_submit_ms.compare_exchange_weak(prev, claim, Ordering::SeqCst, Ordering::Relaxed) {
 +            Ok(_) => return true,
 +            Err(_) => continue,
 +        }
@@ -83,8 +84,9 @@ index 09e0176..070c9cf 100644
 +}
 +
 +#[inline]
-+fn now_epoch_ms() -> u64 {
-+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
++fn now_monotonic_ms() -> u64 {
++    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
++    START.get_or_init(Instant::now).elapsed().as_millis() as u64
 +}
 +
  impl MinerManager {
@@ -100,7 +102,7 @@ index 09e0176..070c9cf 100644
          let watch = WatchSwap::empty();
          let handles = Self::launch_cpu_threads(
              send_channel.clone(),
-@@ -63,6 +87,8 @@ impl MinerManager {
+@@ -63,6 +89,8 @@ impl MinerManager {
              shutdown,
              n_cpus,
              throttle,
@@ -109,7 +111,7 @@ index 09e0176..070c9cf 100644
          )
          .collect();
  
-@@ -84,6 +110,8 @@ impl MinerManager {
+@@ -84,6 +112,8 @@ impl MinerManager {
          shutdown: ShutdownHandler,
          n_cpus: Option<u16>,
          throttle: Option<Duration>,
@@ -118,7 +120,7 @@ index 09e0176..070c9cf 100644
      ) -> impl Iterator<Item = MinerHandler> {
          let n_cpus = get_num_cpus(n_cpus);
          info!("Launching: {} cpu miners", n_cpus);
-@@ -93,6 +121,8 @@ impl MinerManager {
+@@ -93,6 +123,8 @@ impl MinerManager {
                  work_channel.clone(),
                  hashes_tried.clone(),
                  throttle,
@@ -127,7 +129,7 @@ index 09e0176..070c9cf 100644
                  shutdown.clone(),
              )
          })
-@@ -122,6 +152,8 @@ impl MinerManager {
+@@ -122,6 +154,8 @@ impl MinerManager {
          mut block_channel: WatchSwap<pow::State>,
          hashes_tried: Arc<AtomicU64>,
          throttle: Option<Duration>,
@@ -136,13 +138,13 @@ index 09e0176..070c9cf 100644
          shutdown: ShutdownHandler,
      ) -> MinerHandler {
          // We mark it cold as the function is not called often, and it's not in the hot path
-@@ -146,7 +178,14 @@ impl MinerManager {
+@@ -146,7 +180,14 @@ impl MinerManager {
                  state_ref.nonce = nonce.0;
  
                  if let Some(block) = state_ref.generate_block_if_pow() {
 -                    found_block(&send_channel, block)?;
 +                    let allowed = if min_block_interval_ms > 0 {
-+                        try_claim_submit_slot(&last_submit_ms, now_epoch_ms(), min_block_interval_ms)
++                        try_claim_submit_slot(&last_submit_ms, now_monotonic_ms(), min_block_interval_ms)
 +                    } else {
 +                        true
 +                    };
@@ -152,7 +154,7 @@ index 09e0176..070c9cf 100644
                  }
                  nonce += Wrapping(1);
  
-@@ -241,3 +280,26 @@ mod benches {
+@@ -241,3 +282,34 @@ mod benches {
          });
      }
  }
@@ -177,5 +179,13 @@ index 09e0176..070c9cf 100644
 +    fn exactly_at_interval_boundary_allowed() {
 +        let last = AtomicU64::new(1000);
 +        assert!(try_claim_submit_slot(&last, 1150, 150), "elapsed == interval allowed");
++    }
++
++    #[test]
++    fn seed_never_recurs_and_first_block_always_wins() {
++        let last = AtomicU64::new(0);
++        assert!(try_claim_submit_slot(&last, 10, 150), "first block wins even below interval from start");
++        assert_ne!(last.load(Ordering::Relaxed), 0, "claim must not restore the never-submitted seed");
++        assert!(!try_claim_submit_slot(&last, 20, 150), "second block within interval is gated");
 +    }
 +}

--- a/scripts/dev/patches/cpuminer-min-block-interval.patch
+++ b/scripts/dev/patches/cpuminer-min-block-interval.patch
@@ -1,0 +1,181 @@
+diff --git a/src/cli.rs b/src/cli.rs
+index 3c1d4b1..f9a9247 100644
+--- a/src/cli.rs
++++ b/src/cli.rs
+@@ -41,10 +41,15 @@ pub struct Opt {
+     #[clap(long = "throttle", display_order = 9)]
+     /// Throttle (milliseconds) between each pow hash generation (used for development testing)
+     pub throttle: Option<u64>,
+-    #[clap(long, display_order = 10)]
++    #[clap(long = "min-block-interval-ms", display_order = 12)]
++    /// Hard global minimum milliseconds between SUBMITTED blocks across all
++    /// threads (blocks found sooner are dropped). Caps blocks/sec so devnet
++    /// stays under viaduct's per-window block limit. 0 or unset = disabled.
++    pub min_block_interval_ms: Option<u64>,
++    #[clap(long, display_order = 13)]
+     /// Output logs in alternative format (same as kaspad)
+     pub altlogs: bool,
+-    #[clap(long = "user-agent-suffix", display_order = 11)]
++    #[clap(long = "user-agent-suffix", display_order = 14)]
+     /// Custom user agent suffix (max 20 characters)
+     pub user_agent_suffix: Option<String>,
+ }
+diff --git a/src/main.rs b/src/main.rs
+index dca2a3c..7c8e2e4 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -73,6 +73,7 @@ async fn main() -> Result<(), Error> {
+     builder.init();
+ 
+     let throttle = opt.throttle.map(Duration::from_millis);
++    let min_block_interval_ms = opt.min_block_interval_ms.unwrap_or(0);
+     let shutdown = ShutdownHandler(Arc::new(AtomicBool::new(false)));
+     let _shutdown_when_dropped = shutdown.arm();
+ 
+@@ -96,8 +97,13 @@ async fn main() -> Result<(), Error> {
+         client.client_send(NotifyNewBlockTemplateRequestMessage {}).await?;
+         client.client_get_block_template().await?;
+ 
+-        let mut miner_manager =
+-            MinerManager::new(client.send_channel.clone(), opt.num_threads, throttle, shutdown.clone());
++        let mut miner_manager = MinerManager::new(
++            client.send_channel.clone(),
++            opt.num_threads,
++            throttle,
++            min_block_interval_ms,
++            shutdown.clone(),
++        );
+         client.listen(&mut miner_manager, shutdown.clone()).await?;
+         warn!("Disconnected from kaspad, retrying");
+     }
+diff --git a/src/miner.rs b/src/miner.rs
+index 09e0176..070c9cf 100644
+--- a/src/miner.rs
++++ b/src/miner.rs
+@@ -12,7 +12,7 @@ use std::{
+         atomic::{AtomicU64, AtomicUsize, Ordering},
+         Arc,
+     },
+-    time::Duration,
++    time::{Duration, SystemTime, UNIX_EPOCH},
+ };
+ use tokio::{
+     sync::mpsc::Sender,
+@@ -47,14 +47,38 @@ pub fn get_num_cpus(n_cpus: Option<u16>) -> u16 {
+ 
+ const LOG_RATE: Duration = Duration::from_secs(10);
+ 
++/// Global, cross-thread submission gate. Returns `true` and atomically claims
++/// the slot (storing `now_ms`) iff at least `interval_ms` has elapsed since the
++/// last claimed submission; otherwise returns `false` without mutating. A CAS
++/// loop guarantees at most one thread wins the slot per interval.
++fn try_claim_submit_slot(last_submit_ms: &AtomicU64, now_ms: u64, interval_ms: u64) -> bool {
++    loop {
++        let prev = last_submit_ms.load(Ordering::Relaxed);
++        if now_ms.saturating_sub(prev) < interval_ms {
++            return false;
++        }
++        match last_submit_ms.compare_exchange_weak(prev, now_ms, Ordering::SeqCst, Ordering::Relaxed) {
++            Ok(_) => return true,
++            Err(_) => continue,
++        }
++    }
++}
++
++#[inline]
++fn now_epoch_ms() -> u64 {
++    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
++}
++
+ impl MinerManager {
+     pub fn new(
+         send_channel: Sender<KaspadMessage>,
+         n_cpus: Option<u16>,
+         throttle: Option<Duration>,
++        min_block_interval_ms: u64,
+         shutdown: ShutdownHandler,
+     ) -> Self {
+         let hashes_tried = Arc::new(AtomicU64::new(0));
++        let last_submit_ms = Arc::new(AtomicU64::new(0));
+         let watch = WatchSwap::empty();
+         let handles = Self::launch_cpu_threads(
+             send_channel.clone(),
+@@ -63,6 +87,8 @@ impl MinerManager {
+             shutdown,
+             n_cpus,
+             throttle,
++            min_block_interval_ms,
++            last_submit_ms,
+         )
+         .collect();
+ 
+@@ -84,6 +110,8 @@ impl MinerManager {
+         shutdown: ShutdownHandler,
+         n_cpus: Option<u16>,
+         throttle: Option<Duration>,
++        min_block_interval_ms: u64,
++        last_submit_ms: Arc<AtomicU64>,
+     ) -> impl Iterator<Item = MinerHandler> {
+         let n_cpus = get_num_cpus(n_cpus);
+         info!("Launching: {} cpu miners", n_cpus);
+@@ -93,6 +121,8 @@ impl MinerManager {
+                 work_channel.clone(),
+                 hashes_tried.clone(),
+                 throttle,
++                min_block_interval_ms,
++                last_submit_ms.clone(),
+                 shutdown.clone(),
+             )
+         })
+@@ -122,6 +152,8 @@ impl MinerManager {
+         mut block_channel: WatchSwap<pow::State>,
+         hashes_tried: Arc<AtomicU64>,
+         throttle: Option<Duration>,
++        min_block_interval_ms: u64,
++        last_submit_ms: Arc<AtomicU64>,
+         shutdown: ShutdownHandler,
+     ) -> MinerHandler {
+         // We mark it cold as the function is not called often, and it's not in the hot path
+@@ -146,7 +178,14 @@ impl MinerManager {
+                 state_ref.nonce = nonce.0;
+ 
+                 if let Some(block) = state_ref.generate_block_if_pow() {
+-                    found_block(&send_channel, block)?;
++                    let allowed = if min_block_interval_ms > 0 {
++                        try_claim_submit_slot(&last_submit_ms, now_epoch_ms(), min_block_interval_ms)
++                    } else {
++                        true
++                    };
++                    if allowed {
++                        found_block(&send_channel, block)?;
++                    }
+                 }
+                 nonce += Wrapping(1);
+ 
+@@ -241,3 +280,26 @@ mod benches {
+         });
+     }
+ }
++
++#[cfg(test)]
++mod min_interval_tests {
++    use super::try_claim_submit_slot;
++    use std::sync::atomic::{AtomicU64, Ordering};
++
++    #[test]
++    fn first_submit_allowed_then_gated_then_allowed() {
++        let last = AtomicU64::new(0);
++        assert!(try_claim_submit_slot(&last, 1000, 150), "first submit allowed");
++        assert_eq!(last.load(Ordering::Relaxed), 1000);
++        assert!(!try_claim_submit_slot(&last, 1100, 150), "within interval blocked");
++        assert_eq!(last.load(Ordering::Relaxed), 1000, "blocked submit does not advance");
++        assert!(try_claim_submit_slot(&last, 1200, 150), "after interval allowed");
++        assert_eq!(last.load(Ordering::Relaxed), 1200);
++    }
++
++    #[test]
++    fn exactly_at_interval_boundary_allowed() {
++        let last = AtomicU64::new(1000);
++        assert!(try_claim_submit_slot(&last, 1150, 150), "elapsed == interval allowed");
++    }
++}

--- a/scripts/dev/run-devnet-cpuminer.sh
+++ b/scripts/dev/run-devnet-cpuminer.sh
@@ -116,6 +116,8 @@ is_positive_int "$MINING_THREADS" || \
     die "MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')"
 is_port "$KASPAD_GRPC_PORT" || \
     die "KASPAD_GRPC_PORT must be an integer in 1-65535 (got: '${KASPAD_GRPC_PORT:-<unset>}')"
+is_uint "$MINING_MIN_BLOCK_INTERVAL_MS" || \
+    die "MINING_MIN_BLOCK_INTERVAL_MS must be a non-negative integer in ms, 0 disables (got: '${MINING_MIN_BLOCK_INTERVAL_MS:-<unset>}')"
 
 # --- clone + build (unless SKIP_BUILD reuses an existing binary) ---
 build_miner() {
@@ -197,11 +199,13 @@ fi
 args=(-a "$MINING_ADDRESS" -s "$KASPAD_RPC_HOST" -p "$KASPAD_GRPC_PORT" -t "$MINING_THREADS")
 [ "$MINE_WHEN_NOT_SYNCED" = "true" ] && args+=(--mine-when-not-synced)
 # Throttle block production to stay under viaduct's per-window cap; 0 disables.
-case "$MINING_MIN_BLOCK_INTERVAL_MS" in
-    ''|*[!0-9]*) ;;                                   # non-numeric/empty: skip
-    0) ;;                                             # 0: disabled
-    *) args+=(--min-block-interval-ms "$MINING_MIN_BLOCK_INTERVAL_MS") ;;
-esac
+if [ "$MINING_MIN_BLOCK_INTERVAL_MS" -gt 0 ]; then
+    if "$BIN" --help 2>&1 | grep -q -- '--min-block-interval-ms'; then
+        args+=(--min-block-interval-ms "$MINING_MIN_BLOCK_INTERVAL_MS")
+    else
+        warn "$BIN predates the min-block-interval patch; running WITHOUT the rate cap. Rebuild (unset SKIP_BUILD) to apply it."
+    fi
+fi
 
 log "Starting cpuminer -> $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT (address ${MINING_ADDRESS}, ${MINING_THREADS} threads)"
 log "Press Ctrl+C to stop."

--- a/scripts/dev/run-devnet-cpuminer.sh
+++ b/scripts/dev/run-devnet-cpuminer.sh
@@ -45,6 +45,10 @@ shell/CLI values take precedence over the file.
 Environment variables:
   MINING_ADDRESS          Reward address; must be a devnet address (kaspadev:...).
   MINING_THREADS          CPU miner threads (positive integer). Default: 1.
+  MINING_MIN_BLOCK_INTERVAL_MS
+                          Minimum interval between mined blocks, in ms. Passed
+                          as --min-block-interval-ms when a positive integer;
+                          0 disables the throttle. Default: 150.
   KASPAD_GRPC_PORT        Devnet kaspad gRPC port on the host. Default: 16610.
   KASPAD_RPC_HOST         Host the miner dials. Default: 127.0.0.1 (NOT the
                           compose-internal KASPAD_HOST, which is unreachable here).
@@ -86,6 +90,7 @@ source "$SCRIPT_DIR/../lib/devnet-env.sh"
 
 resolve MINING_ADDRESS ""
 resolve MINING_THREADS 1
+resolve MINING_MIN_BLOCK_INTERVAL_MS 150
 resolve KASPAD_GRPC_PORT 16610
 # Host loopback, not the compose-internal KASPAD_HOST (=kaspad).
 resolve KASPAD_RPC_HOST 127.0.0.1
@@ -144,6 +149,20 @@ build_miner() {
         fi
     fi
 
+    # Apply the min-block-interval throttle patch (idempotent). Keeps devnet block
+    # production under viaduct's per-window cap. See scripts/dev/patches/.
+    PATCH_FILE="$SCRIPT_DIR/patches/cpuminer-min-block-interval.patch"
+    if [ -f "$PATCH_FILE" ]; then
+        if git -C "$MINER_DIR" apply --reverse --check "$PATCH_FILE" 2>/dev/null; then
+            log "min-block-interval patch already applied"
+        elif git -C "$MINER_DIR" apply --check "$PATCH_FILE" 2>/dev/null; then
+            git -C "$MINER_DIR" apply "$PATCH_FILE"
+            log "applied min-block-interval patch"
+        else
+            warn "min-block-interval patch does not apply cleanly; miner will run WITHOUT the rate cap"
+        fi
+    fi
+
     # kaspanet/cpuminer is a single CPU-only crate (no GPU crates), so a plain
     # release build produces target/release/kaspa-miner. --locked builds against
     # the committed Cargo.lock so dependency versions cannot drift silently.
@@ -177,6 +196,12 @@ fi
 # network flag to pick a default port, which we always set explicitly with -p.
 args=(-a "$MINING_ADDRESS" -s "$KASPAD_RPC_HOST" -p "$KASPAD_GRPC_PORT" -t "$MINING_THREADS")
 [ "$MINE_WHEN_NOT_SYNCED" = "true" ] && args+=(--mine-when-not-synced)
+# Throttle block production to stay under viaduct's per-window cap; 0 disables.
+case "$MINING_MIN_BLOCK_INTERVAL_MS" in
+    ''|*[!0-9]*) ;;                                   # non-numeric/empty: skip
+    0) ;;                                             # 0: disabled
+    *) args+=(--min-block-interval-ms "$MINING_MIN_BLOCK_INTERVAL_MS") ;;
+esac
 
 log "Starting cpuminer -> $KASPAD_RPC_HOST:$KASPAD_GRPC_PORT (address ${MINING_ADDRESS}, ${MINING_THREADS} threads)"
 log "Press Ctrl+C to stop."

--- a/scripts/dev/run-devnet-l2-load.sh
+++ b/scripts/dev/run-devnet-l2-load.sh
@@ -18,7 +18,13 @@ FINALITY_OVERRIDE="${FINALITY_PERIOD_SECONDS:-}"
 LAUNCH_DAA_OVERRIDE="${IGRA_LAUNCH_DAA_SCORE:-}"
 
 set -a; [ -f "$ROOT_DIR/.env" ] && . "$ROOT_DIR/.env"; set +a
+[ "${NETWORK:-}" = "devnet" ] || {
+    echo "refusing to run: .env has NETWORK='${NETWORK:-<unset>}', expected 'devnet'" >&2
+    exit 2
+}
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-igra-devnet}"
 RPC_PORT="${RPC_PORT:-8555}"
+EL_RPC_HOST_PORT="${EL_RPC_HOST_PORT:-9545}"
 FINALITY_PERIOD_SECONDS="${FINALITY_OVERRIDE:-60}"
 L2_ALIVE_TIMEOUT_SECS="${L2_ALIVE_TIMEOUT_SECS:-900}"
 IGRA_LAUNCH_DAA_SCORE="${LAUNCH_DAA_OVERRIDE:-10}"
@@ -35,17 +41,23 @@ log(){ echo "[l2-load] $*"; }
 for t in docker jq cast websocat; do command -v "$t" >/dev/null || { echo "missing tool: $t" >&2; exit 2; }; done
 [ -d "$IGRA_E2E_DIR" ] || { echo "IGRA_E2E_DIR not found: $IGRA_E2E_DIR" >&2; exit 2; }
 
-mkdir -p "$RUN_DIR"
+(umask 077 && mkdir -p "$RUN_DIR")
 
 export IGRA_LAUNCH_DAA_SCORE FINALITY_PERIOD_SECONDS
 
 # --- 0b. reconcile GENESIS_BLOCK_HASH with the EL this config builds ---------
+mkdir -p "$ROOT_DIR/data/reth" "$ROOT_DIR/data/reth-ipc" \
+         "$ROOT_DIR/network-params" "$ROOT_DIR/keys"
+[ -f "$ROOT_DIR/keys/jwt.hex" ] || {
+    (umask 077 && openssl rand -hex 32 > "$ROOT_DIR/keys/jwt.hex")
+}
 log "probing the EL genesis hash for IGRA_LAUNCH_DAA_SCORE=$IGRA_LAUNCH_DAA_SCORE"
+trap 'COMPOSE_PROFILES=backend docker compose -f docker-compose.devnet.yml down >/dev/null 2>&1 || true' EXIT INT TERM
 COMPOSE_PROFILES=backend docker compose -f docker-compose.devnet.yml up -d execution-layer \
     > "$RUN_DIR/genesis-probe.log" 2>&1
 GENESIS_BLOCK_HASH=""
 for _ in $(seq 1 60); do
-    GENESIS_BLOCK_HASH="$(curl -s http://127.0.0.1:9545 -H 'content-type: application/json' \
+    GENESIS_BLOCK_HASH="$(curl -s "http://127.0.0.1:${EL_RPC_HOST_PORT}" -H 'content-type: application/json' \
         --data '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x0",false]}' \
         | jq -r '.result.hash // empty' 2>/dev/null || true)"
     [ -n "$GENESIS_BLOCK_HASH" ] && break
@@ -53,6 +65,7 @@ for _ in $(seq 1 60); do
 done
 COMPOSE_PROFILES=backend docker compose -f docker-compose.devnet.yml down \
     >> "$RUN_DIR/genesis-probe.log" 2>&1
+trap - EXIT INT TERM
 case "$GENESIS_BLOCK_HASH" in
     0x*) ;;
     *) echo "could not probe the EL genesis hash (see $RUN_DIR/genesis-probe.log)" >&2; exit 8 ;;
@@ -67,14 +80,13 @@ printf '%s' "$SETUP_ANSWERS" \
     | IGRA_ENABLE=true RPC_READ_ONLY=false IGRA_SKIP_LOCK_SCRIPT_CHECK=true \
       FINALITY_PERIOD_SECONDS="$FINALITY_PERIOD_SECONDS" "$ROOT_DIR/scripts/setup-devnet.sh"
 
-setup_pw="$(awk -F= '$1 == "W0_KASWALLET_PASSWORD" { print $2; exit }' "$ROOT_DIR/.env" 2>/dev/null || true)"
-[ -z "$setup_pw" ] || {
-    echo "setup prompt answers desynced: W0_KASWALLET_PASSWORD is non-empty" >&2
+grep -q '^W0_KASWALLET_PASSWORD=$' "$ROOT_DIR/.env" || {
+    echo "setup prompt answers desynced: W0_KASWALLET_PASSWORD missing or non-empty" >&2
     exit 4
 }
 
 # --- 2. start the throttled miner -------------------------------------------
-resolve_kaswallet_container() { docker ps --format '{{.Names}}' | grep -m1 kaswallet-0 || true; }
+resolve_kaswallet_container() { docker ps --format '{{.Names}}' | grep -m1 -x kaswallet-0-devnet || true; }
 
 log "resolving kaswallet-0's mining address"
 MINING_ADDRESS=""
@@ -97,12 +109,23 @@ log "mining to kaswallet-0's address $MINING_ADDRESS"
 log "starting throttled CPU miner in background"
 "$SCRIPT_DIR/run-devnet-cpuminer.sh" > "$RUN_DIR/miner.log" 2>&1 &
 MINER_PID=$!
-trap 'kill "$MINER_PID" 2>/dev/null || true' EXIT
+trap 'kill "$MINER_PID" 2>/dev/null || true' EXIT INT TERM
+sleep 6
+kill -0 "$MINER_PID" 2>/dev/null || {
+    tail -n 20 "$RUN_DIR/miner.log" >&2
+    echo "miner exited early; see $RUN_DIR/miner.log" >&2
+    exit 6
+}
 
 # --- 3. wait for kaswallet-0 to hold matured, spendable KAS -----------------
 log "waiting for kaswallet-0 to accumulate spendable balance (coinbase maturity)"
 funded=false
 for _ in $(seq 1 120); do
+    kill -0 "$MINER_PID" 2>/dev/null || {
+        tail -n 20 "$RUN_DIR/miner.log" >&2
+        echo "miner died during funding wait; see $RUN_DIR/miner.log" >&2
+        exit 6
+    }
     kaswallet_container="$(resolve_kaswallet_container)"
     if [ -n "$kaswallet_container" ]; then
         bal="$(docker exec "$kaswallet_container" /app/kaswallet-cli address-balances 2>/dev/null \
@@ -140,14 +163,17 @@ done
 }
 
 # --- 4. generate an L2 keypair ----------------------------------------------
-cast wallet new --json > "$RUN_DIR/l2-key.json"
+(umask 077 && cast wallet new --json > "$RUN_DIR/l2-key.json")
 L2_ADDRESS="$(jq -r '.[0].address' "$RUN_DIR/l2-key.json")"
 FUNDED_PRIVATE_KEY="$(jq -r '.[0].private_key' "$RUN_DIR/l2-key.json")"
 log "generated L2 account $L2_ADDRESS"
 
 # --- 5. L1->L2 Entry deposit ------------------------------------------------
 log "depositing $DEPOSIT_KAS KAS -> iKAS to $L2_ADDRESS"
-docker exec "$(docker ps --format '{{.Names}}' | grep -m1 rpc-provider-0)" \
+rpc_provider="rpc-provider-0-devnet"
+docker ps --format '{{.Names}}' | grep -qx "$rpc_provider" \
+    || { echo "devnet container $rpc_provider not running; cannot send the Entry deposit" >&2; exit 5; }
+docker exec "$rpc_provider" \
     /app/entry_transaction_sender \
     --recipient "$W0_WALLET_TO_ADDRESS" \
     --amount "$DEPOSIT_KAS" \
@@ -170,18 +196,17 @@ cargo build --release --manifest-path "$IGRA_E2E_DIR/Cargo.toml" -p loadgen
 LOADGEN_BIN="$IGRA_E2E_DIR/target/release/loadgen"
 log "running loadgen: rate=$LOADGEN_RATE conc=$LOADGEN_CONCURRENCY dur=${LOADGEN_DURATION}s"
 mkdir -p "$RUN_DIR/loadgen"
+loadgen_rc=0
 FUNDED_PRIVATE_KEY="$FUNDED_PRIVATE_KEY" "$LOADGEN_BIN" \
     --rpc-url "http://127.0.0.1:${RPC_PORT}" \
     --rate "$LOADGEN_RATE" \
     --concurrency "$LOADGEN_CONCURRENCY" \
     --duration "$LOADGEN_DURATION" \
-    --run-dir "$RUN_DIR/loadgen" | tee "$RUN_DIR/loadgen.log"
-loadgen_rc="${PIPESTATUS[0]}"
+    --run-dir "$RUN_DIR/loadgen" | tee "$RUN_DIR/loadgen.log" || loadgen_rc=$?
 [ "$loadgen_rc" -eq 0 ] || {
     echo "loadgen exited $loadgen_rc; see $RUN_DIR/loadgen.log" >&2
     exit 9
 }
 
-# --- 8. hand off state to the validator -------------------------------------
-{ echo "RUN_DIR=$RUN_DIR"; echo "L2_ADDRESS=$L2_ADDRESS"; echo "FUNDED_PRIVATE_KEY=$FUNDED_PRIVATE_KEY"; } > "$RUN_DIR/env"
-log "load run complete. Validate with: RUN_DIR=$RUN_DIR $SCRIPT_DIR/validate-devnet-l2-lane.sh"
+# --- 8. done -----------------------------------------------------------------
+log "load run complete. Validate with: $SCRIPT_DIR/validate-devnet-l2-lane.sh"

--- a/scripts/dev/run-devnet-l2-load.sh
+++ b/scripts/dev/run-devnet-l2-load.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Drive the full IGRA devnet L2 stack under load and bootstrap L2 funds via an
+# L1->L2 Entry deposit. Dev harness — not for CI/commit.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# --- config (shell env overrides) -------------------------------------------
+IGRA_E2E_DIR="${IGRA_E2E_DIR:-$ROOT_DIR/../igra-e2e-validation}"
+LOADGEN_RATE="${LOADGEN_RATE:-20}"
+LOADGEN_CONCURRENCY="${LOADGEN_CONCURRENCY:-4}"
+LOADGEN_DURATION="${LOADGEN_DURATION:-300}"
+DEPOSIT_KAS_OVERRIDE="${DEPOSIT_KAS:-}"
+RUN_DIR="${RUN_DIR:-$ROOT_DIR/build/l2-load-$(date +%s)}"
+FINALITY_OVERRIDE="${FINALITY_PERIOD_SECONDS:-}"
+LAUNCH_DAA_OVERRIDE="${IGRA_LAUNCH_DAA_SCORE:-}"
+
+set -a; [ -f "$ROOT_DIR/.env" ] && . "$ROOT_DIR/.env"; set +a
+RPC_PORT="${RPC_PORT:-8555}"
+FINALITY_PERIOD_SECONDS="${FINALITY_OVERRIDE:-60}"
+L2_ALIVE_TIMEOUT_SECS="${L2_ALIVE_TIMEOUT_SECS:-900}"
+IGRA_LAUNCH_DAA_SCORE="${LAUNCH_DAA_OVERRIDE:-10}"
+GAS_GWEI="${MIN_PROTOCOL_FEE_PER_GAS_GWEI:-2000}"
+DEPOSIT_KAS="$DEPOSIT_KAS_OVERRIDE"
+if [ -z "$DEPOSIT_KAS" ]; then
+    DEPOSIT_KAS=$(( (LOADGEN_RATE * LOADGEN_DURATION * 21000 * GAS_GWEI / 1000000000) * 3 / 2 + 10 ))
+fi
+W0_WALLET_TO_ADDRESS="${W0_WALLET_TO_ADDRESS:?set W0_WALLET_TO_ADDRESS in .env}"
+
+log(){ echo "[l2-load] $*"; }
+
+# --- 0. tool preflight ------------------------------------------------------
+for t in docker jq cast websocat; do command -v "$t" >/dev/null || { echo "missing tool: $t" >&2; exit 2; }; done
+[ -d "$IGRA_E2E_DIR" ] || { echo "IGRA_E2E_DIR not found: $IGRA_E2E_DIR" >&2; exit 2; }
+
+mkdir -p "$RUN_DIR"
+
+export IGRA_LAUNCH_DAA_SCORE FINALITY_PERIOD_SECONDS
+
+# --- 0b. reconcile GENESIS_BLOCK_HASH with the EL this config builds ---------
+log "probing the EL genesis hash for IGRA_LAUNCH_DAA_SCORE=$IGRA_LAUNCH_DAA_SCORE"
+COMPOSE_PROFILES=backend docker compose -f docker-compose.devnet.yml up -d execution-layer \
+    > "$RUN_DIR/genesis-probe.log" 2>&1
+GENESIS_BLOCK_HASH=""
+for _ in $(seq 1 60); do
+    GENESIS_BLOCK_HASH="$(curl -s http://127.0.0.1:9545 -H 'content-type: application/json' \
+        --data '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x0",false]}' \
+        | jq -r '.result.hash // empty' 2>/dev/null || true)"
+    [ -n "$GENESIS_BLOCK_HASH" ] && break
+    sleep 2
+done
+COMPOSE_PROFILES=backend docker compose -f docker-compose.devnet.yml down \
+    >> "$RUN_DIR/genesis-probe.log" 2>&1
+case "$GENESIS_BLOCK_HASH" in
+    0x*) ;;
+    *) echo "could not probe the EL genesis hash (see $RUN_DIR/genesis-probe.log)" >&2; exit 8 ;;
+esac
+export GENESIS_BLOCK_HASH
+log "EL genesis is $GENESIS_BLOCK_HASH"
+
+# --- 1. bring up the full stack ---------------------------------------------
+log "bringing up full devnet stack (IGRA_ENABLE=true, RPC_READ_ONLY=false, skip-lock-check)"
+SETUP_ANSWERS=$'\n\n\n\n\nn\n'
+printf '%s' "$SETUP_ANSWERS" \
+    | IGRA_ENABLE=true RPC_READ_ONLY=false IGRA_SKIP_LOCK_SCRIPT_CHECK=true \
+      FINALITY_PERIOD_SECONDS="$FINALITY_PERIOD_SECONDS" "$ROOT_DIR/scripts/setup-devnet.sh"
+
+setup_pw="$(awk -F= '$1 == "W0_KASWALLET_PASSWORD" { print $2; exit }' "$ROOT_DIR/.env" 2>/dev/null || true)"
+[ -z "$setup_pw" ] || {
+    echo "setup prompt answers desynced: W0_KASWALLET_PASSWORD is non-empty" >&2
+    exit 4
+}
+
+# --- 2. start the throttled miner -------------------------------------------
+resolve_kaswallet_container() { docker ps --format '{{.Names}}' | grep -m1 kaswallet-0 || true; }
+
+log "resolving kaswallet-0's mining address"
+MINING_ADDRESS=""
+for _ in $(seq 1 30); do
+    kaswallet_container="$(resolve_kaswallet_container)"
+    if [ -n "$kaswallet_container" ]; then
+        MINING_ADDRESS="$(docker exec "$kaswallet_container" /app/kaswallet-cli address-balances 2>/dev/null \
+            | jq -r '.default_address // empty' 2>/dev/null || true)"
+        [ -n "$MINING_ADDRESS" ] && break
+    fi
+    sleep 2
+done
+case "$MINING_ADDRESS" in
+    kaspadev:*) ;;
+    *) echo "could not resolve a devnet mining address from kaswallet-0 (got: '${MINING_ADDRESS:-<none>}')" >&2; exit 5 ;;
+esac
+export MINING_ADDRESS
+log "mining to kaswallet-0's address $MINING_ADDRESS"
+
+log "starting throttled CPU miner in background"
+"$SCRIPT_DIR/run-devnet-cpuminer.sh" > "$RUN_DIR/miner.log" 2>&1 &
+MINER_PID=$!
+trap 'kill "$MINER_PID" 2>/dev/null || true' EXIT
+
+# --- 3. wait for kaswallet-0 to hold matured, spendable KAS -----------------
+log "waiting for kaswallet-0 to accumulate spendable balance (coinbase maturity)"
+funded=false
+for _ in $(seq 1 120); do
+    kaswallet_container="$(resolve_kaswallet_container)"
+    if [ -n "$kaswallet_container" ]; then
+        bal="$(docker exec "$kaswallet_container" /app/kaswallet-cli address-balances 2>/dev/null \
+            | jq -r '(.total_available // 0) / 100000000 | floor' 2>/dev/null || echo 0)"
+    else
+        bal=0
+    fi
+    [ "${bal:-0}" -ge $((DEPOSIT_KAS + 2)) ] 2>/dev/null && { log "kaswallet available >= $((DEPOSIT_KAS+2)) KAS"; funded=true; break; }
+    sleep 5
+done
+[ "$funded" = true ] || {
+    echo "kaswallet-0 never reached $((DEPOSIT_KAS + 2)) KAS (last seen: ${bal:-0} KAS)." >&2
+    echo "Is the miner producing blocks, and is MINING_ADDRESS one this wallet controls?" >&2
+    exit 6
+}
+
+# --- 3b. wait for the L2 to start producing blocks --------------------------
+log "waiting for the L2 to produce its first block (first finality period must elapse)"
+l2_alive=false
+l2_deadline=$(( $(date +%s) + L2_ALIVE_TIMEOUT_SECS ))
+while [ "$(date +%s)" -lt "$l2_deadline" ]; do
+    head_hex="$(curl -s "http://127.0.0.1:${RPC_PORT}" -H 'content-type: application/json' \
+        --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+        | jq -r '.result // "0x0"' 2>/dev/null || echo 0x0)"
+    case "$head_hex" in
+        0x0|null|'') ;;
+        *) log "L2 head is $head_hex"; l2_alive=true; break ;;
+    esac
+    sleep 10
+done
+[ "$l2_alive" = true ] || {
+    echo "L2 produced no blocks within ${L2_ALIVE_TIMEOUT_SECS}s (EL head still 0)." >&2
+    echo "Check kaspad logs for 'Consensus fallback check failed' / ATAN cold-start waits." >&2
+    exit 7
+}
+
+# --- 4. generate an L2 keypair ----------------------------------------------
+cast wallet new --json > "$RUN_DIR/l2-key.json"
+L2_ADDRESS="$(jq -r '.[0].address' "$RUN_DIR/l2-key.json")"
+FUNDED_PRIVATE_KEY="$(jq -r '.[0].private_key' "$RUN_DIR/l2-key.json")"
+log "generated L2 account $L2_ADDRESS"
+
+# --- 5. L1->L2 Entry deposit ------------------------------------------------
+log "depositing $DEPOSIT_KAS KAS -> iKAS to $L2_ADDRESS"
+docker exec "$(docker ps --format '{{.Names}}' | grep -m1 rpc-provider-0)" \
+    /app/entry_transaction_sender \
+    --recipient "$W0_WALLET_TO_ADDRESS" \
+    --amount "$DEPOSIT_KAS" \
+    --l2-address "$L2_ADDRESS" | tee "$RUN_DIR/deposit.log"
+
+# --- 6. wait for the L2 balance to be credited ------------------------------
+log "waiting for L2 balance to appear"
+for _ in $(seq 1 60); do
+    hexbal="$(curl -s "http://127.0.0.1:${RPC_PORT}" -H 'content-type: application/json' \
+        --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBalance\",\"params\":[\"$L2_ADDRESS\",\"latest\"]}" \
+        | jq -r '.result // "0x0"' 2>/dev/null || echo 0x0)"
+    [ "$hexbal" != "0x0" ] && [ "$hexbal" != "null" ] && { log "L2 balance = $hexbal"; break; }
+    sleep 5
+done
+[ "${hexbal:-0x0}" = "0x0" ] && { echo "L2 deposit never credited" >&2; exit 3; }
+
+# --- 7. build + run loadgen -------------------------------------------------
+log "building loadgen"
+cargo build --release --manifest-path "$IGRA_E2E_DIR/Cargo.toml" -p loadgen
+LOADGEN_BIN="$IGRA_E2E_DIR/target/release/loadgen"
+log "running loadgen: rate=$LOADGEN_RATE conc=$LOADGEN_CONCURRENCY dur=${LOADGEN_DURATION}s"
+mkdir -p "$RUN_DIR/loadgen"
+FUNDED_PRIVATE_KEY="$FUNDED_PRIVATE_KEY" "$LOADGEN_BIN" \
+    --rpc-url "http://127.0.0.1:${RPC_PORT}" \
+    --rate "$LOADGEN_RATE" \
+    --concurrency "$LOADGEN_CONCURRENCY" \
+    --duration "$LOADGEN_DURATION" \
+    --run-dir "$RUN_DIR/loadgen" | tee "$RUN_DIR/loadgen.log"
+loadgen_rc="${PIPESTATUS[0]}"
+[ "$loadgen_rc" -eq 0 ] || {
+    echo "loadgen exited $loadgen_rc; see $RUN_DIR/loadgen.log" >&2
+    exit 9
+}
+
+# --- 8. hand off state to the validator -------------------------------------
+{ echo "RUN_DIR=$RUN_DIR"; echo "L2_ADDRESS=$L2_ADDRESS"; echo "FUNDED_PRIVATE_KEY=$FUNDED_PRIVATE_KEY"; } > "$RUN_DIR/env"
+log "load run complete. Validate with: RUN_DIR=$RUN_DIR $SCRIPT_DIR/validate-devnet-l2-lane.sh"

--- a/scripts/dev/test-devnet-preflight.sh
+++ b/scripts/dev/test-devnet-preflight.sh
@@ -101,6 +101,8 @@ no "validate: lane uppercase"       bash -c "$(declare -f good_env validate_devn
 no "validate: lane all-zero"        bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LANE_ID=00000000; validate_devnet_env"
 no "validate: kaswallet port clash" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; KASWALLET_HOST_PORT=8555; validate_devnet_env"
 no "validate: zero-padded launch"   bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; IGRA_LAUNCH_DAA_SCORE=08; validate_devnet_env"
+no "validate: bad min-block-interval" bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; MINING_MIN_BLOCK_INTERVAL_MS=-5; validate_devnet_env"
+ok "validate: min-block-interval 0"  bash -c "$(declare -f good_env validate_devnet_env is_uint is_positive_int is_hex is_hex_even is_port is_valid_mining_address); good_env; MINING_MIN_BLOCK_INTERVAL_MS=0; validate_devnet_env"
 
 # --- resolve_devnet_env ---
 RESOLVE_TMP="$(mktemp -d)"
@@ -110,6 +112,10 @@ NETWORK=devnet
 FINALITY_PERIOD_SECONDS=600
 RPC_PORT=8555
 IGRA_LANE_ID=97b10000
+GENESIS_BLOCK_HASH=0x1111111111111111111111111111111111111111111111111111111111111111
+IGRA_LAUNCH_DAA_SCORE=0
+RPC_READ_ONLY=true
+MINING_THREADS=1
 ENVEOF
 cat > "$RESOLVE_TMP/versions.devnet.env" <<'ENVEOF'
 KASPAD_VERSION=devnet
@@ -120,6 +126,10 @@ ok "resolve: shell override wins"         bash -c "$(declare -f resolve_devnet_e
 # A set-but-empty shell override must win over the file value (opt-out contract).
 ok "resolve: empty shell override wins"   bash -c "$(declare -f resolve_devnet_env); IGRA_LANE_ID= resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ -z \"\$IGRA_LANE_ID\" ]"
 ok "resolve: unset falls to file value"   bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$IGRA_LANE_ID\" = 97b10000 ]"
+ok "resolve: GENESIS_BLOCK_HASH override wins" bash -c "$(declare -f resolve_devnet_env); GENESIS_BLOCK_HASH=0xdeadbeef resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$GENESIS_BLOCK_HASH\" = 0xdeadbeef ]"
+ok "resolve: IGRA_LAUNCH_DAA_SCORE override wins" bash -c "$(declare -f resolve_devnet_env); IGRA_LAUNCH_DAA_SCORE=42 resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$IGRA_LAUNCH_DAA_SCORE\" = 42 ]"
+ok "resolve: RPC_READ_ONLY override wins"  bash -c "$(declare -f resolve_devnet_env); RPC_READ_ONLY=false resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$RPC_READ_ONLY\" = false ]"
+ok "resolve: MINING_THREADS override wins" bash -c "$(declare -f resolve_devnet_env); MINING_THREADS=8 resolve_devnet_env '$RESOLVE_TMP' .env.devnet.example versions.devnet.env; [ \"\$MINING_THREADS\" = 8 ]"
 no "resolve: missing source fails"        bash -c "$(declare -f resolve_devnet_env); resolve_devnet_env '$RESOLVE_TMP' .nope.example versions.devnet.env"
 rm -rf "$RESOLVE_TMP"
 

--- a/scripts/dev/test-devnet-preflight.sh
+++ b/scripts/dev/test-devnet-preflight.sh
@@ -124,11 +124,17 @@ no "resolve: missing source fails"        bash -c "$(declare -f resolve_devnet_e
 rm -rf "$RESOLVE_TMP"
 
 # --- mining_preflight (validates mining config only; the miner is external) ---
-MINE_FUNCS="$(declare -f mining_preflight is_valid_mining_address is_positive_int)"
+MINE_FUNCS="$(declare -f mining_preflight is_valid_mining_address is_positive_int is_uint)"
 
 ok "mining: valid addr + threads" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 mining_preflight 2>/dev/null"
 no "mining: bad address"          bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspa:bad MINING_THREADS=1 mining_preflight 2>/dev/null"
 no "mining: bad threads"          bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=0 mining_preflight 2>/dev/null"
+
+# MINING_MIN_BLOCK_INTERVAL_MS: valid, zero (disabled), and invalid
+ok "mining: interval 150 accepted"       bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 MINING_MIN_BLOCK_INTERVAL_MS=150 mining_preflight 2>/dev/null"
+ok "mining: interval 0 (disabled) accepted" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 MINING_MIN_BLOCK_INTERVAL_MS=0 mining_preflight 2>/dev/null"
+no "mining: negative interval rejected"  bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 MINING_MIN_BLOCK_INTERVAL_MS=-5 mining_preflight 2>/dev/null"
+no "mining: non-numeric interval rejected" bash -c "$MINE_FUNCS; MINING_ADDRESS=kaspadev:qqdk7fjp3dk6yln3d8epz6exafv65jecxkz9ujkhlvgkqwefwtdwsw3q78u7s MINING_THREADS=1 MINING_MIN_BLOCK_INTERVAL_MS=abc mining_preflight 2>/dev/null"
 
 # --- record_source_revisions ---
 REV_TMP="$(mktemp -d)"

--- a/scripts/dev/validate-devnet-l2-lane.sh
+++ b/scripts/dev/validate-devnet-l2-lane.sh
@@ -2,7 +2,7 @@
 # PASS/FAIL validator for the devnet L2 + lane-id run.
 #   1) stability : no viaduct panic / TooManyBlocks; containers healthy
 #   2) lane-id   : every non-native, non-coinbase L1 tx == configured lane
-#   3) Toccata   : lane txs present both below and at/above the activation DAA
+#   3) Toccata   : lane txs present at/above the activation DAA (below is a note)
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 set -a; [ -f "$ROOT_DIR/.env" ] && . "$ROOT_DIR/.env"; set +a
@@ -25,13 +25,16 @@ wrpc_call(){
 
 # ---- 1. stability ----------------------------------------------------------
 echo "== stability =="
-kaspad_name="$(docker ps --format '{{.Names}}' | grep -m1 kaspad || true)"
-[ -n "$kaspad_name" ] || fail "no running kaspad container found (docker ps | grep kaspad)"
-raw_logs="$(docker logs "$kaspad_name" 2>&1)" || fail "docker logs $kaspad_name failed; cannot verify absence of panics"
-logs="$(printf '%s' "$raw_logs" | tail -n 5000)"
-echo "$logs" | grep -qiE 'TooManyBlocks|Viaduct Collector error|panicked' && fail "viaduct panic / TooManyBlocks in kaspad logs"
-containers="$(docker ps --format '{{.Names}}' | grep -E 'kaspad|execution-layer|rpc-provider|kaswallet' || true)"
-[ -n "$containers" ] || fail "no kaspad/execution-layer/rpc-provider/kaswallet containers found; is the stack up?"
+kaspad_name="$(docker ps --format '{{.Names}}' | grep -m1 -x kaspad-devnet || true)"
+[ -n "$kaspad_name" ] || fail "no running kaspad-devnet container found; is the devnet stack up?"
+LOG_SCAN_LINES="${LOG_SCAN_LINES:-5000}"
+logs="$(docker logs --tail "$LOG_SCAN_LINES" "$kaspad_name" 2>&1)" \
+    || fail "docker logs $kaspad_name failed; cannot verify absence of panics"
+if grep -qiE 'TooManyBlocks|Viaduct Collector error|panicked' <<<"$logs"; then
+    fail "viaduct panic / TooManyBlocks in kaspad logs"
+fi
+containers="$(docker ps --format '{{.Names}}' | grep -E '^(kaspad|execution-layer|rpc-provider-[0-9]+|kaswallet-[0-9]+)-devnet$' || true)"
+[ -n "$containers" ] || fail "no devnet (*-devnet) containers found; is the devnet stack up?"
 while IFS= read -r c; do
     [ -n "$c" ] || continue
     status="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null || echo missing)"
@@ -65,7 +68,8 @@ BLOCKS_JSON="$(printf '%s\n' "${block_jsons[@]}" | jq -cs '{"params":{"blocks":.
 
 # ---- 2. lane-id ------------------------------------------------------------
 echo "== lane-id =="
-mapfile -t SUBS < <(echo "$BLOCKS_JSON" | jq -r '.params.blocks[]?.transactions[]?.subnetworkId // empty' 2>/dev/null || true)
+SUBS=()
+while IFS= read -r s; do [ -n "$s" ] && SUBS+=("$s"); done < <(printf '%s' "$BLOCKS_JSON" | jq -r '.params.blocks[]?.transactions[]?.subnetworkId // empty' 2>/dev/null || true)
 [ "${#SUBS[@]}" -gt 0 ] || fail "no transactions found in recent blocks via getBlocks; is loadgen exercising the lane?"
 lane_seen=0
 for s in "${SUBS[@]}"; do
@@ -83,6 +87,7 @@ echo "  ok: $lane_seen ingress txs, all on lane $LANE_HEX"
 echo "== Toccata =="
 if [ -z "$TOCCATA_ACTIVATION_DAA_SCORE" ]; then
     echo "  skip: TOCCATA_ACTIVATION_DAA_SCORE unset"
+    toccata_result="Toccata check skipped (TOCCATA_ACTIVATION_DAA_SCORE unset)"
 else
     vdaa="$(wrpc_call getBlockDagInfo '{}' | jq -r '.params.virtualDaaScore // empty' 2>/dev/null || true)"
     [ -n "$vdaa" ] || fail "could not fetch virtual DAA score via wRPC"
@@ -94,6 +99,7 @@ else
     echo "  lane txs below Toccata: $below ; at/above: $aboveq (virtual DAA $vdaa)"
     [ "${aboveq:-0}" -ge 1 ] || fail "no lane txs at/above Toccata activation DAA"
     [ "${below:-0}" -ge 1 ] || echo "  note: no lane txs below activation in fetched window (run started post-activation?)"
+    toccata_result="Toccata crossed"
 fi
 
-echo "PASS: L2 stable under load, lane-id correct, Toccata crossed"
+echo "PASS: L2 stable under load, lane-id correct, $toccata_result"

--- a/scripts/dev/validate-devnet-l2-lane.sh
+++ b/scripts/dev/validate-devnet-l2-lane.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# PASS/FAIL validator for the devnet L2 + lane-id run.
+#   1) stability : no viaduct panic / TooManyBlocks; containers healthy
+#   2) lane-id   : every non-native, non-coinbase L1 tx == configured lane
+#   3) Toccata   : lane txs present both below and at/above the activation DAA
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+set -a; [ -f "$ROOT_DIR/.env" ] && . "$ROOT_DIR/.env"; set +a
+KASPAD_JSON_PORT="${KASPAD_JSON_PORT:-18610}"
+IGRA_LANE_ID="${IGRA_LANE_ID:-97b10000}"
+TOCCATA_ACTIVATION_DAA_SCORE="${TOCCATA_ACTIVATION_DAA_SCORE:-}"
+WS="ws://127.0.0.1:${KASPAD_JSON_PORT}"
+
+LANE_HEX="$(printf '%s' "$IGRA_LANE_ID" | tr 'A-Z' 'a-z')"
+while [ "${#LANE_HEX}" -lt 40 ]; do LANE_HEX="${LANE_HEX}0"; done
+NATIVE_HEX="$(printf '0%.0s' $(seq 1 40))"
+COINBASE_HEX="01$(printf '0%.0s' $(seq 1 38))"
+
+fail(){ echo "FAIL: $*" >&2; exit 1; }
+wrpc_call(){
+    local method="$1" params="$2"
+    echo "{\"id\":1,\"method\":\"$method\",\"params\":$params}" \
+        | websocat -n1 "$WS" 2>/dev/null || echo '{}'
+}
+
+# ---- 1. stability ----------------------------------------------------------
+echo "== stability =="
+kaspad_name="$(docker ps --format '{{.Names}}' | grep -m1 kaspad || true)"
+[ -n "$kaspad_name" ] || fail "no running kaspad container found (docker ps | grep kaspad)"
+raw_logs="$(docker logs "$kaspad_name" 2>&1)" || fail "docker logs $kaspad_name failed; cannot verify absence of panics"
+logs="$(printf '%s' "$raw_logs" | tail -n 5000)"
+echo "$logs" | grep -qiE 'TooManyBlocks|Viaduct Collector error|panicked' && fail "viaduct panic / TooManyBlocks in kaspad logs"
+containers="$(docker ps --format '{{.Names}}' | grep -E 'kaspad|execution-layer|rpc-provider|kaswallet' || true)"
+[ -n "$containers" ] || fail "no kaspad/execution-layer/rpc-provider/kaswallet containers found; is the stack up?"
+while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    status="$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null || echo missing)"
+    health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$c" 2>/dev/null || echo missing)"
+    [ "$status" = "running" ] || fail "container $c not running: $status"
+    case "$health" in
+        healthy|none) : ;;
+        *) fail "container $c unhealthy: $health" ;;
+    esac
+done <<< "$containers"
+echo "  ok: no panic, containers healthy"
+
+# ---- collect recent blocks (tx subnetwork + block DAA) ---------------------
+SINK="$(wrpc_call getSink '{}' | jq -r '.params.sink // empty' 2>/dev/null || true)"
+[ -n "$SINK" ] || fail "could not fetch chain sink via wRPC (is kaspad wRPC JSON port $KASPAD_JSON_PORT reachable at $WS?)"
+
+WINDOW_BLOCKS="${VALIDATE_WINDOW_BLOCKS:-100}"
+declare -a block_jsons=()
+hash="$SINK"
+for ((i = 0; i < WINDOW_BLOCKS; i++)); do
+    [ -n "$hash" ] || break
+    resp="$(wrpc_call getBlock "{\"hash\":\"$hash\",\"includeTransactions\":true}")"
+    block="$(echo "$resp" | jq -c '.params.block // empty' 2>/dev/null || true)"
+    [ -n "$block" ] || break
+    block_jsons+=("$block")
+    hash="$(echo "$block" | jq -r '.header.parentsByLevel[0][0] // empty' 2>/dev/null || true)"
+done
+[ "${#block_jsons[@]}" -gt 0 ] || fail "could not fetch any blocks walking back from sink $SINK via wRPC"
+BLOCKS_JSON="$(printf '%s\n' "${block_jsons[@]}" | jq -cs '{"params":{"blocks":.}}' 2>/dev/null || true)"
+[ -n "$BLOCKS_JSON" ] || fail "failed to assemble collected-blocks JSON from $WINDOW_BLOCKS walked blocks"
+
+# ---- 2. lane-id ------------------------------------------------------------
+echo "== lane-id =="
+mapfile -t SUBS < <(echo "$BLOCKS_JSON" | jq -r '.params.blocks[]?.transactions[]?.subnetworkId // empty' 2>/dev/null || true)
+[ "${#SUBS[@]}" -gt 0 ] || fail "no transactions found in recent blocks via getBlocks; is loadgen exercising the lane?"
+lane_seen=0
+for s in "${SUBS[@]}"; do
+    case "$s" in
+        "$NATIVE_HEX"|"$COINBASE_HEX") : ;;
+        "$LANE_HEX") lane_seen=$((lane_seen + 1)) ;;
+        *) fail "tx on unexpected subnetwork $s (expected lane $LANE_HEX)";;
+    esac
+done
+MIN_LANE_TXS="${VALIDATE_MIN_LANE_TXS:-10}"
+[ "$lane_seen" -ge "$MIN_LANE_TXS" ] || fail "only $lane_seen lane ($LANE_HEX) tx(s) in the fetched window; expected >= $MIN_LANE_TXS — ingress did not meaningfully exercise the lane (set VALIDATE_MIN_LANE_TXS to lower the bar)"
+echo "  ok: $lane_seen ingress txs, all on lane $LANE_HEX"
+
+# ---- 3. Toccata crossing ---------------------------------------------------
+echo "== Toccata =="
+if [ -z "$TOCCATA_ACTIVATION_DAA_SCORE" ]; then
+    echo "  skip: TOCCATA_ACTIVATION_DAA_SCORE unset"
+else
+    vdaa="$(wrpc_call getBlockDagInfo '{}' | jq -r '.params.virtualDaaScore // empty' 2>/dev/null || true)"
+    [ -n "$vdaa" ] || fail "could not fetch virtual DAA score via wRPC"
+    [ "$vdaa" -gt "$TOCCATA_ACTIVATION_DAA_SCORE" ] 2>/dev/null || fail "virtual DAA $vdaa has not crossed Toccata $TOCCATA_ACTIVATION_DAA_SCORE"
+    below="$(echo "$BLOCKS_JSON" | jq -r --arg L "$LANE_HEX" --argjson T "$TOCCATA_ACTIVATION_DAA_SCORE" \
+        '[.params.blocks[]? | select((.header.daaScore|tonumber) <  $T) | .transactions[]? | select(.subnetworkId==$L)] | length' 2>/dev/null || echo 0)"
+    aboveq="$(echo "$BLOCKS_JSON" | jq -r --arg L "$LANE_HEX" --argjson T "$TOCCATA_ACTIVATION_DAA_SCORE" \
+        '[.params.blocks[]? | select((.header.daaScore|tonumber) >= $T) | .transactions[]? | select(.subnetworkId==$L)] | length' 2>/dev/null || echo 0)"
+    echo "  lane txs below Toccata: $below ; at/above: $aboveq (virtual DAA $vdaa)"
+    [ "${aboveq:-0}" -ge 1 ] || fail "no lane txs at/above Toccata activation DAA"
+    [ "${below:-0}" -ge 1 ] || echo "  note: no lane txs below activation in fetched window (run started post-activation?)"
+fi
+
+echo "PASS: L2 stable under load, lane-id correct, Toccata crossed"

--- a/scripts/lib/devnet-preflight.sh
+++ b/scripts/lib/devnet-preflight.sh
@@ -173,8 +173,18 @@ resolve_devnet_env() {
 
     # Capture shell-provided tunables (set, even if empty) so the file cannot
     # clobber a command-line override.
+    # Every tunable a caller may legitimately override on the command line must be
+    # listed here: `set -a; source` below overwrites the whole environment, so a
+    # variable missing from this list silently loses to the file even though
+    # docker compose would otherwise honour the shell value. That silent loss is
+    # how a harness can end up running with a genesis hash and launch DAA it never
+    # asked for (kaspad then halts on "Genesis hash mismatch", or the L2 collector
+    # panics on the genesis window).
     local k saved=()
-    for k in FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID; do
+    for k in FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID \
+             IGRA_ENABLE ATAN_ENABLE RPC_READ_ONLY IGRA_SKIP_LOCK_SCRIPT_CHECK \
+             IGRA_LAUNCH_DAA_SCORE L1_REFERENCE_DAA_SCORE L1_REFERENCE_TIMESTAMP \
+             GENESIS_BLOCK_HASH MINING_ADDRESS MINING_MIN_BLOCK_INTERVAL_MS; do
         [ -n "${!k+x}" ] && saved+=("$k=${!k}")
     done
 
@@ -194,9 +204,10 @@ resolve_devnet_env() {
     fi
 }
 
-# mining_preflight - validate MINING_ADDRESS/MINING_THREADS and remind the operator
-# to start an external miner. Called when Toccata is scheduled, because the KIP-21
-# rehearsal cannot reach the activation DAA score without mined blocks.
+# mining_preflight - validate MINING_ADDRESS/MINING_THREADS/MINING_MIN_BLOCK_INTERVAL_MS
+# and remind the operator to start an external miner. Called when Toccata is
+# scheduled, because the KIP-21 rehearsal cannot reach the activation DAA score
+# without mined blocks.
 mining_preflight() {
     local errors=()
 
@@ -204,6 +215,8 @@ mining_preflight() {
         errors+=("MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}')")
     is_positive_int "${MINING_THREADS:-}" || \
         errors+=("MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')")
+    is_uint "${MINING_MIN_BLOCK_INTERVAL_MS:-150}" || \
+        errors+=("MINING_MIN_BLOCK_INTERVAL_MS must be a non-negative integer in ms (0 disables) (got: '${MINING_MIN_BLOCK_INTERVAL_MS:-<unset>}')")
 
     if (( ${#errors[@]} > 0 )); then
         echo "Mining preflight failed (required for the Toccata/KIP-21 rehearsal):" >&2

--- a/scripts/lib/devnet-preflight.sh
+++ b/scripts/lib/devnet-preflight.sh
@@ -85,6 +85,8 @@ validate_devnet_env() {
         errors+=("MINING_ADDRESS must be a devnet address (kaspadev:...) (got: '${MINING_ADDRESS:-<unset>}')")
     is_positive_int "${MINING_THREADS:-}" || \
         errors+=("MINING_THREADS must be a positive integer (got: '${MINING_THREADS:-<unset>}')")
+    is_uint "${MINING_MIN_BLOCK_INTERVAL_MS:-150}" || \
+        errors+=("MINING_MIN_BLOCK_INTERVAL_MS must be a non-negative integer in ms (0 disables) (got: '${MINING_MIN_BLOCK_INTERVAL_MS:-<unset>}')")
 
     # Lock script pubkey (entry) hex when present
     if [ -n "${IGRA_LOCK_SCRIPT_PUBKEY:-}" ]; then
@@ -171,22 +173,15 @@ resolve_devnet_env() {
     fi
     export DEVNET_ENV_SOURCE="$source_path"
 
-    # Capture shell-provided tunables (set, even if empty) so the file cannot
-    # clobber a command-line override.
-    # Every tunable a caller may legitimately override on the command line must be
-    # listed here: `set -a; source` below overwrites the whole environment, so a
-    # variable missing from this list silently loses to the file even though
-    # docker compose would otherwise honour the shell value. That silent loss is
-    # how a harness can end up running with a genesis hash and launch DAA it never
-    # asked for (kaspad then halts on "Genesis hash mismatch", or the L2 collector
-    # panics on the genesis window).
+    # Snapshot every shell-set variable that the env source or versions file also
+    # assigns, so a command-line override always wins with no hand-maintained list
+    # to fall out of date (a `set -a; source` below would otherwise let the file
+    # clobber a shell value docker compose is meant to honour).
     local k saved=()
-    for k in FINALITY_PERIOD_SECONDS TOCCATA_ACTIVATION_DAA_SCORE IGRA_LANE_ID \
-             IGRA_ENABLE ATAN_ENABLE RPC_READ_ONLY IGRA_SKIP_LOCK_SCRIPT_CHECK \
-             IGRA_LAUNCH_DAA_SCORE L1_REFERENCE_DAA_SCORE L1_REFERENCE_TIMESTAMP \
-             GENESIS_BLOCK_HASH MINING_ADDRESS MINING_MIN_BLOCK_INTERVAL_MS; do
+    while IFS= read -r k; do
         [ -n "${!k+x}" ] && saved+=("$k=${!k}")
-    done
+    done < <(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/p' \
+        "$source_path" "$project_dir/$versions_file" 2>/dev/null | sort -u)
 
     set -a
     # shellcheck source=/dev/null


### PR DESCRIPTION
A reproducible harness that brings up the devnet stack and proves the L2 stays live under sustained transaction load, with correct IGRA lane-id stamping across the Toccata boundary. Replaces a manual, gotcha-laden bring-up with one non-interactive run plus a PASS/FAIL validator.

What's included
- scripts/dev/run-devnet-l2-load.sh — end-to-end runner: stack up → EL genesis probe → throttled CPU miner → coinbase maturity → L1→L2 Entry deposit → L2 liveness → loadgen. Derives the genesis hash, mining address, launch DAA and deposit size at runtime instead of trusting constants that drift out of sync with the config.
- scripts/dev/validate-devnet-l2-lane.sh — PASS/FAIL validator: no viaduct panic and all containers healthy; at least VALIDATE_MIN_LANE_TXS ingress txs, every one on the configured lane; a Toccata crossing. VALIDATE_WINDOW_BLOCKS widens the chain walk (the miner stops with the runner, leaving an empty chain tail).
- scripts/dev/run-devnet-cpuminer.sh — idempotent min-block-interval throttle patch application + --min-block-interval-ms passthrough.
- scripts/dev/patches/cpuminer-min-block-interval.patch — cross-thread block-submission gate that keeps block production under viaduct's per-window cap, eliminating the TooManyBlocks panic under fast local mining.
- scripts/dev/test-devnet-preflight.sh + scripts/lib/devnet-preflight.sh — interval-validation tests and an override whitelist so documented tunables are no longer silently discarded when .env is sourced.
- .env.devnet.example — MINING_MIN_BLOCK_INTERVAL_MS; GENESIS_BLOCK_HASH corrected to the value this config actually produces, with a recompute recipe.

Testing
Full e2e green on devnet:
- loadgen: submitted=6001, failed=0, success_rate=100.00% over a 300 s run;
- validator: PASS — L2 stable under load, lane-id correct, Toccata crossed (590 ingress txs, all on lane 97b1000…, no panic, containers healthy).

Preflight suite passes; both new scripts pass bash -n.